### PR TITLE
Add publish-default setting to tools.poetry section

### DIFF
--- a/poetry/core/factory.py
+++ b/poetry/core/factory.py
@@ -62,6 +62,7 @@ class Factory(object):
         package.license = license_
         package.keywords = local_config.get("keywords", [])
         package.classifiers = local_config.get("classifiers", [])
+        package.publish_default = local_config.get("publish-default")
 
         if "readme" in local_config:
             package.readme = Path(poetry_file.parent) / local_config["readme"]

--- a/poetry/core/json/schemas/poetry-schema.json
+++ b/poetry/core/json/schemas/poetry-schema.json
@@ -173,6 +173,10 @@
                     "description": "The full url of the custom url."
                 }
             }
+        },
+        "publish-default": {
+            "type": "string",
+            "description": "Repository name that's used to override default repo when running publish without -r argument."
         }
     },
     "definitions": {


### PR DESCRIPTION
This PR adds `publish-default` setting to `[tool.poetry]` section, that allows override of the default behavior of `poetry publish`. Setting it to repository name causes default publish to said repository instead of pypi.org.

Required by: https://github.com/python-poetry/poetry/pull/2287

I'm not sure how to use those changes in the PR on poetry side. If anybody could point me to documentation it would be great. 