### PR TITLE
Release 1.0.0rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [1.0.0rc2] - 2020-09-25
+
+### Fixed
+
+- Fixed `python_full_version` markers conversion to version constraints ([#86](https://github.com/python-poetry/core/pull/86)).
+
+
 ## [1.0.0rc1] - 2020-09-25
 
 ### Fixed
@@ -95,7 +102,8 @@
 - Fixed support for stub-only packages ([#28](https://github.com/python-poetry/core/pull/28)).
 
 
-[Unreleased]: https://github.com/python-poetry/poetry/compare/1.0.0rc1...master
+[Unreleased]: https://github.com/python-poetry/poetry/compare/1.0.0rc2...master
+[1.0.0rc2]: https://github.com/python-poetry/poetry/releases/tag/1.0.0rc2
 [1.0.0rc1]: https://github.com/python-poetry/poetry/releases/tag/1.0.0rc1
 [1.0.0b1]: https://github.com/python-poetry/poetry/releases/tag/1.0.0b1
 [1.0.0a9]: https://github.com/python-poetry/poetry/releases/tag/1.0.0a9

--- a/poetry/core/__init__.py
+++ b/poetry/core/__init__.py
@@ -7,7 +7,7 @@ except ImportError:
     # noinspection PyUnresolvedReferences
     from pathlib2 import Path
 
-__version__ = "1.0.0rc1"
+__version__ = "1.0.0rc2"
 
 __vendor_site__ = (Path(__file__).parent / "_vendor").as_posix()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-core"
-version = "1.0.0rc1"
+version = "1.0.0rc2"
 description = "Poetry PEP 517 Build Backend"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 


### PR DESCRIPTION
### Fixed

- Fixed `python_full_version` markers conversion to version constraints ([#86](https://github.com/python-poetry/core/pull/86)).
