### PR TITLE
pep440: support post/local for semver allows

### DIFF
--- a/tests/semver/test_version.py
+++ b/tests/semver/test_version.py
@@ -113,7 +113,29 @@ def test_allows():
     assert not v.allows(Version.parse("1.3.3"))
     assert not v.allows(Version.parse("1.2.4"))
     assert not v.allows(Version.parse("1.2.3-dev"))
-    assert not v.allows(Version.parse("1.2.3+build"))
+    assert v.allows(Version.parse("1.2.3+build"))
+    assert v.allows(Version.parse("1.2.3-1"))
+    assert v.allows(Version.parse("1.2.3-1+build"))
+
+
+def test_allows_with_local():
+    v = Version.parse("1.2.3+build.1")
+    assert v.allows(v)
+    assert not v.allows(Version.parse("1.3.3"))
+    assert not v.allows(Version.parse("1.2.3-dev"))
+    assert not v.allows(Version.parse("1.2.3+build.2"))
+    assert v.allows(Version.parse("1.2.3-1"))
+    assert v.allows(Version.parse("1.2.3-1+build.1"))
+
+
+def test_allows_with_post():
+    v = Version.parse("1.2.3-1")
+    assert v.allows(v)
+    assert not v.allows(Version.parse("1.2.3"))
+    assert not v.allows(Version.parse("2.2.3"))
+    assert not v.allows(Version.parse("1.2.3-dev"))
+    assert not v.allows(Version.parse("1.2.3+build.2"))
+    assert v.allows(Version.parse("1.2.3-1+build.1"))
 
 
 def test_allows_all():


### PR DESCRIPTION
This change ensures that post and local releases are taken into
consideration when checking if semver version instance allows
post and local build releases.

The following conditions now hold `poetry.core.semver.Version.allows`.

- `3.0.0` allows `3.0.0+local.1`, `3.0.0-1`
- `3.0.0+local.1` disallows `3.0.0+local.2`, allows `3.0.0-1`
- `3.0.0-1` disallows `3.0.0`, `3.0.0+local.1`, allows `3.0.0-1+local.1`

This is a follow up from #157 .

Note this does not change equality check behaviour.