### PR TITLE
Fix the way python markers with a precision >= 3 are handled

### DIFF
--- a/poetry/core/packages/utils/utils.py
+++ b/poetry/core/packages/utils/utils.py
@@ -247,6 +247,9 @@ def create_nested_marker(
 
         marker = glue.join(parts)
     elif isinstance(constraint, Version):
+        if name == "python_version" and constraint.precision >= 3:
+            name = "python_full_version"
+
         marker = '{} == "{}"'.format(name, constraint.text)
     else:
         if constraint.min is not None:
@@ -254,9 +257,16 @@ def create_nested_marker(
             if not constraint.include_min:
                 op = ">"
 
-            version = constraint.min.text
+            version = constraint.min
             if constraint.max is not None:
-                text = '{} {} "{}"'.format(name, op, version)
+                min_name = max_name = name
+                if min_name == "python_version" and constraint.min.precision >= 3:
+                    min_name = "python_full_version"
+
+                if max_name == "python_version" and constraint.max.precision >= 3:
+                    max_name = "python_full_version"
+
+                text = '{} {} "{}"'.format(min_name, op, version)
 
                 op = "<="
                 if not constraint.include_max:
@@ -264,7 +274,7 @@ def create_nested_marker(
 
                 version = constraint.max
 
-                text += ' and {} {} "{}"'.format(name, op, version)
+                text += ' and {} {} "{}"'.format(max_name, op, version)
 
                 return text
         elif constraint.max is not None:
@@ -275,6 +285,9 @@ def create_nested_marker(
             version = constraint.max
         else:
             return ""
+
+        if name == "python_version" and version.precision >= 3:
+            name = "python_full_version"
 
         marker = '{} {} "{}"'.format(name, op, version)
 

--- a/tests/fixtures/sample_project/pyproject.toml
+++ b/tests/fixtures/sample_project/pyproject.toml
@@ -43,6 +43,9 @@ simple-project = { path = "../simple_project/" }
 # Dependency with markers
 functools32 = { version = "^3.2.3", markers = "python_version ~= '2.7' and sys_platform == 'win32' or python_version in '3.4 3.5'" }
 
+# Dependency with python constraint
+dataclasses = {version = "^0.7", python = ">=3.6.1,<3.7"}
+
 
 [tool.poetry.extras]
 db = [ "orator" ]

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -99,6 +99,15 @@ def test_create_poetry():
         == 'python_version ~= "2.7" and sys_platform == "win32" or python_version in "3.4 3.5"'
     )
 
+    dataclasses = dependencies["dataclasses"]
+    assert dataclasses.name == "dataclasses"
+    assert dataclasses.pretty_constraint == "^0.7"
+    assert dataclasses.python_versions == ">=3.6.1,<3.7"
+    assert (
+        str(dataclasses.marker)
+        == 'python_full_version >= "3.6.1" and python_version < "3.7"'
+    )
+
     assert "db" in package.extras
 
     classifiers = package.classifiers


### PR DESCRIPTION
This PR ensures that python version related markers are correct by changing them is necessary if the constraint has a precision of 3 or more.

Resolves: python-poetry/poetry#3347

- [x] Added **tests** for changed code.
- [ ] ~Updated **documentation** for changed code.~
