### PR TITLE
Improve package equality check and repr

### DIFF
--- a/poetry/core/packages/package.py
+++ b/poetry/core/packages/package.py
@@ -456,10 +456,33 @@ class Package(object):
         if not isinstance(other, Package):
             return NotImplemented
 
+        if self.source_type in ["file", "directory", "url", "git"]:
+            if self.source_type != other.source_type:
+                return False
+
+            if self.source_url or other.source_url:
+                if self.source_url != other.source_url:
+                    return False
+
+            if self.source_reference or other.source_reference:
+                # special handling for packages with references
+                if not self.source_reference or not other.source_reference:
+                    # case: one reference is defined and is non-empty, but other is not
+                    return False
+
+                if not (
+                    self.source_reference == other.source_reference
+                    or self.source_reference.startswith(other.source_reference)
+                    or other.source_reference.startswith(self.source_reference)
+                ):
+                    # case: both references defined, but one is not equal to or a short
+                    # representation of the other
+                    return False
+
         return self._name == other.name and self._version == other.version
 
     def __str__(self):
         return self.unique_name
 
     def __repr__(self):
-        return "<Package {}>".format(self.unique_name)
+        return "<Package {} {}>".format(self.name, self.full_pretty_version)

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -67,3 +67,77 @@ def test_package_url_category_optional(category, optional):
     )
     assert dependency.category == category
     assert dependency.is_optional() == optional
+
+
+def test_package_equality_simple():
+    assert Package("foo", "0.1.0") == Package("foo", "0.1.0")
+    assert Package("foo", "0.1.0") != Package("foo", "0.1.1")
+    assert Package("bar", "0.1.0") != Package("foo", "0.1.0")
+
+
+def test_package_equality_source_type():
+    a1 = Package("a", "0.1.0")
+    a1.source_type = "file"
+
+    a2 = Package(a1.name, a1.version)
+    a2.source_type = "directory"
+
+    a3 = Package(a1.name, a1.version)
+    a3.source_type = a1.source_type
+
+    a4 = Package(a1.name, a1.version)
+
+    assert a1 == a1
+    assert a1 == a3
+    assert a1 != a2
+    assert a2 != a3
+    assert a1 != a4
+    assert a2 != a4
+
+
+def test_package_equality_source_url():
+    a1 = Package("a", "0.1.0")
+    a1.source_type = "file"
+    a1.source_url = "/some/path"
+
+    a2 = Package(a1.name, a1.version)
+    a2.source_type = a1.source_type
+    a2.source_url = "/some/other/path"
+
+    a3 = Package(a1.name, a1.version)
+    a3.source_type = a1.source_type
+    a3.source_url = a1.source_url
+
+    a4 = Package(a1.name, a1.version)
+    a4.source_type = a1.source_type
+
+    assert a1 == a1
+    assert a1 == a3
+    assert a1 != a2
+    assert a2 != a3
+    assert a1 != a4
+    assert a2 != a4
+
+
+def test_package_equality_source_reference():
+    a1 = Package("a", "0.1.0")
+    a1.source_type = "git"
+    a1.source_reference = "c01b317af582501c5ba07b23d5bef3fbada2d4ef"
+
+    a2 = Package(a1.name, a1.version)
+    a2.source_type = a1.source_type
+    a2.source_reference = "a444731cd243cb5cd04e4d5fb81f86e1fecf8a00"
+
+    a3 = Package(a1.name, a1.version)
+    a3.source_type = a1.source_type
+    a3.source_reference = a1.source_reference
+
+    a4 = Package(a1.name, a1.version)
+    a4.source_type = a1.source_type
+
+    assert a1 == a1
+    assert a1 == a3
+    assert a1 != a2
+    assert a2 != a3
+    assert a1 != a4
+    assert a2 != a4


### PR DESCRIPTION
We need to be a bit more stricter with how we compare packages as prior to this we would check two packages,  `foo-1.0.0` with `source_reference=x` and  `foo-1.0.0` with `source_reference=y` as the same. Which can lead to some unexpected issues at poetry runtime and incorrect validation in poetry's test suites as well.
