### PR TITLE
Fix caret constraint parsing

### DIFF
--- a/poetry/core/semver/version.py
+++ b/poetry/core/semver/version.py
@@ -48,7 +48,7 @@ class Version(PEP440Version, VersionRangeConstraint):
 
             return self.next_patch()
 
-        return self.next_major()
+        return self.stable.next_major()
 
     def first_pre_release(self) -> "Version":
         return self.__class__(release=self.release, pre=ReleaseTag("alpha"))

--- a/tests/semver/test_parse_constraint.py
+++ b/tests/semver/test_parse_constraint.py
@@ -4,6 +4,7 @@ from poetry.core.semver.helpers import parse_constraint
 from poetry.core.semver.version import Version
 from poetry.core.semver.version_range import VersionRange
 from poetry.core.semver.version_union import VersionUnion
+from poetry.core.version.pep440 import ReleaseTag
 
 
 @pytest.mark.parametrize(
@@ -169,6 +170,22 @@ from poetry.core.semver.version_union import VersionUnion
                     max=Version.from_parts(3, 9),
                     include_min=True,
                 ),
+            ),
+        ),
+        (
+            "^1.0.0a1",
+            VersionRange(
+                min=Version.from_parts(1, 0, 0, pre=ReleaseTag("a", 1)),
+                max=Version.from_parts(2, 0, 0),
+                include_min=True,
+            ),
+        ),
+        (
+            "~1.0.0a1",
+            VersionRange(
+                min=Version.from_parts(1, 0, 0, pre=ReleaseTag("a", 1)),
+                max=Version.from_parts(1, 1, 0),
+                include_min=True,
             ),
         ),
     ],


### PR DESCRIPTION
This PR fixes how caret constraints are parsed when the lower bound is a prerelease.

Basically, a constraint like `^1.0.0a3` was converted to `>=1.0.0a3,<1.0.0` which cannot be satisfied.

The issue was coming from the `Version.next_breaking()` method which did not take the stable release as a starting point.

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

