### PR TITLE
Release 1.1.0a3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [1.1.0a3] - 2021-04-09
+
+### Fixed
+
+- Fixed dependency markers not being properly copied when changing the constraint ([#162](https://github.com/python-poetry/poetry-core/pull/162)).
+
+
 ## [1.1.0a2] - 2021-04-08
 
 ### Fixed
@@ -173,7 +180,8 @@ No changes.
 - Fixed support for stub-only packages ([#28](https://github.com/python-poetry/core/pull/28)).
 
 
-[Unreleased]: https://github.com/python-poetry/poetry-core/compare/1.1.0a2...master
+[Unreleased]: https://github.com/python-poetry/poetry-core/compare/1.1.0a3...master
+[1.1.0a3]: https://github.com/python-poetry/poetry-core/releases/tag/1.1.0a3
 [1.1.0a2]: https://github.com/python-poetry/poetry-core/releases/tag/1.1.0a2
 [1.1.0a1]: https://github.com/python-poetry/poetry-core/releases/tag/1.1.0a1
 [1.0.2]: https://github.com/python-poetry/poetry-core/releases/tag/1.0.2

--- a/poetry/core/__init__.py
+++ b/poetry/core/__init__.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 
 
-__version__ = "1.1.0a2"
+__version__ = "1.1.0a3"
 
 __vendor_site__ = (Path(__file__).parent / "_vendor").as_posix()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-core"
-version = "1.1.0a2"
+version = "1.1.0a3"
 description = "Poetry PEP 517 Build Backend"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 


### PR DESCRIPTION
### Fixed

- Fixed dependency markers not being properly copied when changing the constraint ([#162](https://github.com/python-poetry/poetry-core/pull/162)).

