### PR TITLE
Ensure dependency string is PEP 508 compliant

### DIFF
--- a/poetry/core/packages/dependency.py
+++ b/poetry/core/packages/dependency.py
@@ -396,13 +396,7 @@ class Dependency(PackageSpecification):
     def __str__(self):
         if self.is_root:
             return self._pretty_name
-
-        name = self._pretty_name
-
-        if self._features:
-            name = "{}[{}]".format(name, ",".join(sorted(self._features)))
-
-        return "{} ({})".format(name, self._pretty_constraint)
+        return self.base_pep_508_name
 
     def __repr__(self):
         return "<{} {}>".format(self.__class__.__name__, str(self))

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -184,3 +184,22 @@ def test_complete_name():
         "foo[bar,baz]"
         == Dependency("foo", ">=1.2.3", extras=["baz", "bar"]).complete_name
     )
+
+
+@pytest.mark.parametrize(
+    "name,constraint,extras,expected",
+    [
+        ("A", ">2.7,<3.0", None, "A (>2.7,<3.0)"),
+        ("A", ">2.7,<3.0", ["x"], "A[x] (>2.7,<3.0)"),
+        ("A", ">=1.6.5,<1.8.0 || >1.8.0,<3.1.0", None, "A (>=1.6.5,!=1.8.0,<3.1.0)"),
+        (
+            "A",
+            ">=1.6.5,<1.8.0 || >1.8.0,<3.1.0",
+            ["x"],
+            "A[x] (>=1.6.5,!=1.8.0,<3.1.0)",
+        ),
+    ],
+)
+def test_dependency_string_representation(name, constraint, extras, expected):
+    dependency = Dependency(name=name, constraint=constraint, extras=extras)
+    assert str(dependency) == expected


### PR DESCRIPTION
This issue was dicovered during root cause analysis for python-poetry/poetry#3224 