### PR TITLE
Raise a more explicit error when include is not a package

### DIFF
--- a/poetry/core/masonry/utils/package_include.py
+++ b/poetry/core/masonry/utils/package_include.py
@@ -1,6 +1,10 @@
 from .include import Include
 
 
+class NotAPackageError(ValueError):
+    pass
+
+
 class PackageInclude(Include):
     def __init__(self, base, include, formats=None, source=None):
         self._package = None
@@ -61,7 +65,7 @@ class PackageInclude(Include):
             self._package = root.parent.name
 
             if not self.is_stub_only() and not self.has_modules():
-                raise ValueError("{} is not a package.".format(root.name))
+                raise NotAPackageError("{} is not a package.".format(root.name))
 
         else:
             if root.is_dir():
@@ -70,7 +74,7 @@ class PackageInclude(Include):
                 self._elements = sorted(list(root.glob("**/*")))
 
                 if not self.is_stub_only() and not self.has_modules():
-                    raise ValueError("{} is not a package.".format(root.name))
+                    raise NotAPackageError("{} is not a package.".format(root.name))
 
                 self._is_package = True
             else:

--- a/tests/masonry/utils/test_package_include.py
+++ b/tests/masonry/utils/test_package_include.py
@@ -1,6 +1,7 @@
 import pytest
 
-from poetry.core.masonry.utils.package_include import NotAPackageError, PackageInclude
+from poetry.core.masonry.utils.package_include import NotAPackageError
+from poetry.core.masonry.utils.package_include import PackageInclude
 from poetry.core.utils._compat import Path
 
 

--- a/tests/masonry/utils/test_package_include.py
+++ b/tests/masonry/utils/test_package_include.py
@@ -1,6 +1,6 @@
 import pytest
 
-from poetry.core.masonry.utils.package_include import PackageInclude
+from poetry.core.masonry.utils.package_include import NotAPackageError, PackageInclude
 from poetry.core.utils._compat import Path
 
 
@@ -37,7 +37,7 @@ def test_package_include_with_nested_dir():
 
 
 def test_package_include_with_no_python_files_in_dir():
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(NotAPackageError) as e:
         PackageInclude(base=with_includes, include="not_a_python_pkg")
 
     assert str(e.value) == "not_a_python_pkg is not a package."


### PR DESCRIPTION
Related to: python-poetry#[689](https://github.com/python-poetry/poetry/issues/689)

When an include is not a package, a `ValueError` is raised, which is not catched by Poetry's `install` command, resulting in a error (see issue). Raising a more specific exception (like  `NotAPackageError`) could allow `install` command to [catch it](https://github.com/python-poetry/poetry/blob/de0b32c245c72568cf546090600d4626917cd3a4/poetry/console/commands/install.py#L81) and silent it.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] ~Updated **documentation** for changed code.~

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
