### PR TITLE
Fix dependency markers not being copied in with_constraint()

### DIFF
--- a/poetry/core/packages/dependency.py
+++ b/poetry/core/packages/dependency.py
@@ -394,6 +394,9 @@ class Dependency(PackageSpecification):
 
         new.is_root = self.is_root
         new.python_versions = self.python_versions
+        new.transitive_python_versions = self.transitive_python_versions
+        new.marker = self.marker
+        new.transitive_marker = self.transitive_marker
 
         for in_extra in self.in_extras:
             new.in_extras.append(in_extra)

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -2,6 +2,7 @@ import pytest
 
 from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.package import Package
+from poetry.core.version.markers import parse_marker
 
 
 def test_accepts():
@@ -225,3 +226,35 @@ def test_complete_name():
 def test_dependency_string_representation(name, constraint, extras, expected):
     dependency = Dependency(name=name, constraint=constraint, extras=extras)
     assert str(dependency) == expected
+
+
+def test_with_constraint():
+    dependency = Dependency(
+        "foo",
+        "^1.2.3",
+        optional=True,
+        category="dev",
+        allows_prereleases=True,
+        extras=["bar", "baz"],
+    )
+    dependency.marker = parse_marker(
+        'python_version >= "3.6" and python_version < "4.0"'
+    )
+    dependency.transitive_marker = parse_marker(
+        'python_version >= "3.7" and python_version < "4.0"'
+    )
+    dependency.python_versions = "^3.6"
+    dependency.transitive_python_versions = "^3.7"
+
+    new = dependency.with_constraint("^1.2.6")
+
+    assert new.name == dependency.name
+    assert str(new.constraint) == ">=1.2.6,<2.0.0"
+    assert new.is_optional()
+    assert new.category == "dev"
+    assert new.allows_prereleases()
+    assert set(new.extras) == {"bar", "baz"}
+    assert new.marker == dependency.marker
+    assert new.transitive_marker == dependency.transitive_marker
+    assert new.python_constraint == dependency.python_constraint
+    assert new.transitive_python_constraint == dependency.transitive_python_constraint


### PR DESCRIPTION
The dependency markers were not copied when using `Dependency.with_constraint()` causing resolution issues like in python-poetry/poetry#3878

Resolves: python-poetry/poetry#3878

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
