### PR TITLE
Fix version union constraint not properly generated

### DIFF
--- a/poetry/core/packages/dependency.py
+++ b/poetry/core/packages/dependency.py
@@ -159,7 +159,10 @@ class Dependency(object):
             if self.constraint.excludes_single_version():
                 requirement += " ({})".format(str(self.constraint))
             else:
-                requirement += " ({})".format(self.pretty_constraint)
+                constraints = self.pretty_constraint.split(",")
+                constraints = [parse_constraint(c) for c in constraints]
+                constraints = [str(c) for c in constraints]
+                requirement += " ({})".format(",".join(constraints))
         elif isinstance(self.constraint, Version):
             requirement += " (=={})".format(self.constraint.text)
         elif not self.constraint.is_any():

--- a/tests/masonry/builders/test_sdist.py
+++ b/tests/masonry/builders/test_sdist.py
@@ -49,6 +49,8 @@ def test_convert_dependencies():
             Dependency("B", "~1.0"),
             Dependency("C", "1.2.3"),
             VCSDependency("D", "git", "https://github.com/sdispater/d.git"),
+            Dependency("E", "^1.0"),
+            Dependency("F", "^1.0,!=1.3"),
         ],
     )
     main = [
@@ -56,6 +58,8 @@ def test_convert_dependencies():
         "B>=1.0,<1.1",
         "C==1.2.3",
         "D @ git+https://github.com/sdispater/d.git@master",
+        "E>=1.0,<2.0",
+        "F>=1.0,<2.0,!=1.3",
     ]
     extras = {}
 

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -130,3 +130,49 @@ def test_to_pep_508_with_patch_python_version(python_versions, marker):
 
     assert expected == dependency.to_pep_508()
     assert marker == str(dependency.marker)
+
+
+def test_to_pep_508_tilde():
+    dependency = Dependency("foo", "~1.2.3")
+
+    assert "foo (>=1.2.3,<1.3.0)" == dependency.to_pep_508()
+
+    dependency = Dependency("foo", "~1.2")
+
+    assert "foo (>=1.2,<1.3)" == dependency.to_pep_508()
+
+    dependency = Dependency("foo", "~0.2.3")
+
+    assert "foo (>=0.2.3,<0.3.0)" == dependency.to_pep_508()
+
+    dependency = Dependency("foo", "~0.2")
+
+    assert "foo (>=0.2,<0.3)" == dependency.to_pep_508()
+
+
+def test_to_pep_508_caret():
+    dependency = Dependency("foo", "^1.2.3")
+
+    assert "foo (>=1.2.3,<2.0.0)" == dependency.to_pep_508()
+
+    dependency = Dependency("foo", "^1.2")
+
+    assert "foo (>=1.2,<2.0)" == dependency.to_pep_508()
+
+    dependency = Dependency("foo", "^0.2.3")
+
+    assert "foo (>=0.2.3,<0.3.0)" == dependency.to_pep_508()
+
+    dependency = Dependency("foo", "^0.2")
+
+    assert "foo (>=0.2,<0.3)" == dependency.to_pep_508()
+
+
+def test_to_pep_508_combination():
+    dependency = Dependency("foo", "^1.2,!=1.3.5")
+
+    assert "foo (>=1.2,<2.0,!=1.3.5)" == dependency.to_pep_508()
+
+    dependency = Dependency("foo", "~1.2,!=1.2.5")
+
+    assert "foo (>=1.2,<1.3,!=1.2.5)" == dependency.to_pep_508()


### PR DESCRIPTION
Migrated from https://github.com/python-poetry/poetry/pull/1767.

When we have a union of constraints, those were not properly generated.
For example, `^1.2.3,!=1.3.5` would be converted to `^1.2.3,!=1.3.5` (same
string) under PEP508, which is not valid. This PR will instead produce
`>1.2.3,<2.0.0,!=1.3.5`.

The approach may not be the best/cleanest, so I'm open to hear suggestions of improvements.

Thanks!

Note: Should fix https://github.com/python-poetry/poetry/issues/1522.

# Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] ~Updated **documentation** for changed code.~
