### PR TITLE
Add helper to access build-system dependencies

### DIFF
--- a/poetry/core/poetry.py
+++ b/poetry/core/poetry.py
@@ -1,27 +1,36 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from typing import TYPE_CHECKING
 from typing import Any
 
-from .packages import ProjectPackage
-from .pyproject import PyProjectTOMLFile
-from .utils._compat import Path
+from poetry.core.pyproject import PyProjectTOML
+from poetry.core.utils._compat import Path  # noqa
+
+
+if TYPE_CHECKING:
+    from poetry.core.packages import ProjectPackage  # noqa
+    from poetry.core.pyproject.toml import PyProjectTOMLFile  # noqa
 
 
 class Poetry(object):
     def __init__(
         self, file, local_config, package,
-    ):  # type: (Path, dict, ProjectPackage) -> None
-        self._file = PyProjectTOMLFile(file)
+    ):  # type: (Path, dict, "ProjectPackage") -> None
+        self._pyproject = PyProjectTOML(file)
         self._package = package
         self._local_config = local_config
 
     @property
-    def file(self):
-        return self._file
+    def pyproject(self):  # type: () -> PyProjectTOML
+        return self._pyproject
 
     @property
-    def package(self):  # type: () -> ProjectPackage
+    def file(self):  # type: () -> "PyProjectTOMLFile"
+        return self._pyproject.file
+
+    @property
+    def package(self):  # type: () -> "ProjectPackage"
         return self._package
 
     @property

--- a/poetry/core/pyproject/tables.py
+++ b/poetry/core/pyproject/tables.py
@@ -1,6 +1,9 @@
 from typing import List
 from typing import Optional
 
+from poetry.core.utils._compat import Path
+from poetry.core.utils.helpers import canonicalize_name
+
 
 # TODO: Convert to dataclass once python 2.7, 3.5 is dropped
 class BuildSystem:
@@ -13,3 +16,42 @@ class BuildSystem:
             else "setuptools.build_meta:__legacy__"
         )
         self.requires = requires if requires is not None else ["setuptools", "wheel"]
+        self._dependencies = None
+
+    @property
+    def dependencies(self):
+        if self._dependencies is None:
+            # avoid circular dependency when loading DirectoryDependency
+            from poetry.core.packages import DirectoryDependency
+            from poetry.core.packages import FileDependency
+            from poetry.core.packages import dependency_from_pep_508
+
+            self._dependencies = []
+            for requirement in self.requires:
+                dependency = None
+                try:
+                    dependency = dependency_from_pep_508(requirement)
+                except ValueError:
+                    # PEP 517 requires can be path if not PEP 508
+                    path = Path(requirement)
+                    try:
+                        if path.is_file():
+                            dependency = FileDependency(
+                                name=canonicalize_name(path.name), path=path
+                            )
+                        elif path.is_dir():
+                            dependency = DirectoryDependency(
+                                name=canonicalize_name(path.name), path=path
+                            )
+                    except OSError:
+                        # compatibility Python < 3.8
+                        # https://docs.python.org/3/library/pathlib.html#methods
+                        pass
+
+                if dependency is None:
+                    # skip since we could not determine requirement
+                    continue
+
+                self._dependencies.append(dependency)
+
+        return self._dependencies

--- a/tests/fixtures/project_with_build_system_requires/pyproject.toml
+++ b/tests/fixtures/project_with_build_system_requires/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = [
+  "poetry-core",
+  "Cython~=0.29.6",
+]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "poetry-cython-example"
+version = "0.1.0"
+description = ""
+authors = []
+include = [{ path = "project/**/*.so", format = "wheel" }]
+
+[tool.poetry.build]
+generate-setup-file = false
+script = "build.py"
+
+[tool.poetry.dependencies]
+python = "^3.7"
+
+[tool.poetry.dev-dependencies]

--- a/tests/pyproject/test_pyproject_toml.py
+++ b/tests/pyproject/test_pyproject_toml.py
@@ -6,6 +6,7 @@ from tomlkit.toml_file import TOMLFile
 
 from poetry.core.pyproject import PyProjectException
 from poetry.core.pyproject import PyProjectTOML
+from poetry.core.utils._compat import Path  # noqa
 
 
 def test_pyproject_toml_simple(pyproject_toml, build_system_section, poetry_section):
@@ -34,7 +35,23 @@ def test_pyproject_toml_poetry_config(pyproject_toml, poetry_section):
     assert pyproject.poetry_config == config
 
 
-def test_pyproject_toml_no_build_system_defaults(pyproject_toml):
+def test_pyproject_toml_no_build_system_defaults():
+    pyproject_toml = (
+        Path(__file__).parent.parent
+        / "fixtures"
+        / "project_with_build_system_requires"
+        / "pyproject.toml"
+    )
+
+    build_system = PyProjectTOML(pyproject_toml).build_system
+    assert build_system.requires == ["poetry-core", "Cython~=0.29.6"]
+
+    assert len(build_system.dependencies) == 2
+    assert build_system.dependencies[0].to_pep_508() == "poetry-core"
+    assert build_system.dependencies[1].to_pep_508() == "Cython (>=0.29.6,<0.30.0)"
+
+
+def test_pyproject_toml_build_requires_as_dependencies(pyproject_toml):
     build_system = PyProjectTOML(pyproject_toml).build_system
     assert build_system.requires == ["setuptools", "wheel"]
     assert build_system.build_backend == "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
This change improves the `BuildSystem` class to expose a `dependencies` propertry that allows for easy access to `build-system` requirements as poetry depdency instances.
