### PR TITLE
mypy: Fix Missing return statement/value errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,8 @@ MANIFEST.in
 /docs/site/*
 /tests/fixtures/simple_project/setup.py
 /tests/fixtures/project_with_extras/setup.py
-.mypy_cache
+.mypy_cache/
+__pycache__/
 
 .venv
 /releases/*

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+exclude = poetry/core/_vendor

--- a/poetry/core/semver/version.py
+++ b/poetry/core/semver/version.py
@@ -300,11 +300,11 @@ class Version(VersionRange):
 
     def _normalize_prerelease(self, pre: str) -> Optional[str]:
         if not pre:
-            return
+            return None
 
         m = re.match(r"(?i)^(a|alpha|b|beta|c|pre|rc|dev)[-.]?(\d+)?$", pre)
         if not m:
-            return
+            return None
 
         modifier = m.group(1)
         number = m.group(2)
@@ -325,13 +325,13 @@ class Version(VersionRange):
 
     def _normalize_build(self, build: str) -> Optional[str]:
         if not build:
-            return
+            return None
 
         if build.startswith("post"):
             build = build.lstrip("post")
 
         if not build:
-            return
+            return None
 
         return build
 

--- a/poetry/core/version/version.py
+++ b/poetry/core/version/version.py
@@ -136,6 +136,7 @@ class Version(BaseVersion):
         version_string = str(self)
         if "+" in version_string:
             return version_string.split("+", 1)[1]
+        return version_string
 
     @property
     def is_prerelease(self) -> bool:
@@ -146,7 +147,9 @@ class Version(BaseVersion):
         return bool(self._version.post)
 
 
-def _parse_letter_version(letter: str, number: Optional[str]) -> Tuple[str, int]:
+def _parse_letter_version(
+    letter: str, number: Optional[str]
+) -> Optional[Tuple[str, int]]:
     if letter:
         # We consider there to be an implicit 0 in a pre-release if there is
         # not a numeral associated with it.
@@ -176,6 +179,8 @@ def _parse_letter_version(letter: str, number: Optional[str]) -> Tuple[str, int]
 
         return letter, int(number)
 
+    return None
+
 
 _local_version_seperators = re.compile(r"[._-]")
 
@@ -184,11 +189,13 @@ def _parse_local_version(local: Optional[str]) -> Tuple[Union[str, int], ...]:
     """
     Takes a string like abc.1.twelve and turns it into ("abc", 1, "twelve").
     """
-    if local is not None:
-        return tuple(
-            part.lower() if not part.isdigit() else int(part)
-            for part in _local_version_seperators.split(local)
-        )
+    if local is None:
+        return None
+
+    return tuple(
+        part.lower() if not part.isdigit() else int(part)
+        for part in _local_version_seperators.split(local)
+    )
 
 
 def _cmpkey(


### PR DESCRIPTION
I see that this repository doesn't yet include `mypy` as a dependency like `python-poetry/poetry` does, though using it I was able to find quite a few errors. By resolving these errors, I hope to make poetry-core _some amount_ more correct. For the purposes of this PR, I narrowed the scope to the following:

```sh
$ poetry run mypy poetry --exclude=poetry/core/_vendor | grep "Missing return statement\|Return value expected"
poetry/core/version/version.py:135: error: Missing return statement
poetry/core/version/version.py:149: error: Missing return statement
poetry/core/version/version.py:183: error: Missing return statement
poetry/core/semver/version.py:303: error: Return value expected
poetry/core/semver/version.py:307: error: Return value expected
poetry/core/semver/version.py:328: error: Return value expected
poetry/core/semver/version.py:334: error: Return value expected
```

Each error was rather innocuous, though easy enough to correct. Extra consideration was taken, possibly incorrectly, to ignore the `poetry/core/_vendor` directory as this looks like external code as the folder name suggests. I included this directory in a `mypy.ini` file as seen in the proposed commits, though left granular configuration alone for now pending broader discussion.

The GitHub Actions should confirm this as well, provided I haven't made a mistake, though the tests pass locally:

```sh
$ poetry run tox -e py39
...
== 529 passed, 2 skipped, 8 deselected in 2.96 seconds ==
```