### PR TITLE
Fix Python constraint propagation for package to dependency conversion

### DIFF
--- a/poetry/core/packages/package.py
+++ b/poetry/core/packages/package.py
@@ -357,6 +357,9 @@ class Package(PackageSpecification):
         if not self.marker.is_any():
             dep.marker = self.marker
 
+        if not self.python_constraint.is_any():
+            dep.python_versions = self.python_versions
+
         if self._source_type not in ["directory", "file", "url", "git"]:
             return dep
 

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -202,6 +202,16 @@ def test_to_dependency():
     assert package.version == dep.constraint
 
 
+def test_to_dependency_with_python_constraint():
+    package = Package("foo", "1.2.3")
+    package.python_versions = ">=3.6"
+    dep = package.to_dependency()
+
+    assert "foo" == dep.name
+    assert package.version == dep.constraint
+    assert ">=3.6" == dep.python_versions
+
+
 def test_to_dependency_with_features():
     package = Package("foo", "1.2.3", features=["baz", "bar"])
     dep = package.to_dependency()


### PR DESCRIPTION
Resolves: https://github.com/python-poetry/poetry/issues/2950

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

This fixes a regression introduced in #78. Basically, the python constraint was lost when converting a package to a dependency leading to resolution errors on Poetry's side.
