### PR TITLE
Update VERSION_PATTERN

### DIFF
--- a/poetry/core/version/version.py
+++ b/poetry/core/version/version.py
@@ -12,41 +12,9 @@ _Version = namedtuple("_Version", ["epoch", "release", "dev", "pre", "post", "lo
 
 
 VERSION_PATTERN = re.compile(
-    r"""
-    ^
-    v?
-    (?:
-        (?:(?P<epoch>[0-9]+)!)?                           # epoch
-        (?P<release>[0-9]+(?:\.[0-9]+)*)                  # release segment
-        (?P<pre>                                          # pre-release
-            [-_.]?
-            (?P<pre_l>(a|b|c|rc|alpha|beta|pre|preview))
-            [-_.]?
-            (?P<pre_n>[0-9]+)?
-        )?
-        (?P<post>                                         # post release
-            (?:-(?P<post_n1>[0-9]+))
-            |
-            (?:
-                [-_.]?
-                (?P<post_l>post|rev|r)
-                [-_.]?
-                (?P<post_n2>[0-9]+)?
-            )
-        )?
-        (?P<dev>                                          # dev release
-            [-_.]?
-            (?P<dev_l>dev)
-            [-_.]?
-            (?P<dev_n>[0-9]+)?
-        )?
-    )
-    (?:\+(?P<local>[a-z0-9]+(?:[-_.][a-z0-9]+)*))?       # local version
-    $
-""",
+    "^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$",
     re.IGNORECASE | re.VERBOSE,
 )
-
 
 class Version(BaseVersion):
     def __init__(self, version):


### PR DESCRIPTION
The VERSION_PATTERN should be compatible with semantic version guideline. I replace the old pattern string with the official recommendation in this fix.

For example, 1.0.0-0.3.7 should be a valid version according to the official website of [semver](https://semver.org/), but it breaks with the current VERSION_PATTERN. This proposed fix comes from the official website so it should be the most reliable one.

Could someone help review this pull request? @sdispater Thanks!
