### PR TITLE
pep440: support upper bound post/local release comparisons

### DIFF
--- a/poetry/core/semver/version_range.py
+++ b/poetry/core/semver/version_range.py
@@ -74,10 +74,20 @@ class VersionRange(VersionRangeConstraint):
                 return False
 
         if self.full_max is not None:
-            if other > self.full_max:
+            _this, _other = self.full_max, other
+
+            if not _this.is_local() and _other.is_local():
+                # allow weak equality to allow `3.0.0+local.1` for `<=3.0.0`
+                _other = _other.without_local()
+
+            if not _this.is_postrelease() and _other.is_postrelease():
+                # allow weak equality to allow `3.0.0-1` for `<=3.0.0`
+                _other = _other.without_postrelease()
+
+            if _other > _this:
                 return False
 
-            if not self._include_max and other == self.full_max:
+            if not self._include_max and _other == _this:
                 return False
 
         return True

--- a/poetry/core/version/pep440/version.py
+++ b/poetry/core/version/pep440/version.py
@@ -140,6 +140,9 @@ class PEP440Version:
     def is_devrelease(self) -> bool:
         return self.dev is not None
 
+    def is_local(self) -> bool:
+        return self.local is not None
+
     def is_no_suffix_release(self) -> bool:
         return not (self.pre or self.post or self.dev)
 
@@ -203,3 +206,21 @@ class PEP440Version:
         return self.__class__(
             epoch=self.epoch, release=self.release, pre=ReleaseTag(RELEASE_PHASE_ALPHA)
         )
+
+    def replace(self, **kwargs):
+        return self.__class__(
+            **{
+                **{
+                    k: getattr(self, k)
+                    for k in self.__dataclass_fields__.keys()
+                    if k not in ("_compare_key", "text")
+                },  # setup defaults with current values, excluding compare keys and text
+                **kwargs,  # keys to replace
+            }
+        )
+
+    def without_local(self) -> "PEP440Version":
+        return self.replace(local=None)
+
+    def without_postrelease(self) -> "PEP440Version":
+        return self.replace(post=None)

--- a/poetry/core/version/pep440/version.py
+++ b/poetry/core/version/pep440/version.py
@@ -36,6 +36,9 @@ class PEP440Version:
         if self.local is not None and not isinstance(self.local, tuple):
             object.__setattr__(self, "local", (self.local,))
 
