### PR TITLE
Enable hash checking again (currently hashes from lock file are not validated at all)

### DIFF
--- a/poetry/core/packages/file_dependency.py
+++ b/poetry/core/packages/file_dependency.py
@@ -63,8 +63,8 @@ class FileDependency(Dependency):
     def is_file(self):
         return True
 
-    def hash(self):
-        h = hashlib.sha256()
+    def hash(self, name="sha256"):
+        h = hashlib.new(name)
         with self._full_path.open("rb") as fp:
             for content in iter(lambda: fp.read(io.DEFAULT_BUFFER_SIZE), b""):
                 h.update(content)

--- a/poetry/core/packages/package.py
+++ b/poetry/core/packages/package.py
@@ -406,6 +406,7 @@ class Package(PackageSpecification):
         clone.extras = self.extras
         clone.root_dir = self.root_dir
         clone.develop = self.develop
+        clone.files = self.files
 
         for dep in self.requires:
             clone.requires.append(dep)


### PR DESCRIPTION
Resolves: https://github.com/python-poetry/poetry/issues/2422
Replaces: https://github.com/python-poetry/poetry/pull/2611
Blocks: [TBD]

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code. - Not needed as this is a bug fix


# Questions

1. The MR template asks me to base this on `develop` but no branch with this name exists, so I am sticking to `master`, am I missing something?
2. I had some trouble setting up my local dev environment for poetry, so no unit tests yet. How do I get proper tracebacks out of poetry? I only get the last line not a full traceback or no line at all and just the exception name.