### PR TITLE
Fix builders logging

### DIFF
--- a/poetry/core/masonry/builders/builder.py
+++ b/poetry/core/masonry/builders/builder.py
@@ -179,7 +179,7 @@ class Builder(object):
                     # Skip duplicates
                     continue
 
-                logger.debug(" - Adding: {}".format(str(file)))
+                logger.debug("Adding: {}".format(str(file)))
                 to_add.add(include_file)
 
         # add build script if it is specified and explicitly required

--- a/poetry/core/masonry/builders/sdist.py
+++ b/poetry/core/masonry/builders/sdist.py
@@ -56,7 +56,7 @@ class SdistBuilder(Builder):
     format = "sdist"
 
     def build(self, target_dir=None):  # type: (Path) -> Path
-        logger.info(" - Building <info>sdist</info>")
+        logger.info("Building <info>sdist</info>")
         if target_dir is None:
             target_dir = self._path / "dist"
 
@@ -106,7 +106,7 @@ class SdistBuilder(Builder):
             tar.close()
             gz.close()
 
-        logger.info(" - Built <comment>{}</comment>".format(target.name))
+        logger.info("Built <comment>{}</comment>".format(target.name))
         return target
 
     def build_setup(self):  # type: () -> bytes
@@ -209,9 +209,7 @@ class SdistBuilder(Builder):
         has_setup = setup.exists()
 
         if has_setup:
-            logger.info(
-                " - <warning>A setup.py file already exists. Using it.</warning>"
-            )
+            logger.warning("A setup.py file already exists. Using it.")
         else:
             with setup.open("w", encoding="utf-8") as f:
                 f.write(decode(self.build_setup()))
@@ -323,7 +321,7 @@ class SdistBuilder(Builder):
         for file in additional_files:
             file = BuildIncludeFile(path=file, source_root=self._path)
             if file.path.exists():
-                logger.debug(" - Adding: {}".format(file.relative_to_source_root()))
+                logger.debug("Adding: {}".format(file.relative_to_source_root()))
                 to_add.add(file)
 
         return to_add

--- a/poetry/core/masonry/builders/wheel.py
+++ b/poetry/core/masonry/builders/wheel.py
@@ -62,7 +62,7 @@ class WheelBuilder(Builder):
         cls.make_in(poetry)
 
     def build(self):
-        logger.info(" - Building wheel")
+        logger.info("Building wheel")
 
         dist_dir = self._target_dir
         if not dist_dir.exists():
@@ -92,7 +92,7 @@ class WheelBuilder(Builder):
             wheel_path.unlink()
         shutil.move(temp_path, str(wheel_path))
 
-        logger.info(" - Built {}".format(self.wheel_filename))
+        logger.info("Built {}".format(self.wheel_filename))
 
     def _build(self, wheel):
         if self._package.build_script:
@@ -137,7 +137,7 @@ class WheelBuilder(Builder):
                         if rel_path in wheel.namelist():
                             continue
 
-                        logger.debug(" - Adding: {}".format(rel_path))
+                        logger.debug("Adding: {}".format(rel_path))
 
                         self._add_file(wheel, pkg, rel_path)
 
@@ -147,6 +147,7 @@ class WheelBuilder(Builder):
         )
 
     def _run_build_script(self, build_script):
+        logger.debug("Executing build script: {}".format(build_script))
         subprocess.check_call([sys.executable, build_script])
 
     def _copy_module(self, wheel):  # type: (zipfile.ZipFile) -> None


### PR DESCRIPTION
The logging messages needed to be fixed since they kept the format initially required in Poetry and never were adapted to the standalone aspect of poetry-core.

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
