### PR TITLE
Keep leading zeros in version labels. Resolves: python-poetry#3705.

### DIFF
--- a/poetry/core/version/pep440/parser.py
+++ b/poetry/core/version/pep440/parser.py
@@ -56,7 +56,7 @@ class PEP440Parser:
             return None
 
         return tuple(
-            part.lower() if not part.isdigit() else int(part)
+            part.lower() if not part.isdigit() or part.startswith("0") else int(part)
             for part in cls._local_version_separators.split(match.group("local"))
         )
 

--- a/poetry/core/version/pep440/parser.py
+++ b/poetry/core/version/pep440/parser.py
@@ -56,7 +56,7 @@ class PEP440Parser:
             return None
 
         return tuple(
-            part.lower() if not part.isdigit() or part.startswith("0") else int(part)
+            part.lower()
             for part in cls._local_version_separators.split(match.group("local"))
         )
 

--- a/poetry/core/version/pep440/version.py
+++ b/poetry/core/version/pep440/version.py
@@ -82,7 +82,7 @@ class PEP440Version:
             #   match exactly
             _local = tuple(
                 # We typecast strings that are integers so that they can be compared
-                (int(i), "") if isinstance(i, int) or i.isdigit() else (-math.inf, i)
+                (int(i), "") if str(i).isnumeric() else (-math.inf, i)
                 for i in self.local
             )
         return self.epoch, self.release, _pre, _post, _dev, _local

--- a/poetry/core/version/pep440/version.py
+++ b/poetry/core/version/pep440/version.py
@@ -81,7 +81,9 @@ class PEP440Version:
             # - Shorter versions sort before longer versions when the prefixes
             #   match exactly
             _local = tuple(
-                (i, "") if isinstance(i, int) else (-math.inf, i) for i in self.local
+                # We typecast strings that are integers so that they can be compared
+                (int(i), "") if isinstance(i, int) or i.isdigit() else (-math.inf, i)
+                for i in self.local
             )
         return self.epoch, self.release, _pre, _post, _dev, _local
 

--- a/tests/version/test_version_pep440.py
+++ b/tests/version/test_version_pep440.py
@@ -150,6 +150,14 @@ def test_pep440_release_tag_next(phase):
             "1.2.3.rc1",
             PEP440Version(release=Release.from_parts(1, 2, 3), pre=ReleaseTag("rc", 1)),
         ),
+        (
+            "2.2.0dev0+build.05669607",
+            PEP440Version(
+                release=Release.from_parts(2, 2, 0),
+                dev=ReleaseTag("dev", 0),
+                local=("build", "05669607"),
+            ),
+        ),
     ],
 )
 def test_pep440_parse_text(text, result):


### PR DESCRIPTION
Resolves: [python-poetry#3705](https://github.com/python-poetry/poetry/issues/3705)

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.

This PR ensures that leading zeros are kept in labels (for cases when the short git commit is used).
