### PR TITLE
chore: packaging 20.9, Universal2 wheels on Apple Silicon

### DIFF
--- a/poetry/core/_vendor/packaging/__about__.py
+++ b/poetry/core/_vendor/packaging/__about__.py
@@ -18,7 +18,7 @@ __title__ = "packaging"
 __summary__ = "Core utilities for Python packages"
 __uri__ = "https://github.com/pypa/packaging"
 
-__version__ = "20.8"
+__version__ = "20.9"
 
 __author__ = "Donald Stufft and individual contributors"
 __email__ = "donald@stufft.io"

--- a/poetry/core/_vendor/packaging/markers.py
+++ b/poetry/core/_vendor/packaging/markers.py
@@ -8,13 +8,21 @@ import os
 import platform
 import sys
 
-from pyparsing import ParseException, ParseResults, stringStart, stringEnd
-from pyparsing import ZeroOrMore, Group, Forward, QuotedString
-from pyparsing import Literal as L  # noqa
+from pyparsing import (  # noqa: N817
+    Forward,
+    Group,
+    Literal as L,
+    ParseException,
+    ParseResults,
+    QuotedString,
+    ZeroOrMore,
+    stringEnd,
+    stringStart,
+)
 
 from ._compat import string_types
 from ._typing import TYPE_CHECKING
-from .specifiers import Specifier, InvalidSpecifier
+from .specifiers import InvalidSpecifier, Specifier
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, Callable, Dict, List, Optional, Tuple, Union

--- a/poetry/core/_vendor/packaging/requirements.py
+++ b/poetry/core/_vendor/packaging/requirements.py
@@ -3,13 +3,22 @@
 # for complete details.
 from __future__ import absolute_import, division, print_function
 
-import string
 import re
+import string
 import sys
 
-from pyparsing import stringStart, stringEnd, originalTextFor, ParseException
-from pyparsing import ZeroOrMore, Word, Optional, Regex, Combine
-from pyparsing import Literal as L  # noqa
+from pyparsing import (  # noqa: N817
+    Combine,
+    Literal as L,
+    Optional,
+    ParseException,
+    Regex,
+    Word,
+    ZeroOrMore,
+    originalTextFor,
+    stringEnd,
+    stringStart,
+)
 
 from ._typing import TYPE_CHECKING
 from .markers import MARKER_EXPR, Marker

--- a/poetry/core/_vendor/packaging/specifiers.py
+++ b/poetry/core/_vendor/packaging/specifiers.py
@@ -12,10 +12,10 @@ import warnings
 from ._compat import string_types, with_metaclass
 from ._typing import TYPE_CHECKING
 from .utils import canonicalize_version
-from .version import Version, LegacyVersion, parse
+from .version import LegacyVersion, Version, parse
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import List, Dict, Union, Iterable, Iterator, Optional, Callable, Tuple
+    from typing import Callable, Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
     ParsedVersion = Union[Version, LegacyVersion]
     UnparsedVersion = Union[Version, LegacyVersion, str]

--- a/poetry/core/_vendor/packaging/tags.py
+++ b/poetry/core/_vendor/packaging/tags.py
@@ -27,9 +27,9 @@ from ._typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import (
+        IO,
         Dict,
         FrozenSet,
-        IO,
         Iterable,
         Iterator,
         List,
@@ -458,14 +458,28 @@ def mac_platforms(version=None, arch=None):
                     major=major_version, minor=0, binary_format=binary_format
                 )
 
-    if version >= (11, 0) and arch == "x86_64":
+    if version >= (11, 0):
         # Mac OS 11 on x86_64 is compatible with binaries from previous releases.
         # Arm64 support was introduced in 11.0, so no Arm binaries from previous
         # releases exist.
