### PR TITLE
Output valid file URLs when building requirements

### DIFF
--- a/poetry/core/packages/directory_dependency.py
+++ b/poetry/core/packages/directory_dependency.py
@@ -122,8 +122,8 @@ class DirectoryDependency(Dependency):
         if self.extras:
             requirement += "[{}]".format(",".join(self.extras))
 
-        path_url = path_to_url(self._path)
-        requirement += " @ {}".format(path_url)
+        path = path_to_url(self.path) if self.path.is_absolute() else self.path
+        requirement += " @ {}".format(path)
 
         return requirement
 

--- a/poetry/core/packages/directory_dependency.py
+++ b/poetry/core/packages/directory_dependency.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from .constraints import BaseConstraint  # noqa
 
 from .dependency import Dependency
+from .utils.utils import path_to_url
 
 
 class DirectoryDependency(Dependency):
@@ -121,7 +122,8 @@ class DirectoryDependency(Dependency):
         if self.extras:
             requirement += "[{}]".format(",".join(self.extras))
 
-        requirement += " @ {}".format(self._path.as_posix())
+        path_url = path_to_url(self._path)
+        requirement += " @ {}".format(path_url)
 
         return requirement
 


### PR DESCRIPTION
Resolves: python-poetry/poetry#3818

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

This code isn't currently covered by a test, but I can add one. I also didn't see any relevant docs to update but can if someone could point me to them.

Similar to the issue fixed by python-poetry/poetry#3121, file/directory dependencies in requirements.txt format (and transitively, in wheels) must be in URL format. Running `pip install .` for any poetry project containing a directory dependency will currently fail due to this issue.
