### PR TITLE
schema: add support for source.links boolean

### DIFF
--- a/poetry/core/json/schemas/poetry-schema.json
+++ b/poetry/core/json/schemas/poetry-schema.json
@@ -559,6 +559,10 @@
                 "secondary": {
                     "type": "boolean",
                     "description": "Declare this repository as secondary, i.e. it will only be looked up last for packages."
+                },
+                "links": {
+                    "type": "boolean",
+                    "description": "Declare this as a link source. Links at uri/path can point to sdist or bdist archives."
                 }
             }
         },


### PR DESCRIPTION
Thsi change is required to add support for archive link source urls as project sources. This will enable the use of scenarios currently facilitated in `pip` by the use of `--find-links` flag.