+        if isinstance(self.release, tuple):
+            object.__setattr__(self, "release", Release(*self.release))
+
         # we do this here to handle both None and tomlkit string values
         object.__setattr__(
             self, "text", self.to_string() if not self.text else str(self.text)

--- a/tests/version/test_version_pep440.py
+++ b/tests/version/test_version_pep440.py
@@ -1,0 +1,164 @@
+import pytest
+
+from poetry.core.version.exceptions import InvalidVersion
+from poetry.core.version.pep440 import PEP440Version
+from poetry.core.version.pep440 import Release
+from poetry.core.version.pep440 import ReleaseTag
+from poetry.core.version.pep440.segments import RELEASE_PHASES
+from poetry.core.version.pep440.segments import RELEASE_PHASES_SHORT
+
+
+@pytest.mark.parametrize(
+    "parts,result",
+    [
+        ((1,), Release(1)),
+        ((1, 2), Release(1, 2)),
+        ((1, 2, 3), Release(1, 2, 3)),
+        ((1, 2, 3, 4), Release(1, 2, 3, 4)),
+        ((1, 2, 3, 4, 5, 6), Release(1, 2, 3, (4, 5, 6))),
+    ],
+)
+def test_pep440_release_segment_from_parts(parts, result):
+    assert Release.from_parts(*parts) == result
+
+
+@pytest.mark.parametrize(
+    "parts,result",
+    [
+        (("a",), ReleaseTag("alpha", 0)),
+        (("a", 1), ReleaseTag("alpha", 1)),
+        (("b",), ReleaseTag("beta", 0)),
+        (("b", 1), ReleaseTag("beta", 1)),
+        (("pre",), ReleaseTag("preview", 0)),
+        (("pre", 1), ReleaseTag("preview", 1)),
+        (("c",), ReleaseTag("rc", 0)),
+        (("c", 1), ReleaseTag("rc", 1)),
+        (("r",), ReleaseTag("rev", 0)),
+        (("r", 1), ReleaseTag("rev", 1)),
+    ],
+)
+def test_pep440_release_tag_normalisation(parts, result):
+    tag = ReleaseTag(*parts)
+    assert tag == result
+    assert tag.to_string() == result.to_string()
+    assert tag.to_string(short=True) == result.to_string(short=True)
+
+
+@pytest.mark.parametrize(
+    "parts,result",
+    [
+        (("a",), ReleaseTag("beta")),
+        (("b",), ReleaseTag("rc")),
+        (("post",), None),
+        (("rc",), None),
+        (("rev",), None),
+        (("dev",), None),
+    ],
+)
+def test_pep440_release_tag_next_phase(parts, result):
+    assert ReleaseTag(*parts).next_phase() == result
+
+
+@pytest.mark.parametrize(
+    "phase", list({*RELEASE_PHASES.keys(), *RELEASE_PHASES_SHORT.keys()})
+)
+def test_pep440_release_tag_next(phase):
+    tag = ReleaseTag(phase=phase).next()
+    assert tag.phase == ReleaseTag.expand(phase)
+    assert tag.number == 1
+
+
+@pytest.mark.parametrize(
+    "text,result",
+    [
+        ("1", PEP440Version(release=Release.from_parts(1))),
+        ("1.2.3", PEP440Version(release=Release.from_parts(1, 2, 3))),
+        (
+            "1.2.3-1",
+            PEP440Version(
+                release=Release.from_parts(1, 2, 3), post=ReleaseTag("post", 1)
+            ),
+        ),
+        (
+            "1.2.3.dev1",
+            PEP440Version(
+                release=Release.from_parts(1, 2, 3), dev=ReleaseTag("dev", 1)
+            ),
+        ),
+        (
+            "1.2.3-1.dev1",
+            PEP440Version(
+                release=Release.from_parts(1, 2, 3),
+                post=ReleaseTag("post", 1),
+                dev=ReleaseTag("dev", 1),
+            ),
+        ),
+        (
+            "1.2.3+local",
+            PEP440Version(release=Release.from_parts(1, 2, 3), local="local"),
+        ),
+        (
+            "1.2.3+local.1",
+            PEP440Version(release=Release.from_parts(1, 2, 3), local=("local", 1)),
+        ),
+        (
+            "1.2.3+local1",
+            PEP440Version(release=Release.from_parts(1, 2, 3), local="local1"),
+        ),
+        ("1.2.3+1", PEP440Version(release=Release.from_parts(1, 2, 3), local=1)),
+        (
+            "1.2.3a1",
+            PEP440Version(
+                release=Release.from_parts(1, 2, 3), pre=ReleaseTag("alpha", 1)
+            ),
+        ),
+        (
+            "1.2.3.a1",
+            PEP440Version(
+                release=Release.from_parts(1, 2, 3), pre=ReleaseTag("alpha", 1)
+            ),
+        ),
+        (
+            "1.2.3alpha1",
+            PEP440Version(
+                release=Release.from_parts(1, 2, 3), pre=ReleaseTag("alpha", 1)
+            ),
+        ),
+        (
+            "1.2.3b1",
+            PEP440Version(
+                release=Release.from_parts(1, 2, 3), pre=ReleaseTag("beta", 1)
+            ),
+        ),
+        (
+            "1.2.3.b1",
+            PEP440Version(
+                release=Release.from_parts(1, 2, 3), pre=ReleaseTag("beta", 1)
+            ),
+        ),
+        (
+            "1.2.3beta1",
+            PEP440Version(
+                release=Release.from_parts(1, 2, 3), pre=ReleaseTag("beta", 1)
+            ),
+        ),
+        (
+            "1.2.3rc1",
+            PEP440Version(release=Release.from_parts(1, 2, 3), pre=ReleaseTag("rc", 1)),
+        ),
+        (
+            "1.2.3.rc1",
+            PEP440Version(release=Release.from_parts(1, 2, 3), pre=ReleaseTag("rc", 1)),
+        ),
+    ],
+)
+def test_pep440_parse_text(text, result):
+    assert PEP440Version.parse(text) == result
+
+
+@pytest.mark.parametrize(
+    "text", ["1.2.3.dev1-1" "example-1" "1.2.3-random1" "1.2.3-1-1"]
+)
+def test_pep440_parse_text_invalid_versions(text):
+    with pytest.raises(InvalidVersion):
+        assert PEP440Version.parse(text)


### PR DESCRIPTION
This change ensures that post and local releases are taken into 
consideration when checking if version range allows a post release 
local build release at upper and lower bounds.

The following conditions now hold for upper bound checks.

- `<=3.0.0` allows `3.0.0+local.1`, `3.0.0-1`
- `<=3.0.0+local.1` disallows `3.0.0+local.2`, allows `3.0.0-1` 
- `<=3.0.0-1` allows `3.0.0+local.1`, `3.0.0`

Lower bound checks require no modification and works due to the 
implicit version comparison of `poetry.core.pep440.PEP440Version`.

Note: Majority of the changes here are test coverage.