### PR TITLE
Add look_up_current_branch_name method in class Git

### DIFF
--- a/poetry/core/vcs/git.py
+++ b/poetry/core/vcs/git.py
@@ -223,6 +223,25 @@ class Git:
 
         return self.run(*args)
 
+    def get_current_branch(self, folder=None):
+        args = []
+
+        if folder is None and self._work_dir:
+            folder = self._work_dir
+
+        if folder:
+            print("folder is not empty string 2")
+            args += [
+                "--git-dir",
+                (folder / ".git").as_posix(),
+                "--work-tree",
+                folder.as_posix(),
+            ]
+
+        args += ["rev-parse", "--abbrev-ref", "HEAD"]
+
+        return self.run(*args)
+
     def rev_parse(self, rev: str, folder: Optional[Path] = None) -> str:
         args = []
         if folder is None and self._work_dir:


### PR DESCRIPTION
Resolves: python-poetry/poetry#3366


<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

This pull request is used by python-poetry/poetry#4386 which achieves "auto fetch git branch name when no rev/branch is specified on git url"
