### PR TITLE
Fix default value for build.generate-setup-file

### DIFF
--- a/poetry/core/masonry/builders/sdist.py
+++ b/poetry/core/masonry/builders/sdist.py
@@ -89,7 +89,7 @@ class SdistBuilder(Builder):
                 else:
                     tar.addfile(tar_info)  # Symlinks & ?
 
-            if not self._poetry.package.build_config.get("generate-setup-file", False):
+            if self._poetry.package.build_config.get("generate-setup-file", True):
                 setup = self.build_setup()
                 tar_info = tarfile.TarInfo(pjoin(tar_dir, "setup.py"))
                 tar_info.size = len(setup)

--- a/tests/masonry/builders/fixtures/disable_setup_py/pyproject.toml
+++ b/tests/masonry/builders/fixtures/disable_setup_py/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 
 [tool.poetry.build]
-generate-setup-file = true
+generate-setup-file = false
 
 # Requirements
 [tool.poetry.dependencies]


### PR DESCRIPTION
The oirginal default configuration for `build.generate-setup-file` was incorrect. This change aligns it with the name of the config.