### PR TITLE
package: do not default to develop

### DIFF
--- a/poetry/core/packages/package.py
+++ b/poetry/core/packages/package.py
@@ -49,7 +49,8 @@ class Package(PackageSpecification):
         source_url: Optional[str] = None,
         source_reference: Optional[str] = None,
         source_resolved_reference: Optional[str] = None,
-        features: Optional[List[str]] = None,  # type
+        features: Optional[List[str]] = None,
+        develop: bool = False,
     ) -> None:
         """
         Creates a new in memory package.
@@ -105,7 +106,7 @@ class Package(PackageSpecification):
 
         self.root_dir = None
 
-        self.develop = True
+        self.develop = develop
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
Setting develop to `True` by default causes un-expected side-effects
and requires downstream consumers to rely on checks like
`package.develop and package.source_type == "directory""` to determine
if develop mode (python-poetry/poetry#3099).

This also corresponds to current high-level behaviour of packages being
non-develop by default.
