### PR TITLE
Release 1.0.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Install and set up Poetry
       run: |
         curl -fsS -o get-poetry.py https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py
-        python get-poetry.py --preview -y
+        python get-poetry.py -y
     - name: Build distributions
       run: |
         source $HOME/.poetry/env
@@ -78,7 +78,7 @@ jobs:
     - name: Install and setup Poetry
       run: |
         Invoke-WebRequest https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py -O get-poetry.py
-        python get-poetry.py --preview -y
+        python get-poetry.py -y
     - name: Build distributions
       run: |
         $env:Path += ";$env:Userprofile\.poetry\bin"
@@ -108,7 +108,7 @@ jobs:
       - name: Install and set up Poetry
         run: |
           curl -fsS -o get-poetry.py https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py
-          python get-poetry.py --preview -y
+          python get-poetry.py -y
       - name: Check distributions
         run: |
           ls -la dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [1.0.4] - 2021-08-19
+
+### Fixed
+
+- Fixed an error in the way python markers with a precision >= 3 were handled. ([#180](https://github.com/python-poetry/poetry-core/pull/180))
+- Fixed an error in the evaluation of `in/not in` markers ([#189](https://github.com/python-poetry/poetry-core/pull/189))
+
+
 ## [1.0.3] - 2021-04-09
 
 ### Fixed
@@ -147,7 +155,8 @@ No changes.
 - Fixed support for stub-only packages ([#28](https://github.com/python-poetry/core/pull/28)).
 
 
-[Unreleased]: https://github.com/python-poetry/poetry-core/compare/1.0.3...master
+[Unreleased]: https://github.com/python-poetry/poetry-core/compare/1.0.4...1.1
+[1.0.4]: https://github.com/python-poetry/poetry-core/releases/tag/1.0.4
 [1.0.3]: https://github.com/python-poetry/poetry-core/releases/tag/1.0.3
 [1.0.2]: https://github.com/python-poetry/poetry-core/releases/tag/1.0.2
 [1.0.1]: https://github.com/python-poetry/poetry-core/releases/tag/1.0.1

--- a/poetry/core/__init__.py
+++ b/poetry/core/__init__.py
@@ -7,7 +7,7 @@ except ImportError:
     # noinspection PyUnresolvedReferences
     from pathlib2 import Path
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 __vendor_site__ = (Path(__file__).parent / "_vendor").as_posix()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-core"
-version = "1.0.3"
+version = "1.0.4"
 description = "Poetry PEP 517 Build Backend"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 


### PR DESCRIPTION
### Fixed

- Fixed an error in the way python markers with a precision >= 3 were handled. ([#180](https://github.com/python-poetry/poetry-core/pull/180))
- Fixed an error in the evaluation of `in/not in` markers ([#189](https://github.com/python-poetry/poetry-core/pull/189))
