### PR TITLE
Fix issue with PEP 517 builds failing when projects have includes

### DIFF
--- a/poetry/core/masonry/api.py
+++ b/poetry/core/masonry/api.py
@@ -31,7 +31,7 @@ get_requires_for_build_sdist = get_requires_for_build_wheel
 
 
 def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
-    poetry = Factory().create_poetry(Path("."))
+    poetry = Factory().create_poetry(Path(".").resolve())
     builder = WheelBuilder(poetry)
 
     dist_info = Path(metadata_directory, builder.dist_info)
@@ -52,14 +52,14 @@ def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
 
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     """Builds a wheel, places it in wheel_directory"""
-    poetry = Factory().create_poetry(Path("."))
+    poetry = Factory().create_poetry(Path(".").resolve())
 
     return unicode(WheelBuilder.make_in(poetry, Path(wheel_directory)))
 
 
 def build_sdist(sdist_directory, config_settings=None):
     """Builds an sdist, places it in sdist_directory"""
-    poetry = Factory().create_poetry(Path("."))
+    poetry = Factory().create_poetry(Path(".").resolve())
 
     path = SdistBuilder(poetry).build(Path(sdist_directory))
 

--- a/tests/masonry/test_api.py
+++ b/tests/masonry/test_api.py
@@ -55,6 +55,18 @@ def test_build_wheel():
             assert "my_package-1.2.3.dist-info/METADATA" in namelist
 
 
+def test_build_wheel_with_include():
+    with temporary_directory() as tmp_dir, cwd(os.path.join(fixtures, "with-include")):
+        filename = api.build_wheel(tmp_dir)
+
+        with zipfile.ZipFile(str(os.path.join(tmp_dir, filename))) as zip:
+            namelist = zip.namelist()
+
+            assert "with_include-1.2.3.dist-info/entry_points.txt" in namelist
+            assert "with_include-1.2.3.dist-info/WHEEL" in namelist
+            assert "with_include-1.2.3.dist-info/METADATA" in namelist
+
+
 @pytest.mark.skipif(
     sys.platform == "win32"
     and sys.version_info <= (3, 6)
@@ -84,6 +96,16 @@ def test_build_sdist():
             namelist = tar.getnames()
 
             assert "my-package-1.2.3/LICENSE" in namelist
+
+
+def test_build_sdist_with_include():
+    with temporary_directory() as tmp_dir, cwd(os.path.join(fixtures, "with-include")):
+        filename = api.build_sdist(tmp_dir)
+
+        with tarfile.open(str(os.path.join(tmp_dir, filename))) as tar:
+            namelist = tar.getnames()
+
+            assert "with-include-1.2.3/LICENSE" in namelist
 
 
 def test_prepare_metadata_for_build_wheel():

--- a/tests/masonry/test_api.py
+++ b/tests/masonry/test_api.py
@@ -4,8 +4,6 @@ from __future__ import unicode_literals
 import os
 import platform
 import sys
-import tarfile
-import zipfile
 
 from contextlib import contextmanager
 
@@ -16,6 +14,8 @@ from poetry.core.masonry import api
 from poetry.core.utils._compat import Path
 from poetry.core.utils._compat import decode
 from poetry.core.utils.helpers import temporary_directory
+from tests.testutils import validate_sdist_contents
+from tests.testutils import validate_wheel_contents
 
 
 @contextmanager
@@ -46,25 +46,23 @@ def test_get_requires_for_build_sdist():
 def test_build_wheel():
     with temporary_directory() as tmp_dir, cwd(os.path.join(fixtures, "complete")):
         filename = api.build_wheel(tmp_dir)
-
-        with zipfile.ZipFile(str(os.path.join(tmp_dir, filename))) as zip:
-            namelist = zip.namelist()
-
-            assert "my_package-1.2.3.dist-info/entry_points.txt" in namelist
-            assert "my_package-1.2.3.dist-info/WHEEL" in namelist
-            assert "my_package-1.2.3.dist-info/METADATA" in namelist
+        validate_wheel_contents(
+            name="my_package",
+            version="1.2.3",
+            path=str(os.path.join(tmp_dir, filename)),
+            files=["entry_points.txt"],
+        )
 
 
 def test_build_wheel_with_include():
     with temporary_directory() as tmp_dir, cwd(os.path.join(fixtures, "with-include")):
         filename = api.build_wheel(tmp_dir)
-
-        with zipfile.ZipFile(str(os.path.join(tmp_dir, filename))) as zip:
-            namelist = zip.namelist()
-
-            assert "with_include-1.2.3.dist-info/entry_points.txt" in namelist
-            assert "with_include-1.2.3.dist-info/WHEEL" in namelist
-            assert "with_include-1.2.3.dist-info/METADATA" in namelist
+        validate_wheel_contents(
+            name="with_include",
+            version="1.2.3",
+            path=str(os.path.join(tmp_dir, filename)),
+            files=["entry_points.txt"],
+        )
 
 
 @pytest.mark.skipif(
@@ -76,36 +74,31 @@ def test_build_wheel_with_include():
 def test_build_wheel_extended():
     with temporary_directory() as tmp_dir, cwd(os.path.join(fixtures, "extended")):
         filename = api.build_wheel(tmp_dir)
-
         whl = Path(tmp_dir) / filename
         assert whl.exists()
-
-        with zipfile.ZipFile(str(os.path.join(tmp_dir, filename))) as zip:
-            namelist = zip.namelist()
-
-            assert "extended-0.1.dist-info/RECORD" in namelist
-            assert "extended-0.1.dist-info/WHEEL" in namelist
-            assert "extended-0.1.dist-info/METADATA" in namelist
+        validate_wheel_contents(name="extended", version="0.1", path=whl.as_posix())
 
 
 def test_build_sdist():
     with temporary_directory() as tmp_dir, cwd(os.path.join(fixtures, "complete")):
         filename = api.build_sdist(tmp_dir)
-
-        with tarfile.open(str(os.path.join(tmp_dir, filename))) as tar:
-            namelist = tar.getnames()
-
-            assert "my-package-1.2.3/LICENSE" in namelist
+        validate_sdist_contents(
+            name="my-package",
+            version="1.2.3",
+            path=str(os.path.join(tmp_dir, filename)),
+            files=["LICENSE"],
+        )
 
 
 def test_build_sdist_with_include():
     with temporary_directory() as tmp_dir, cwd(os.path.join(fixtures, "with-include")):
         filename = api.build_sdist(tmp_dir)
-
-        with tarfile.open(str(os.path.join(tmp_dir, filename))) as tar:
-            namelist = tar.getnames()
-
-            assert "with-include-1.2.3/LICENSE" in namelist
+        validate_sdist_contents(
+            name="with-include",
+            version="1.2.3",
+            path=str(os.path.join(tmp_dir, filename)),
+            files=["LICENSE"],
+        )
 
 
 def test_prepare_metadata_for_build_wheel():


### PR DESCRIPTION
PEP 517 builds using `masonry.api` was failing with:
```
  FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-req-build-eda28f1f/src/src/src_package/__init__.py'
```
This also contains an additional commit containing test cleanups.

- [x] Added **tests** for changed code.
