### PR TITLE
[1.0] Fix dependency markers not being copied in with_constraint()

### DIFF
--- a/poetry/core/packages/dependency.py
+++ b/poetry/core/packages/dependency.py
@@ -382,6 +382,9 @@ class Dependency(PackageSpecification):
 
         new.is_root = self.is_root
         new.python_versions = self.python_versions
+        new.transitive_python_versions = self.transitive_python_versions
+        new.marker = self.marker
+        new.transitive_marker = self.transitive_marker
 
         for in_extra in self.in_extras:
             new.in_extras.append(in_extra)


### PR DESCRIPTION
Backport of #162 to the `1.0` branch.

Resolves: python-poetry/poetry#3878

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
