### PR TITLE
helpers: ensure cleanup when using tempfile.mkdtemp

### DIFF
--- a/poetry/core/utils/helpers.py
+++ b/poetry/core/utils/helpers.py
@@ -41,10 +41,10 @@ def temporary_directory(*args, **kwargs):
             yield name
     except ImportError:
         name = tempfile.mkdtemp(*args, **kwargs)
-
-        yield name
-
-        shutil.rmtree(name)
+        try:
+            yield name
+        finally:
+            shutil.rmtree(name)
 
 
 def parse_requires(requires):  # type: (str) -> List[str]


### PR DESCRIPTION
Minor cleanup fix. When we fellback to using `tempfile.mkdtemp` cleanup was not done properly.