### PR TITLE
Add "authors" as a required field in config schema

### DIFF
--- a/poetry/core/json/schemas/poetry-schema.json
+++ b/poetry/core/json/schemas/poetry-schema.json
@@ -6,7 +6,8 @@
     "required": [
         "name",
         "version",
-        "description"
+        "description",
+        "authors"
     ],
     "properties": {
         "name": {


### PR DESCRIPTION
As seen [here](https://github.com/python-poetry/poetry/pull/2540)

Before this change, a pyproject.toml file without an "authors" field would throw an unhandled `NonExistentKey` exception. Now it will be returned as a config validation error, as with the "name", "version", and "description" fields.

<details><summary>Before</summary>

```console
$ poetry install -vvv
[NonExistentKey]
'Key "authors" does not exist.'

Traceback (most recent call last):
  File "/Users/ryan/.local/pipx/venvs/poetry/lib/python3.7/site-packages/clikit/console_application.py", line 131, in run
    status_code = command.handle(parsed_args, io)
  File "/Users/ryan/.local/pipx/venvs/poetry/lib/python3.7/site-packages/clikit/api/command/command.py", line 120, in handle
    status_code = self._do_handle(args, io)
  File "/Users/ryan/.local/pipx/venvs/poetry/lib/python3.7/site-packages/clikit/api/command/command.py", line 163, in _do_handle
    self._dispatcher.dispatch(PRE_HANDLE, event)
  File "/Users/ryan/.local/pipx/venvs/poetry/lib/python3.7/site-packages/clikit/api/event/event_dispatcher.py", line 22, in dispatch
    self._do_dispatch(listeners, event_name, event)
  File "/Users/ryan/.local/pipx/venvs/poetry/lib/python3.7/site-packages/clikit/api/event/event_dispatcher.py", line 89, in _do_dispatch
    listener(event, event_name, self)
  File "/Users/ryan/.local/pipx/venvs/poetry/lib/python3.7/site-packages/poetry/console/config/application_config.py", line 86, in set_env
    poetry = command.poetry
  File "/Users/ryan/.local/pipx/venvs/poetry/lib/python3.7/site-packages/poetry/console/commands/command.py", line 10, in poetry
    return self.application.poetry
  File "/Users/ryan/.local/pipx/venvs/poetry/lib/python3.7/site-packages/poetry/console/application.py", line 49, in poetry
    self._poetry = Factory().create_poetry(Path.cwd())
  File "/Users/ryan/.local/pipx/venvs/poetry/lib/python3.7/site-packages/poetry/factory.py", line 62, in create_poetry
    for author in local_config["authors"]:
  File "/Users/ryan/.local/pipx/venvs/poetry/lib/python3.7/site-packages/tomlkit/items.py", line 1008, in __getitem__
    return self._value[key]
  File "/Users/ryan/.local/pipx/venvs/poetry/lib/python3.7/site-packages/tomlkit/container.py", line 540, in __getitem__
    raise NonExistentKey(key)
```
</details>

<details><summary>After</summary>

```console
$ poetry install -vvv
[RuntimeError]
The Poetry configuration is invalid:
  - 'authors' is a required property


Traceback (most recent call last):
  File "/Users/ryan/.local/pipx/venvs/poetry/lib/python3.7/site-packages/clikit/console_application.py", line 131, in run
    status_code = command.handle(parsed_args, io)
  File "/Users/ryan/.local/pipx/venvs/poetry/lib/python3.7/site-packages/clikit/api/command/command.py", line 120, in handle
    status_code = self._do_handle(args, io)
  File "/Users/ryan/.local/pipx/venvs/poetry/lib/python3.7/site-packages/clikit/api/command/command.py", line 163, in _do_handle
    self._dispatcher.dispatch(PRE_HANDLE, event)
  File "/Users/ryan/.local/pipx/venvs/poetry/lib/python3.7/site-packages/clikit/api/event/event_dispatcher.py", line 22, in dispatch
    self._do_dispatch(listeners, event_name, event)
  File "/Users/ryan/.local/pipx/venvs/poetry/lib/python3.7/site-packages/clikit/api/event/event_dispatcher.py", line 89, in _do_dispatch
    listener(event, event_name, self)
  File "/Users/ryan/.local/pipx/venvs/poetry/lib/python3.7/site-packages/poetry/console/config/application_config.py", line 86, in set_env
    poetry = command.poetry
  File "/Users/ryan/.local/pipx/venvs/poetry/lib/python3.7/site-packages/poetry/console/commands/command.py", line 10, in poetry
    return self.application.poetry
  File "/Users/ryan/.local/pipx/venvs/poetry/lib/python3.7/site-packages/poetry/console/application.py", line 49, in poetry
    self._poetry = Factory().create_poetry(Path.cwd())
  File "/Users/ryan/.local/pipx/venvs/poetry/lib/python3.7/site-packages/poetry/factory.py", line 54, in create_poetry
    raise RuntimeError('The Poetry configuration is invalid:
'" + message)
```
</details>

# Pull Request Check List

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.

I didn't do this, because:

1. I couldn't find a way to add a test without breaking many other tests in a reasonable time.
    * My first try was on `test_factory.py` line 184, but adding a line with `- 'authors' is a required property` broke a whole lot of other tests. 
1. The tests don't seem to check for all the other required fields besides "description" as they are.

I'd be happy to add a test but I will need either more time or a bit of guidance.

- [ ] Updated **documentation** for changed code.

I don't believe this is applicable. 

<!-- **Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch. -->

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
