### PR TITLE
Use pkgutil.get_data for zip-safe resource loading

### DIFF
--- a/poetry/core/_vendor/jsonschema/_utils.py
+++ b/poetry/core/_vendor/jsonschema/_utils.py
@@ -1,6 +1,6 @@
 import itertools
 import json
-import os
+import pkgutil
 import re
 
 from jsonschema.compat import MutableMapping, str_types, urlsplit
@@ -50,12 +50,12 @@ def load_schema(name):
     """
     Load a schema from ./schemas/``name``.json and return it.
     """
-    with open(
-        os.path.join(os.path.dirname(__file__), "schemas", "{0}.json".format(name))
-    ) as f:
-        data = f.read()
 
-    return json.loads(data)
+    data = pkgutil.get_data(
+        "poetry.core",
+        "_vendor/jsonschema/schemas/{0}.json".format(name),
+    )
+    return json.loads(data.decode("utf-8"))
 
 
 def indent(string, times=1):

--- a/vendors/patches/jsonschema.patch
+++ b/vendors/patches/jsonschema.patch
@@ -17,26 +17,13 @@ diff --git a/poetry/core/_vendor/jsonschema/_utils.py b/poetry/core/_vendor/json
 index 8fb8593..368474a 100644
 --- a/poetry/core/_vendor/jsonschema/_utils.py
 +++ b/poetry/core/_vendor/jsonschema/_utils.py
-@@ -1,6 +1,6 @@
- import itertools
- import json
--import pkgutil
-+import os
- import re
-
- from jsonschema.compat import MutableMapping, str_types, urlsplit
-@@ -50,9 +50,12 @@ def load_schema(name):
-     """
+@@ -51,5 +51,8 @@ def load_schema(name):
      Load a schema from ./schemas/``name``.json and return it.
      """
-+    with open(
-+        os.path.join(os.path.dirname(__file__), "schemas", "{0}.json".format(name))
-+    ) as f:
-+        data = f.read()
 
 -    data = pkgutil.get_data("jsonschema", "schemas/{0}.json".format(name))
--    return json.loads(data.decode("utf-8"))
-+    return json.loads(data)
-
-
- def indent(string, times=1):
++    data = pkgutil.get_data(
++        "poetry.core",
++        "_vendor/jsonschema/schemas/{0}.json".format(name),
++    )
+     return json.loads(data.decode("utf-8"))


### PR DESCRIPTION
When running from a Zip file (`zipapp`, `*.pyz`), loading resources
from package data can not be done by directly reading files relative
to `__file__`, since there is no valid path on the file system for
zipped files.

Using `pkgutil.get_data` ensures that loading files from a Zip archive
is handled accordingly.

Resolves: python-poetry/poetry#2965