### PR TITLE
Ensure Path.glob argument is a string

### DIFF
--- a/poetry/core/masonry/builders/builder.py
+++ b/poetry/core/masonry/builders/builder.py
@@ -96,7 +96,7 @@ class Builder(object):
 
             explicitely_excluded = set()
             for excluded_glob in self._package.exclude:
-                for excluded in self._path.glob(excluded_glob):
+                for excluded in self._path.glob(str(excluded_glob)):
                     explicitely_excluded.add(
                         Path(excluded).relative_to(self._path).as_posix()
                     )

--- a/tests/masonry/builders/fixtures/complete/pyproject.toml
+++ b/tests/masonry/builders/fixtures/complete/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 ]
 
 exclude = [
+    "does-not-exist",
     "**/*.xml"
 ]
 


### PR DESCRIPTION
When excluded path is not a glob pattern, pathlib implementation relies on `sys.intern`, which expects a string. However, the value passed in is of `tomlkit.items.String`. This change ensures poetry does not crash in this scenario.

Resolves: python-poetry/poetry#2798

Co-authored-by: @darkvariantdivine