### PR TITLE
Support build system requires and enable use of custom executable for build script execution

### DIFF
--- a/poetry/core/masonry/builder.py
+++ b/poetry/core/masonry/builder.py
@@ -1,3 +1,8 @@
+from typing import Optional
+from typing import Union
+
+from poetry.core.utils._compat import Path
+
 from .builders.complete import CompleteBuilder
 from .builders.sdist import SdistBuilder
 from .builders.wheel import WheelBuilder
@@ -10,10 +15,12 @@ class Builder:
     def __init__(self, poetry):
         self._poetry = poetry
 
-    def build(self, fmt):
+    def build(
+        self, fmt, executable=None
+    ):  # type: (str, Optional[Union[str, Path]]) -> None
         if fmt not in self._FORMATS:
             raise ValueError("Invalid format: {}".format(fmt))
 
-        builder = self._FORMATS[fmt](self._poetry)
+        builder = self._FORMATS[fmt](self._poetry, executable=executable)
 
         return builder.build()

--- a/poetry/core/masonry/builders/builder.py
+++ b/poetry/core/masonry/builders/builder.py
@@ -2,6 +2,7 @@
 import logging
 import re
 import shutil
+import sys
 import tempfile
 
 from collections import defaultdict
@@ -40,13 +41,14 @@ class Builder(object):
     format = None
 
     def __init__(
-        self, poetry, ignore_packages_formats=False
-    ):  # type: ("Poetry", bool) -> None
+        self, poetry, ignore_packages_formats=False, executable=None
+    ):  # type: ("Poetry", bool, Optional[Union[Path, str]]) -> None
         self._poetry = poetry
         self._package = poetry.package
         self._path = poetry.file.parent
         self._original_path = self._path
         self._excluded_files = None
+        self._executable = Path(executable or sys.executable)  # type: Path
 
         packages = []
         for p in self._package.packages:
@@ -86,6 +88,10 @@ class Builder(object):
         )
 
         self._meta = Metadata.from_package(self._package)
+
+    @property
+    def executable(self):  # type: () -> Path
+        return self._executable
 
     def build(self):
         raise NotImplementedError()

--- a/poetry/core/masonry/builders/complete.py
+++ b/poetry/core/masonry/builders/complete.py
@@ -38,12 +38,18 @@ class CompleteBuilder(Builder):
 
                 with self.unpacked_tarball(sdist_file) as tmpdir:
                     WheelBuilder.make_in(
-                        Factory().create_poetry(tmpdir), dist_dir, original=self._poetry
+                        Factory().create_poetry(tmpdir),
+                        dist_dir,
+                        original=self._poetry,
+                        executable=self.executable,
                     )
         else:
             with self.unpacked_tarball(sdist_file) as tmpdir:
                 WheelBuilder.make_in(
-                    Factory().create_poetry(tmpdir), dist_dir, original=self._poetry
+                    Factory().create_poetry(tmpdir),
+                    dist_dir,
+                    original=self._poetry,
+                    executable=self.executable,
                 )
 
     @classmethod

--- a/poetry/core/packages/package.py
+++ b/poetry/core/packages/package.py
@@ -77,6 +77,7 @@ class Package(object):
 
         self.requires = []
         self.dev_requires = []
+        self.build_requires = []
         self.extras = {}
         self.requires_extras = []
 
@@ -164,7 +165,7 @@ class Package(object):
 
     @property
     def all_requires(self):
-        return self.requires + self.dev_requires
+        return self.requires + self.dev_requires + self.build_requires
 
     def _get_author(self):  # type: () -> dict
         if not self._authors:
@@ -404,6 +405,8 @@ class Package(object):
 
         if category == "dev":
             self.dev_requires.append(dependency)
+        elif category == "build":
+            self.build_requires.append(dependency)
         else:
             self.requires.append(dependency)
 
@@ -446,6 +449,9 @@ class Package(object):
 
         for dep in self.dev_requires:
             clone.dev_requires.append(dep)
+
+        for dep in self.build_requires:
+            clone.build_requires.append(dep)
 
         return clone
 

--- a/tests/fixtures/project_with_build_system_requires/pyproject.toml
+++ b/tests/fixtures/project_with_build_system_requires/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = [
+  "poetry-core",
+  "Cython~=0.29.6",
+]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "poetry-cython-example"
+version = "0.1.0"
+description = ""
+authors = []
+include = [{ path = "project/**/*.so", format = "wheel" }]
+
+[tool.poetry.build]
+generate-setup-file = false
+script = "build.py"
+
+[tool.poetry.dependencies]
+python = "^3.7"
+
+[tool.poetry.dev-dependencies]

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -199,3 +199,22 @@ The Poetry configuration is invalid:
   - 'description' is a required property
 """
     assert expected == str(e.value)
+
+
+def test_create_poetry_with_build_system_requires():
+    poetry = Factory().create_poetry(
+        fixtures_dir / "project_with_build_system_requires"
+    )
+    package = poetry.package
+
+    assert package.name == "poetry-cython-example"
+    assert package.version.text == "0.1.0"
+
+    assert not package.dev_requires
+    assert not package.requires
+
+    assert len(package.build_requires) == 1
+
+    dependency = package.build_requires[0]
+    assert dependency.category == "build"
+    assert dependency.to_pep_508() == "cython (>=0.29.6,<0.30.0)"


### PR DESCRIPTION
This change adds `build-system.requires` requirements other than `poetry` and `poetry-core` as a dependency for the package (marked with `build` category). This is required in order to allow for `poetry` to effectively manage development environments, for example when the project is installed as an editable package during development. In scenarios where a build script is executed, and it requires `cython` (as an example), today this will fail unless `cython` is listed as a `dev-dependency` explicitly. This change allows for this to be detected from `build-system` configuration table and handled transparently.

Additionally, in order to allow for build script execution under development environment, we allow for the python executable used to be configurable.

Relates-to: python-poetry/poetry#2789