-        for minor_version in range(16, 3, -1):
-            compat_version = 10, minor_version
-            binary_formats = _mac_binary_formats(compat_version, arch)
-            for binary_format in binary_formats:
+        #
+        # However, the "universal2" binary format can have a
+        # macOS version earlier than 11.0 when the x86_64 part of the binary supports
+        # that version of macOS.
+        if arch == "x86_64":
+            for minor_version in range(16, 3, -1):
+                compat_version = 10, minor_version
+                binary_formats = _mac_binary_formats(compat_version, arch)
+                for binary_format in binary_formats:
+                    yield "macosx_{major}_{minor}_{binary_format}".format(
+                        major=compat_version[0],
+                        minor=compat_version[1],
+                        binary_format=binary_format,
+                    )
+        else:
+            for minor_version in range(16, 3, -1):
+                compat_version = 10, minor_version
+                binary_format = "universal2"
                 yield "macosx_{major}_{minor}_{binary_format}".format(
                     major=compat_version[0],
                     minor=compat_version[1],

--- a/poetry/core/_vendor/packaging/utils.py
+++ b/poetry/core/_vendor/packaging/utils.py
@@ -6,23 +6,41 @@ from __future__ import absolute_import, division, print_function
 import re
 
 from ._typing import TYPE_CHECKING, cast
+from .tags import Tag, parse_tag
 from .version import InvalidVersion, Version
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import NewType, Union
+    from typing import FrozenSet, NewType, Tuple, Union
 
+    BuildTag = Union[Tuple[()], Tuple[int, str]]
     NormalizedName = NewType("NormalizedName", str)
 else:
+    BuildTag = tuple
     NormalizedName = str
 
+
+class InvalidWheelFilename(ValueError):
+    """
+    An invalid wheel filename was found, users should refer to PEP 427.
+    """
+
+
+class InvalidSdistFilename(ValueError):
+    """
+    An invalid sdist filename was found, users should refer to the packaging user guide.
+    """
+
+
 _canonicalize_regex = re.compile(r"[-_.]+")
+# PEP 427: The build number must start with a digit.
+_build_tag_regex = re.compile(r"(\d+)(.*)")
 
 
 def canonicalize_name(name):
     # type: (str) -> NormalizedName
     # This is taken from PEP 503.
     value = _canonicalize_regex.sub("-", name).lower()
-    return cast("NormalizedName", value)
+    return cast(NormalizedName, value)
 
 
 def canonicalize_version(version):
@@ -65,3 +83,56 @@ def canonicalize_version(version):
         parts.append("+{0}".format(version.local))
 
     return "".join(parts)
+
+
+def parse_wheel_filename(filename):
+    # type: (str) -> Tuple[NormalizedName, Version, BuildTag, FrozenSet[Tag]]
+    if not filename.endswith(".whl"):
+        raise InvalidWheelFilename(
+            "Invalid wheel filename (extension must be '.whl'): {0}".format(filename)
+        )
+
+    filename = filename[:-4]
+    dashes = filename.count("-")
+    if dashes not in (4, 5):
+        raise InvalidWheelFilename(
+            "Invalid wheel filename (wrong number of parts): {0}".format(filename)
+        )
+
+    parts = filename.split("-", dashes - 2)
+    name_part = parts[0]
+    # See PEP 427 for the rules on escaping the project name
+    if "__" in name_part or re.match(r"^[\w\d._]*$", name_part, re.UNICODE) is None:
+        raise InvalidWheelFilename("Invalid project name: {0}".format(filename))
+    name = canonicalize_name(name_part)
+    version = Version(parts[1])
+    if dashes == 5:
+        build_part = parts[2]
+        build_match = _build_tag_regex.match(build_part)
+        if build_match is None:
+            raise InvalidWheelFilename(
+                "Invalid build number: {0} in '{1}'".format(build_part, filename)
+            )
+        build = cast(BuildTag, (int(build_match.group(1)), build_match.group(2)))
+    else:
+        build = ()
+    tags = parse_tag(parts[-1])
+    return (name, version, build, tags)
+
+
+def parse_sdist_filename(filename):
+    # type: (str) -> Tuple[NormalizedName, Version]
+    if not filename.endswith(".tar.gz"):
+        raise InvalidSdistFilename(
+            "Invalid sdist filename (extension must be '.tar.gz'): {0}".format(filename)
+        )
+
+    # We are requiring a PEP 440 version, which cannot contain dashes,
+    # so we split on the last dash.
+    name_part, sep, version_part = filename[:-7].rpartition("-")
+    if not sep:
+        raise InvalidSdistFilename("Invalid sdist filename: {0}".format(filename))
+
+    name = canonicalize_name(name_part)
+    version = Version(version_part)
+    return (name, version)

--- a/poetry/core/_vendor/vendor.txt
+++ b/poetry/core/_vendor/vendor.txt
@@ -1,7 +1,7 @@
 attrs==20.3.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 jsonschema==3.2.0
 lark-parser==0.9.0
-packaging==20.8; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
+packaging==20.9; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 pyparsing==2.4.7; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 pyrsistent==0.16.1; python_version >= "2.7"
 six==1.15.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "2.7"

--- a/vendors/poetry.lock
+++ b/vendors/poetry.lock
@@ -59,7 +59,7 @@ regex = ["regex"]
 
 [[package]]
 name = "packaging"
-version = "20.8"
+version = "20.9"
 description = "Core utilities for Python packages"
 category = "main"
 optional = false
@@ -126,7 +126,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "f9770372f7c711e4c2941e30c28b26a58a8c76aae88ddc1e3ea8e175fcc6a534"
+content-hash = "6790cea1370c2296b96f05af2218de159499268429c0c81757de8e4e90bfa9b0"
 
 [metadata.files]
 attrs = [
@@ -145,8 +145,8 @@ lark-parser = [
     {file = "lark-parser-0.9.0.tar.gz", hash = "sha256:9e7589365d6b6de1cca40b0eaec31104a3fb96a37a11a9dfd5098e95b50aa6cd"},
 ]
 packaging = [
-    {file = "packaging-20.8-py2.py3-none-any.whl", hash = "sha256:24e0da08660a87484d1602c30bb4902d74816b6985b93de36926f5bc95741858"},
-    {file = "packaging-20.8.tar.gz", hash = "sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093"},
+    {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
+    {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},

--- a/vendors/pyproject.toml
+++ b/vendors/pyproject.toml
@@ -23,6 +23,6 @@ python = "^3.6"
 
 jsonschema = "^3.2.0"
 lark-parser = "^0.9.0"
-packaging = "^20.8"
+packaging = "^20.9"
 pyrsistent = "^0.16.0"
 tomlkit = ">=0.7.0,<1.0.0"


### PR DESCRIPTION

This bumps packaging to 20.9, which is a key component to supporting Apple Silicon installing Universal2 wheels. Follow up to #125, which was a fix for Intel Apple Silicon. Once Universal2 wheels start shipping, this is needed for Poetry to be able to download them on Apple Silicon.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
