### PR TITLE
Fix an error when handling single digit Python markers

### DIFF
--- a/poetry/core/packages/dependency.py
+++ b/poetry/core/packages/dependency.py
@@ -409,7 +409,6 @@ class Dependency(PackageSpecification):
         path is specified, this is used as the base directory if the identified dependency is
         of file or directory type.
         """
-        from poetry.core.semver.version import Version
         from poetry.core.utils.patterns import wheel_file_re
         from poetry.core.vcs.git import ParsedUrl
         from poetry.core.version.requirements import Requirement
@@ -546,22 +545,6 @@ class Dependency(PackageSpecification):
                         op = ""
                     elif op == "!=":
                         version += ".*"
-                    elif op in ("<=", ">"):
-                        parsed_version = Version.parse(version)
-                        if parsed_version.precision == 1:
-                            if op == "<=":
-                                op = "<"
-                                version = parsed_version.next_major().text
-                            elif op == ">":
-                                op = ">="
-                                version = parsed_version.next_major().text
-                        elif parsed_version.precision == 2:
-                            if op == "<=":
-                                op = "<"
-                                version = parsed_version.next_minor().text
-                            elif op == ">":
-                                op = ">="
-                                version = parsed_version.next_minor().text
                     elif op in ("in", "not in"):
                         versions = []
                         for v in re.split("[ ,]+", version):

--- a/tests/packages/test_main.py
+++ b/tests/packages/test_main.py
@@ -1,4 +1,5 @@
 from poetry.core.packages.dependency import Dependency
+from poetry.core.semver.version import Version
 
 
 def test_dependency_from_pep_508():
@@ -254,3 +255,20 @@ def test_dependency_from_pep_508_with_python_full_version_pep440_compatible_rele
     assert dep.name == "pathlib2"
     assert str(dep.constraint) == "*"
     assert dep.python_versions == "~=3.4 || <3"
+
+
+def test_dependency_from_pep_508_should_not_produce_empty_constraints_for_correct_markers():
+    name = 'pytest-mypy; python_implementation != "PyPy" and python_version <= "3.10" and python_version > "3"'
+    dep = Dependency.create_from_pep_508(name)
+
+    assert dep.name == "pytest-mypy"
+    assert str(dep.constraint) == "*"
+    assert dep.python_versions == "<=3.10 >3"
+    assert dep.python_constraint.allows(Version.parse("3.6"))
+    assert dep.python_constraint.allows(Version.parse("3.10"))
+    assert not dep.python_constraint.allows(Version.parse("3"))
+    assert dep.python_constraint.allows(Version.parse("3.0.1"))
+    assert (
+        str(dep.marker)
+        == 'platform_python_implementation != "PyPy" and python_version <= "3.10" and python_version > "3"'
+    )


### PR DESCRIPTION
Resolves: python-poetry/poetry#3862

Supersedes #154 

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.


The code responsible for this error (introduced 2 years ago https://github.com/python-poetry/poetry/commit/46ad807209b97aaf88fe17fa90b227cb7a398a5f) just needed to be removed.

This code was here to translate PEP 508 markers conditions to Poetry's internal comparison system. However, it seems that `packaging` interprets `>3` as `>3.0.0` just like Poetry does so it seems that this is no longer needed.