### PR TITLE
fix(packages/dependency): add space after filename for file dependencies with markers

### DIFF
--- a/poetry/core/packages/dependency.py
+++ b/poetry/core/packages/dependency.py
@@ -262,7 +262,7 @@ class Dependency(PackageSpecification):
             )
 
         if markers:
-            if self.is_vcs() or self.is_url():
+            if self.is_vcs() or self.is_url() or self.is_file():
                 requirement += " "
 
             if len(markers) > 1:

--- a/tests/packages/test_file_dependency.py
+++ b/tests/packages/test_file_dependency.py
@@ -67,7 +67,7 @@ def test_file_dependency_pep_508_local_file_relative_path(mocker):
     _test_file_dependency_pep_508(mocker, "demo", path, requirement)
 
 
-def test_to_pep_508_with_marker(mocker):
+def test_absolute_file_dependency_to_pep_508_with_marker(mocker):
     wheel = "demo-0.1.0-py2.py3-none-any.whl"
 
     abs_path = DIST_PATH / wheel
@@ -81,6 +81,10 @@ def test_to_pep_508_with_marker(mocker):
         requirement,
         marker=SingleMarker("sys.platform", "linux"),
     )
+
+
+def test_relative_file_dependency_to_pep_508_with_marker(mocker):
+    wheel = "demo-0.1.0-py2.py3-none-any.whl"
 
     rel_path = Path("..") / "fixtures" / "distributions" / wheel
     requirement = '{} @ {} ; sys_platform == "linux"'.format(

--- a/tests/packages/test_file_dependency.py
+++ b/tests/packages/test_file_dependency.py
@@ -4,6 +4,7 @@ import pytest
 
 from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.file_dependency import FileDependency
+from poetry.core.version.markers import SingleMarker
 
 
 DIST_PATH = Path(__file__).parent.parent / "fixtures" / "distributions"
@@ -20,7 +21,7 @@ def test_file_dependency_dir():
 
 
 def _test_file_dependency_pep_508(
-    mocker, name, path, pep_508_input, pep_508_output=None
+    mocker, name, path, pep_508_input, pep_508_output=None, marker=None
 ):
     mocker.patch.object(Path, "exists").return_value = True
     mocker.patch.object(Path, "is_file").return_value = True
@@ -28,6 +29,8 @@ def _test_file_dependency_pep_508(
     dep = Dependency.create_from_pep_508(
         pep_508_input, relative_to=Path(__file__).parent
     )
+    if marker:
+        dep.marker = marker
 
     assert dep.is_file()
     assert dep.name == name
@@ -62,3 +65,31 @@ def test_file_dependency_pep_508_local_file_relative_path(mocker):
 
     requirement = "{} @ {}".format("demo", path)
     _test_file_dependency_pep_508(mocker, "demo", path, requirement)
+
+
+def test_to_pep_508_with_marker(mocker):
+    wheel = "demo-0.1.0-py2.py3-none-any.whl"
+
+    abs_path = DIST_PATH / wheel
+    requirement = '{} @ file://{} ; sys_platform == "linux"'.format(
+        "demo", abs_path.as_posix()
+    )
+    _test_file_dependency_pep_508(
+        mocker,
+        "demo",
+        abs_path,
+        requirement,
+        marker=SingleMarker("sys.platform", "linux"),
+    )
+
+    rel_path = Path("..") / "fixtures" / "distributions" / wheel
+    requirement = '{} @ {} ; sys_platform == "linux"'.format(
+        "demo", rel_path.as_posix()
+    )
+    _test_file_dependency_pep_508(
+        mocker,
+        "demo",
+        rel_path,
+        requirement,
+        marker=SingleMarker("sys.platform", "linux"),
+    )


### PR DESCRIPTION
Resolves: https://github.com/python-poetry/poetry/issues/3872

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.


local vendored files need a space after the file name and before the ";" which demarks the start of
markers




