### PR TITLE
Resolve invalid python version constraint

### DIFF
--- a/poetry/core/packages/dependency.py
+++ b/poetry/core/packages/dependency.py
@@ -276,6 +276,7 @@ class Dependency(PackageSpecification):
     def _create_nested_marker(
         self, name: str, constraint: Union["BaseConstraint", "VersionTypes"]
     ) -> str:
+        from poetry.core.semver.empty_constraint import EmptyConstraint
         from poetry.core.semver.version import Version
         from poetry.core.semver.version_union import VersionUnion
 
@@ -318,6 +319,8 @@ class Dependency(PackageSpecification):
                 name = "python_full_version"
 
             marker = '{} == "{}"'.format(name, constraint.text)
+        elif isinstance(constraint, EmptyConstraint):
+            marker = ""
         else:
             if constraint.min is not None:
                 min_name = name

--- a/tests/packages/test_main.py
+++ b/tests/packages/test_main.py
@@ -272,3 +272,12 @@ def test_dependency_from_pep_508_should_not_produce_empty_constraints_for_correc
         str(dep.marker)
         == 'platform_python_implementation != "PyPy" and python_version <= "3.10" and python_version > "3"'
     )
+
+
+def test_dependency_from_pep_508_with_invalid_python_version_constraint():
+    name = 'some-dependency ; python_version >= "3.6" and python_version <= "3.4"'
+    dep = Dependency.create_from_pep_508(name)
+
+    assert dep.name == "some-dependency"
+    assert str(dep.constraint) == "*"
+    assert dep.python_versions == "*"


### PR DESCRIPTION
Resolves: python-poetry#<!-- add issue number/link here -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

~~[`backports.functools_lru_cache`](https://github.com/jaraco/backports.functools_lru_cache) has following dependency in `setup.cfg` (https://github.com/jaraco/backports.functools_lru_cache/blob/74120920aa77047323b7ca25533f57bdae4ead1c/setup.cfg#L48):~~

```
	pytest-mypy; python_implementation != "PyPy" and python_version < "3.10" and python_version > "3"
```

~~It has a python version constraint of `<3.10 >3` and it seems invalid. And it breaks poetry. Related issue: https://github.com/python-poetry/poetry/issues/534~~

The constraint mentioned above was not actually invalid. That case was resolved in #155.

This PR makes poetry can resolve dependencies with the broken constraints, such as `python_version >= "3.6" and python_version <= "3.4"`