### PR TITLE
Let poetry use default branch if none is specified

### DIFF
--- a/poetry/core/packages/vcs_dependency.py
+++ b/poetry/core/packages/vcs_dependency.py
@@ -34,8 +34,8 @@ class VCSDependency(Dependency):
         self._source = source
 
         if not any([branch, tag, rev]):
-            # If nothing has been specified, we assume master
-            branch = "master"
+            # If nothing has been specified, we assume nothing and use default branch
+            branch = ""
 
         self._branch = branch
         self._tag = tag
@@ -107,6 +107,12 @@ class VCSDependency(Dependency):
         if self.extras:
             requirement += "[{}]".format(",".join(self.extras))
 
+        if self.branch == "":
+            if parsed_url.protocol is not None:
+                requirement += " @ {}+{}".format(self._vcs, self._source)
+            else:
+                requirement += " @ {}+ssh://{}".format(self._vcs, parsed_url.format())
+            return requirement
         if parsed_url.protocol is not None:
             requirement += " @ {}+{}@{}".format(self._vcs, self._source, self.reference)
         else:

--- a/tests/masonry/builders/test_sdist.py
+++ b/tests/masonry/builders/test_sdist.py
@@ -55,7 +55,7 @@ def test_convert_dependencies():
         "A>=1.0,<2.0",
         "B>=1.0,<1.1",
         "C==1.2.3",
-        "D @ git+https://github.com/sdispater/d.git@master",
+        "D @ git+https://github.com/sdispater/d.git",
         "E>=1.0,<2.0",
         "F>=1.0,<2.0,!=1.3",
     ]

--- a/tests/packages/test_vcs_dependency.py
+++ b/tests/packages/test_vcs_dependency.py
@@ -8,7 +8,7 @@ def test_to_pep_508():
         "poetry", "git", "https://github.com/python-poetry/poetry.git"
     )
 
-    expected = "poetry @ git+https://github.com/python-poetry/poetry.git@master"
+    expected = "poetry @ git+https://github.com/python-poetry/poetry.git"
 
     assert expected == dependency.to_pep_508()
 
@@ -16,7 +16,7 @@ def test_to_pep_508():
 def test_to_pep_508_ssh():
     dependency = VCSDependency("poetry", "git", "git@github.com:sdispater/poetry.git")
 
-    expected = "poetry @ git+ssh://git@github.com/sdispater/poetry.git@master"
+    expected = "poetry @ git+ssh://git@github.com/sdispater/poetry.git"
 
     assert expected == dependency.to_pep_508()
 
@@ -26,7 +26,7 @@ def test_to_pep_508_with_extras():
         "poetry", "git", "https://github.com/python-poetry/poetry.git", extras=["foo"]
     )
 
-    expected = "poetry[foo] @ git+https://github.com/python-poetry/poetry.git@master"
+    expected = "poetry[foo] @ git+https://github.com/python-poetry/poetry.git"
 
     assert expected == dependency.to_pep_508()
 
@@ -37,7 +37,9 @@ def test_to_pep_508_in_extras():
     )
     dependency.in_extras.append("foo")
 
-    expected = 'poetry @ git+https://github.com/python-poetry/poetry.git@master ; extra == "foo"'
+    expected = (
+        'poetry @ git+https://github.com/python-poetry/poetry.git ; extra == "foo"'
+    )
     assert expected == dependency.to_pep_508()
 
     dependency = VCSDependency(
@@ -45,7 +47,9 @@ def test_to_pep_508_in_extras():
     )
     dependency.in_extras.append("foo")
 
-    expected = 'poetry[bar] @ git+https://github.com/python-poetry/poetry.git@master ; extra == "foo"'
+    expected = (
+        'poetry[bar] @ git+https://github.com/python-poetry/poetry.git ; extra == "foo"'
+    )
 
     assert expected == dependency.to_pep_508()
 


### PR DESCRIPTION
Resolves:  [python-poetry/poetry#3366](https://github.com/python-poetry/poetry/issues/3366).

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

Based on https://github.com/python-poetry/poetry-core/pull/117 + fixed the failing unit tests.

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

