### PR TITLE
Fix python_full_version marker conversion to constraint

### DIFF
--- a/poetry/core/packages/utils/utils.py
+++ b/poetry/core/packages/utils/utils.py
@@ -267,7 +267,7 @@ def create_nested_marker(name, constraint):
 def get_python_constraint_from_marker(
     marker,
 ):  # type: (BaseMarker) -> VersionConstraint
-    python_marker = marker.only("python_version")
+    python_marker = marker.only("python_version", "python_full_version")
     if python_marker.is_any():
         return VersionRange()
 

--- a/poetry/core/version/markers.py
+++ b/poetry/core/version/markers.py
@@ -65,7 +65,7 @@ class BaseMarker(object):
     def exclude(self, marker_name):  # type: (str) -> BaseMarker
         raise NotImplementedError()
 
-    def only(self, marker_name):  # type: (str) -> BaseMarker
+    def only(self, *marker_names):  # type: (str) -> BaseMarker
         raise NotImplementedError()
 
     def invert(self):  # type: () -> BaseMarker
@@ -97,7 +97,7 @@ class AnyMarker(BaseMarker):
     def exclude(self, marker_name):  # type: (str) -> AnyMarker
         return self
 
-    def only(self, marker_name):  # type: (str) -> AnyMarker
+    def only(self, *marker_names):  # type: (str) -> AnyMarker
         return self
 
     def invert(self):  # type: () -> EmptyMarker
@@ -141,7 +141,7 @@ class EmptyMarker(BaseMarker):
     def exclude(self, marker_name):  # type: (str) -> EmptyMarker
         return self
 
-    def only(self, marker_name):  # type: (str) -> EmptyMarker
+    def only(self, *marker_names):  # type: (str) -> EmptyMarker
         return self
 
     def invert(self):  # type: () -> AnyMarker
@@ -287,8 +287,8 @@ class SingleMarker(BaseMarker):
 
         return self
 
-    def only(self, marker_name):  # type: (str) -> BaseMarker
-        if self.name != marker_name:
+    def only(self, *marker_names):  # type: (str) -> BaseMarker
+        if self.name not in marker_names:
             return EmptyMarker()
 
         return self
@@ -464,15 +464,15 @@ class MultiMarker(BaseMarker):
 
         return self.of(*new_markers)
 
-    def only(self, marker_name):  # type: (str) -> BaseMarker
+    def only(self, *marker_names):  # type: (str) -> BaseMarker
         new_markers = []
 
         for m in self._markers:
-            if isinstance(m, SingleMarker) and m.name != marker_name:
+            if isinstance(m, SingleMarker) and m.name not in marker_names:
                 # The marker is not relevant since it's not one we want
                 continue
 
-            marker = m.only(marker_name)
+            marker = m.only(*marker_names)
 
             if not marker.is_empty():
                 new_markers.append(marker)
@@ -628,15 +628,15 @@ class MarkerUnion(BaseMarker):
 
         return self.of(*new_markers)
 
-    def only(self, marker_name):  # type: (str) -> BaseMarker
+    def only(self, *marker_names):  # type: (str) -> BaseMarker
         new_markers = []
 
         for m in self._markers:
-            if isinstance(m, SingleMarker) and m.name != marker_name:
+            if isinstance(m, SingleMarker) and m.name not in marker_names:
                 # The marker is not relevant since it's not one we want
                 continue
 
-            marker = m.only(marker_name)
+            marker = m.only(*marker_names)
 
             if not marker.is_empty():
                 new_markers.append(marker)

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -1,4 +1,8 @@
+import pytest
+
 from poetry.core.packages.utils.utils import convert_markers
+from poetry.core.packages.utils.utils import get_python_constraint_from_marker
+from poetry.core.semver import parse_constraint
 from poetry.core.version.markers import parse_marker
 
 
@@ -21,3 +25,19 @@ def test_convert_markers():
     converted = convert_markers(marker)
 
     assert converted["python_version"] == [[("==", "2.7")], [("==", "2.6")]]
+
+
+@pytest.mark.parametrize(
+    ["marker", "constraint"],
+    [
+        ('python_version >= "3.6" and python_full_version < "4.0"', ">=3.6, <4.0"),
+        (
+            'python_full_version >= "3.6.1" and python_full_version < "4.0.0"',
+            ">=3.6.1, <4.0.0",
+        ),
+    ],
+)
+def test_get_python_constraint_from_marker(marker, constraint):
+    marker = parse_marker(marker)
+    constraint = parse_constraint(constraint)
+    assert constraint == get_python_constraint_from_marker(marker)

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -572,38 +572,43 @@ def test_exclude(marker, excluded, expected):
 @pytest.mark.parametrize(
     "marker, only, expected",
     [
-        ('python_version >= "3.6"', "python_version", 'python_version >= "3.6"'),
+        ('python_version >= "3.6"', ["python_version"], 'python_version >= "3.6"'),
         (
             'python_version >= "3.6" and extra == "foo"',
-            "python_version",
+            ["python_version"],
             'python_version >= "3.6"',
         ),
         (
             'python_version >= "3.6" and (extra == "foo" or extra == "bar")',
-            "extra",
+            ["extra"],
             '(extra == "foo" or extra == "bar")',
         ),
         (
             'python_version >= "3.6" and (extra == "foo" or extra == "bar") or implementation_name == "pypy"',
-            "implementation_name",
+            ["implementation_name"],
             'implementation_name == "pypy"',
         ),
         (
             'python_version >= "3.6" and extra == "foo" or implementation_name == "pypy" and extra == "bar"',
-            "implementation_name",
+            ["implementation_name"],
             'implementation_name == "pypy"',
         ),
         (
             'python_version >= "3.6" or extra == "foo" and implementation_name == "pypy" or extra == "bar"',
-            "implementation_name",
+            ["implementation_name"],
             'implementation_name == "pypy"',
+        ),
+        (
+            'python_version >= "3.6" or extra == "foo" and implementation_name == "pypy" or extra == "bar"',
+            ["implementation_name", "python_version"],
+            'python_version >= "3.6" or implementation_name == "pypy"',
         ),
     ],
 )
 def test_only(marker, only, expected):
     m = parse_marker(marker)
 
-    assert expected == str(m.only(only))
+    assert expected == str(m.only(*only))
 
 
 def test_union_of_a_single_marker_is_the_single_marker():


### PR DESCRIPTION
I stumbled upon this one when trying to update `poetry-core`.

Basically, we would get the following error:

```
  SolverProblemError

  The current project's Python requirement (>=2.7,<2.8 || >=3.5,<4.0) is not compatible with some of the required packages Python requirement:
    - pre-commit requires Python >=3.6.1, so it will not be satisfied for Python >=2.7,<2.8 || >=3.5,<3.6.1
```

The root cause was that `get_python_constraint_from_marker()` was generating empty constraints for `python_full_version` markers since we were only checking `python_version` markers.