### PR TITLE
Glob to find stale dist-infos

### DIFF
--- a/poetry/core/masonry/builders/wheel.py
+++ b/poetry/core/masonry/builders/wheel.py
@@ -258,6 +258,12 @@ class WheelBuilder(Builder):
         return "{}-{}.dist-info".format(escaped_name, escaped_version)
 
     @property
+    def dist_info_glob(self) -> str:
+        escaped_name = escape_name(self._package.name)
+
+        return "{}-*.dist-info".format(escaped_name)
+
+    @property
     def tag(self) -> str:
         if self._package.build_script:
             tag = next(sys_tags())


### PR DESCRIPTION
This is a preparation for https://github.com/python-poetry/poetry/pull/3742.

It seems the sibling method is not documented/tested, so not clear what to do on that front.
Alternative might be to pass through `name` in `dist_info_name` unescaped if it's the `*`-glob?