### PR TITLE
Whitespace missing after URL in PEP508 string for URL Dependency

### DIFF
--- a/poetry/core/packages/dependency.py
+++ b/poetry/core/packages/dependency.py
@@ -228,7 +228,7 @@ class Dependency(object):
             )
 
         if markers:
-            if self.is_vcs():
+            if self.is_vcs() or self.is_url():
                 requirement += " "
 
             if len(markers) > 1:

--- a/tests/packages/test_url_dependency.py
+++ b/tests/packages/test_url_dependency.py
@@ -1,0 +1,23 @@
+from poetry.core.packages import URLDependency
+from poetry.core.version.markers import SingleMarker
+
+
+def test_to_pep_508():
+    dependency = URLDependency(
+        "pytorch",
+        "https://download.pytorch.org/whl/cpu/torch-1.5.1%2Bcpu-cp38-cp38-linux_x86_64.whl",
+    )
+
+    expected = "pytorch @ https://download.pytorch.org/whl/cpu/torch-1.5.1%2Bcpu-cp38-cp38-linux_x86_64.whl"
+    assert expected == dependency.to_pep_508()
+
+
+def test_to_pep_508_with_marker():
+    dependency = URLDependency(
+        "pytorch",
+        "https://download.pytorch.org/whl/cpu/torch-1.5.1%2Bcpu-cp38-cp38-linux_x86_64.whl",
+    )
+    dependency.marker = SingleMarker("sys.platform", "linux")
+
+    expected = 'pytorch @ https://download.pytorch.org/whl/cpu/torch-1.5.1%2Bcpu-cp38-cp38-linux_x86_64.whl ; sys_platform == "linux"'
+    assert expected == dependency.to_pep_508()


### PR DESCRIPTION
At the end of an URL there must be a whitespace to represent the end of the url when representing in url dependency in PEP508 format.

Resolves: https://github.com/python-poetry/poetry/issues/2802

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.