### PR TITLE
Add support for dependency groups

### DIFF
--- a/poetry/core/json/schemas/poetry-schema.json
+++ b/poetry/core/json/schemas/poetry-schema.json
@@ -147,6 +147,32 @@
         }
       }
     },
+    "group": {
+      "type": "object",
+      "description": "This represents groups of dependencies",
+      "patternProperties": {
+        "^[a-zA-Z-_.0-9]+$": {
+          "type": "object",
+          "description": "This represents a single dependency group",
+          "required": [
+            "dependencies"
+          ],
+          "properties": {
+            "optional": {
+              "type": "boolean",
+              "description": "Whether the dependency group is optional or not"
+            },
+            "dependencies": {
+              "type": "object",
+              "description": "The dependencies of this dependency group",
+              "$ref": "#/definitions/dependencies",
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
     "build": {
       "$ref": "#/definitions/build-section"
     },

--- a/poetry/core/masonry/api.py
+++ b/poetry/core/masonry/api.py
@@ -39,7 +39,7 @@ get_requires_for_build_sdist = get_requires_for_build_wheel
 def prepare_metadata_for_build_wheel(
     metadata_directory: str, config_settings: Optional[Dict[str, Any]] = None
 ) -> str:
-    poetry = Factory().create_poetry(Path(".").resolve(), with_dev=False)
+    poetry = Factory().create_poetry(Path(".").resolve(), with_groups=False)
     builder = WheelBuilder(poetry)
 
     dist_info = Path(metadata_directory, builder.dist_info)
@@ -64,7 +64,7 @@ def build_wheel(
     metadata_directory: Optional[str] = None,
 ) -> str:
     """Builds a wheel, places it in wheel_directory"""
-    poetry = Factory().create_poetry(Path(".").resolve(), with_dev=False)
+    poetry = Factory().create_poetry(Path(".").resolve(), with_groups=False)
 
     return WheelBuilder.make_in(poetry, Path(wheel_directory))
 
@@ -73,7 +73,7 @@ def build_sdist(
     sdist_directory: str, config_settings: Optional[Dict[str, Any]] = None
 ) -> str:
     """Builds an sdist, places it in sdist_directory"""
-    poetry = Factory().create_poetry(Path(".").resolve(), with_dev=False)
+    poetry = Factory().create_poetry(Path(".").resolve(), with_groups=False)
 
     path = SdistBuilder(poetry).build(Path(sdist_directory))
 

--- a/poetry/core/packages/dependency.py
+++ b/poetry/core/packages/dependency.py
@@ -34,7 +34,7 @@ class Dependency(PackageSpecification):
         name: str,
         constraint: Union[str, "VersionTypes"],
         optional: bool = False,
-        category: str = "main",
+        groups: Optional[List[str]] = None,
         allows_prereleases: bool = False,
         extras: Union[List[str], FrozenSet[str]] = None,
         source_type: Optional[str] = None,
@@ -58,7 +58,11 @@ class Dependency(PackageSpecification):
 
         self._pretty_constraint = str(constraint)
         self._optional = optional
-        self._category = category
+
+        if not groups:
+            groups = ["default"]
+
+        self._groups = frozenset(groups)
 
         if (
             isinstance(self._constraint, VersionRangeConstraint)
@@ -113,8 +117,8 @@ class Dependency(PackageSpecification):
         return self._pretty_name
 
     @property
-    def category(self) -> str:
-        return self._category
+    def groups(self) -> FrozenSet[str]:
+        return self._groups
 
     @property
     def python_versions(self) -> str:
@@ -387,7 +391,7 @@ class Dependency(PackageSpecification):
             self.pretty_name,
             constraint,
             optional=self.is_optional(),
-            category=self.category,
+            groups=list(self._groups),
             allows_prereleases=self.allows_prereleases(),
             extras=self._extras,
             source_type=self._source_type,

--- a/poetry/core/packages/dependency_group.py
+++ b/poetry/core/packages/dependency_group.py
@@ -1,0 +1,54 @@
+from typing import TYPE_CHECKING
+from typing import List
+
+
+if TYPE_CHECKING:
+    from .types import DependencyTypes
+
+
+class DependencyGroup:
+    def __init__(self, name: str, optional: bool = False) -> None:
+        self._name: str = name
+        self._optional: bool = optional
+        self._dependencies: List["DependencyTypes"] = []
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def dependencies(self) -> List["DependencyTypes"]:
+        return self._dependencies
+
+    def is_optional(self) -> bool:
+        return self._optional
+
+    def add_dependency(self, dependency: "DependencyTypes") -> None:
+        self._dependencies.append(dependency)
+
+    def remove_dependency(self, name: "str") -> None:
+        from poetry.core.utils.helpers import canonicalize_name
+
+        name = canonicalize_name(name)
+
+        dependencies = []
+        for dependency in dependencies:
+            if dependency.name == name:
+                continue
+
+            dependencies.append(dependency)
+
+        self._dependencies = dependencies
+
+    def __eq__(self, other: "DependencyGroup") -> bool:
+        if not isinstance(other, DependencyGroup):
+            return NotImplemented
+
+        return self._name == other.name and set(self._dependencies) == set(
+            other.dependencies
+        )
+
+    def __repr__(self) -> str:
+        return "{}({}, optional={})".format(
+            self.__class__.__name__, self._name, self._optional
+        )

--- a/poetry/core/packages/directory_dependency.py
+++ b/poetry/core/packages/directory_dependency.py
@@ -18,7 +18,7 @@ class DirectoryDependency(Dependency):
         self,
         name: str,
         path: Path,
-        category: str = "main",
+        groups: Optional[List[str]] = None,
         optional: bool = False,
         base: Optional[Path] = None,
         develop: bool = False,
@@ -61,7 +61,7 @@ class DirectoryDependency(Dependency):
         super(DirectoryDependency, self).__init__(
             name,
             "*",
-            category=category,
+            groups=groups,
             optional=optional,
             allows_prereleases=True,
             source_type="directory",
@@ -97,7 +97,7 @@ class DirectoryDependency(Dependency):
             path=self.path,
             base=self.base,
             optional=self.is_optional(),
-            category=self.category,
+            groups=list(self._groups),
             develop=self._develop,
             extras=self._extras,
         )

--- a/poetry/core/packages/file_dependency.py
+++ b/poetry/core/packages/file_dependency.py
@@ -22,7 +22,7 @@ class FileDependency(Dependency):
         self,
         name: str,
         path: Path,
-        category: str = "main",
+        groups: Optional[List[str]] = None,
         optional: bool = False,
         base: Optional[Path] = None,
         extras: Optional[Union[List[str], FrozenSet[str]]] = None,
@@ -46,7 +46,7 @@ class FileDependency(Dependency):
         super(FileDependency, self).__init__(
             name,
             "*",
-            category=category,
+            groups=groups,
             optional=optional,
             allows_prereleases=True,
             source_type="file",
@@ -83,7 +83,7 @@ class FileDependency(Dependency):
             path=self.path,
             base=self.base,
             optional=self.is_optional(),
-            category=self.category,
+            groups=list(self._groups),
             extras=self._extras,
         )
 

--- a/poetry/core/packages/package.py
+++ b/poetry/core/packages/package.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from poetry.core.spdx.license import License  # noqa
     from poetry.core.version.markers import BaseMarker  # noqa
 
+    from .dependency_group import DependencyGroup
     from .types import DependencyTypes
 
 AUTHOR_REGEX = re.compile(r"(?u)^(?P<name>[- .,\w\d'’\"()&]+)(?: <(?P<email>.+?)>)?$")
@@ -87,11 +88,12 @@ class Package(PackageSpecification):
         self._license = None
         self.readme = None
 
-        self.requires = []
-        self.dev_requires = []
         self.extras = {}
         self.requires_extras = []
 
+        self._dependency_groups: Dict[str, "DependencyGroup"] = {}
+
+        # For compatibility with previous version, we keep the category
         self.category = "main"
         self.files = []
         self.optional = False
@@ -184,10 +186,28 @@ class Package(PackageSpecification):
         return self._get_maintainer()["email"]
 
     @property
+    def requires(self) -> List["DependencyTypes"]:
+        """
+        Returns the default dependencies
+        """
+        if not self._dependency_groups or "default" not in self._dependency_groups:
+            return []
+
+        return self._dependency_groups["default"].dependencies
+
+    @property
     def all_requires(
         self,
     ) -> List[Union["DependencyTypes"]]:
-        return self.requires + self.dev_requires
+        """
+        Returns the default dependencies and group dependencies.
+        """
+        return self.requires + [
+            dependency
+            for group in self._dependency_groups.values()
+            for dependency in group.dependencies
+            if group.name != "default"
+        ]
 
     def _get_author(self) -> Dict[str, Optional[str]]:
         if not self._authors:
@@ -332,16 +352,76 @@ class Package(PackageSpecification):
     def is_root(self) -> bool:
         return False
 
+    def add_dependency_group(self, group: "DependencyGroup") -> None:
+        self._dependency_groups[group.name] = group
+
+    def dependency_group(self, name: str) -> "DependencyGroup":
+        if name not in self._dependency_groups:
+            raise ValueError(f'The dependency group "{name}" does not exist.')
+
+        return self._dependency_groups[name]
+
     def add_dependency(
         self,
         dependency: "DependencyTypes",
     ) -> "DependencyTypes":
-        if dependency.category == "dev":
-            self.dev_requires.append(dependency)
-        else:
-            self.requires.append(dependency)
+        from .dependency_group import DependencyGroup
+
+        for group_name in dependency.groups:
+            if group_name not in self._dependency_groups:
+                # Dynamically add the dependency group
+                self.add_dependency_group(DependencyGroup(group_name))
+
+            self._dependency_groups[group_name].add_dependency(dependency)
 
         return dependency
+
+    def without_dependency_groups(self, groups: List[str]) -> "Package":
+        """
+        Returns a clone of the package with the given dependency groups excluded.
+        """
+        package = self.clone()
+
+        for group_name in groups:
+            if group_name in package._dependency_groups:
+                del package._dependency_groups[group_name]
+
+        return package
+
+    def without_optional_dependency_groups(self) -> "Package":
+        """
+        Returns a clone of the package without optional dependency groups.
+        """
+        package = self.clone()
+
+        for group_name, group in self._dependency_groups.items():
+            if group.is_optional():
+                del package._dependency_groups[group_name]
+
+        return package
+
+    def with_dependency_groups(
+        self, groups: List[str], only: bool = False
+    ) -> "Package":
+        """
+        Returns a clone of the package with the given dependency groups opted in.
+
+        Note that it will return all dependencies across all groups
+        more the given, optional, groups.
+
+        If `only` is set to True, then only the given groups will be selected.
+        """
+        package = self.clone()
+
+        for group_name, group in self._dependency_groups.items():
+            if only:
+                if group_name not in groups:
+                    del package._dependency_groups[group_name]
+            else:
+                if group.is_optional() and group_name not in groups:
+                    del package._dependency_groups[group_name]
+
+        return package
 
     def to_dependency(
         self,
@@ -358,7 +438,7 @@ class Package(PackageSpecification):
             dep = DirectoryDependency(
                 self._name,
                 Path(self._source_url),
-                category=self.category,
+                groups=list(self._dependency_groups.keys()),
                 optional=self.optional,
                 base=self.root_dir,
                 develop=self.develop,
@@ -368,7 +448,7 @@ class Package(PackageSpecification):
             dep = FileDependency(
                 self._name,
                 Path(self._source_url),
-                category=self.category,
+                groups=list(self._dependency_groups.keys()),
                 optional=self.optional,
                 base=self.root_dir,
                 extras=self.features,
@@ -377,7 +457,7 @@ class Package(PackageSpecification):
             dep = URLDependency(
                 self._name,
                 self._source_url,
-                category=self.category,
+                groups=list(self._dependency_groups.keys()),
                 optional=self.optional,
                 extras=self.features,
             )
@@ -388,7 +468,7 @@ class Package(PackageSpecification):
                 self.source_url,
                 rev=self.source_reference,
                 resolved_rev=self.source_resolved_reference,
-                category=self.category,
+                groups=list(self._dependency_groups.keys()),
                 optional=self.optional,
                 develop=self.develop,
                 extras=self.features,

--- a/poetry/core/packages/url_dependency.py
+++ b/poetry/core/packages/url_dependency.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 from typing import FrozenSet
 from typing import List
+from typing import Optional
 from typing import Union
 from urllib.parse import urlparse
 
@@ -16,7 +17,7 @@ class URLDependency(Dependency):
         self,
         name: str,
         url: str,
-        category: str = "main",
+        groups: Optional[List[str]] = None,
         optional: bool = False,
         extras: Union[List[str], FrozenSet[str]] = None,
     ):
@@ -29,7 +30,7 @@ class URLDependency(Dependency):
         super(URLDependency, self).__init__(
             name,
             "*",
-            category=category,
+            groups=groups,
             optional=optional,
             allows_prereleases=True,
             source_type="url",
@@ -60,7 +61,7 @@ class URLDependency(Dependency):
             self.pretty_name,
             url=self._url,
             optional=self.is_optional(),
-            category=self.category,
+            groups=list(self._groups),
             extras=self._extras,
         )
 

--- a/poetry/core/packages/vcs_dependency.py
+++ b/poetry/core/packages/vcs_dependency.py
@@ -25,7 +25,7 @@ class VCSDependency(Dependency):
         tag: Optional[str] = None,
         rev: Optional[str] = None,
         resolved_rev: Optional[str] = None,
-        category: str = "main",
+        groups: Optional[List[str]] = None,
         optional: bool = False,
         develop: bool = False,
         extras: Union[List[str], FrozenSet[str]] = None,
@@ -45,7 +45,7 @@ class VCSDependency(Dependency):
         super(VCSDependency, self).__init__(
             name,
             "*",
-            category=category,
+            groups=groups,
             optional=optional,
             allows_prereleases=True,
             source_type=self._vcs.lower(),
@@ -132,7 +132,7 @@ class VCSDependency(Dependency):
             rev=self._rev,
             resolved_rev=self._source_resolved_reference,
             optional=self.is_optional(),
-            category=self.category,
+            groups=list(self._groups),
             develop=self._develop,
             extras=self._extras,
         )

--- a/tests/fixtures/sample_project/pyproject.toml
+++ b/tests/fixtures/sample_project/pyproject.toml
@@ -50,7 +50,7 @@ dataclasses = {version = "^0.7", python = ">=3.6.1,<3.7"}
 [tool.poetry.extras]
 db = [ "orator" ]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "~3.4"
 
 

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -250,7 +250,7 @@ def test_with_constraint():
         "foo",
         "^1.2.3",
         optional=True,
-        category="dev",
+        groups=["dev"],
         allows_prereleases=True,
         extras=["bar", "baz"],
     )
@@ -268,7 +268,7 @@ def test_with_constraint():
     assert new.name == dependency.name
     assert str(new.constraint) == ">=1.2.6,<2.0.0"
     assert new.is_optional()
-    assert new.category == "dev"
+    assert new.groups == frozenset(["dev"])
     assert new.allows_prereleases()
     assert set(new.extras) == {"bar", "baz"}
     assert new.marker == dependency.marker

--- a/tests/packages/test_vcs_dependency.py
+++ b/tests/packages/test_vcs_dependency.py
@@ -59,15 +59,15 @@ def test_to_pep_508_in_extras():
     assert expected == dependency.to_pep_508()
 
 
-@pytest.mark.parametrize("category", ["main", "dev"])
-def test_category(category):
+@pytest.mark.parametrize("groups", [["main"], ["dev"]])
+def test_category(groups):
     dependency = VCSDependency(
         "poetry",
         "git",
         "https://github.com/python-poetry/poetry.git",
-        category=category,
+        groups=groups,
     )
-    assert category == dependency.category
+    assert dependency.groups == frozenset(groups)
 
 
 def test_vcs_dependency_can_have_resolved_reference_specified():

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -199,11 +199,11 @@ The Poetry configuration is invalid:
 
 
 def test_create_poetry_omits_dev_dependencies_iff_with_dev_is_false():
-    poetry = Factory().create_poetry(fixtures_dir / "sample_project", with_dev=False)
-    assert not any(r for r in poetry.package.dev_requires if "pytest" in str(r))
+    poetry = Factory().create_poetry(fixtures_dir / "sample_project", with_groups=False)
+    assert not any("dev" in r.groups for r in poetry.package.all_requires)
 
     poetry = Factory().create_poetry(fixtures_dir / "sample_project")
-    assert any(r for r in poetry.package.dev_requires if "pytest" in str(r))
+    assert any("dev" in r.groups for r in poetry.package.all_requires)
 
 
 def test_create_poetry_fails_with_invalid_dev_dependencies_iff_with_dev_is_true():
@@ -212,5 +212,5 @@ def test_create_poetry_fails_with_invalid_dev_dependencies_iff_with_dev_is_true(
     assert "does not exist" in str(err.value)
 
     Factory().create_poetry(
-        fixtures_dir / "project_with_invalid_dev_deps", with_dev=False
+        fixtures_dir / "project_with_invalid_dev_deps", with_groups=False
     )


### PR DESCRIPTION
This PR adds support for dependency groups at the core level (PR on the Poetry side to follow).

Basically, dependency groups can be declared in the `pyproject.toml` file like so:

```toml
[tool.poetry.group.dev.dependencies]
black = "*"

[tool.poetry.group.test.dependencies]
pytest = "*"
```

There is also support for optional dependency groups that can be opted in:

```toml
[tool.poetry.group]
optional = true

[tool.poetry.group.docsdependencies]
mkdocs = "*"
```

Groups can be excluded, opted in and exclusively selected via specific methods on the `Package` class.

Resolves: python-poetry/poetry#1644

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.