### PR TITLE
Revert changes to canonicalize_name

### DIFF
--- a/poetry/core/utils/helpers.py
+++ b/poetry/core/utils/helpers.py
@@ -20,7 +20,7 @@ except ImportError:
     from collections import Mapping
 
 
-_canonicalize_regex = re.compile(r"[-_.]+")
+_canonicalize_regex = re.compile(r"[-_]+")
 
 
 def canonicalize_name(name):  # type: (str) -> str

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -62,9 +62,7 @@ isort@ git+git://github.com/timothycrosley/isort.git@e63ae06ec7d70b06df9e5283576
     assert result == expected
 
 
-@pytest.mark.parametrize(
-    "raw", ["a-b-c", "a.b-c", "a.b.c", "a_b-c", "a_b_c", "a-b_c", "a.b_c", "a-b.c"]
-)
+@pytest.mark.parametrize("raw", ["a-b-c", "a_b-c", "a_b_c", "a-b_c"])
 def test_utils_helpers_canonical_names(raw):
     assert canonicalize_name(raw) == "a-b-c"
 


### PR DESCRIPTION
Reverts #100 

While it fixed some issues, it had some unintended side effects and the canonicalized names were propagated in too many places.

We should find a way to keep the original name of the package but still be able to compare it to the canonicalized version.

But I feel more comfortable reverting it for now.
