### PR TITLE
Alter rev-parse syntax to support msys git

### DIFF
--- a/poetry/core/vcs/git.py
+++ b/poetry/core/vcs/git.py
@@ -229,7 +229,15 @@ class Git:
                 folder.as_posix(),
             ]
 
-        args += ["rev-parse", rev + "^{commit}"]
+        # We need "^0" (an alternative to "^{commit}") to ensure that the
+        # commit SHA of the commit the tag points to is returned, even in
+        # the case of annotated tags.
+        #
+        # We deliberately avoid the "^{commit}" syntax itself as on some
+        # platforms (cygwin/msys to be specific), the braces are interpreted
+        # as special characters and would require escaping, while on others
+        # they should not be escaped.
+        args += ["rev-parse", rev + "^0"]
 
         return self.run(*args)
 


### PR DESCRIPTION
### Note:

This PR replaces an [existing one](python-poetry/poetry#2668) as the relevant code had moved

# Details

On windows, `msys` and `cygwin` versions of `git` need braces to be escaped when they are invoked via subprocess.  (This appears to be an unfortunate side effect of the machinery that converts windows paths to posix-like paths for the executable, and is usually hidden when executing from an msys based shell).

If they are not escaped, then `rev^{commit]` becomes a meaningless `rev^commit` to an `msys` `git`, resulting in an error.

In contrast, we do **not** want to escape the braces if passing `rev^{commit}` to any other form of `git`.  We can avoid having to decide whether escaping is needed by using the alternative notation `^0`.

As noted in the [`rev-parse` documentation](https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt-emltrevgtlttypegtemegemv0998commitem)

> A suffix `^` followed by an object type name enclosed in brace pair means dereference the object at `<rev>` recursively ... 
> `<rev>^0` is a short-hand for `<rev>^{commit}`.

# Pull Request Check List

Resolves: python-poetry/poetry#2667
Replaces: python-poetry/poetry#2668

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code. *No additional tests should be necessary*
- [ ] Updated **documentation** for changed code. *No additional documentation necessary*

<!-- **Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch. -->

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
