### PR TITLE
Always close the wheel tempfile after writing to it

### DIFF
--- a/poetry/core/masonry/builders/wheel.py
+++ b/poetry/core/masonry/builders/wheel.py
@@ -78,18 +78,19 @@ class WheelBuilder(Builder):
         new_mode = normalize_file_permissions(st_mode)
         os.chmod(temp_path, new_mode)
 
-        with zipfile.ZipFile(
-            os.fdopen(fd, "w+b"), mode="w", compression=zipfile.ZIP_DEFLATED
-        ) as zip_file:
-            if not self._poetry.package.build_should_generate_setup():
-                self._build(zip_file)
-                self._copy_module(zip_file)
-            else:
-                self._copy_module(zip_file)
-                self._build(zip_file)
+        with os.fdopen(fd, "w+b") as fd_file:
+            with zipfile.ZipFile(
+                fd_file, mode="w", compression=zipfile.ZIP_DEFLATED
+            ) as zip_file:
+                if not self._poetry.package.build_should_generate_setup():
+                    self._build(zip_file)
+                    self._copy_module(zip_file)
+                else:
+                    self._copy_module(zip_file)
+                    self._build(zip_file)
 
-            self._write_metadata(zip_file)
-            self._write_record(zip_file)
+                self._write_metadata(zip_file)
+                self._write_record(zip_file)
 
         wheel_path = dist_dir / self.wheel_filename
         if wheel_path.exists():


### PR DESCRIPTION
Resolves: python-poetry/poetry#3545

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

As mentioned in python-poetry/poetry#3545, PyPy3 on Windows does not auto-close the tempfile that is created when building wheels. It appears that CPython auto-closes the file as the zip file context manager exits, but PyPy3 does not, leading to a PermissionError.

There are two commits in this patch:

1. The first demonstrates the issue. In fact, by maintaining a reference to the file object, it stays open in CPython and generates the exact same PermissionError as in PyPy3.
2. The second closes the issue by moving the bare `os.fdopen()` call into a context manager.

Please let me know if there is anything else that needs to be done, or if you want something accomplished in a different way. Resolving this issue will allow me to run feedparser unit tests on Windows with PyPy3.