### PR TITLE
Backport fix for mismatching hash check

### DIFF
--- a/poetry/core/packages/package.py
+++ b/poetry/core/packages/package.py
@@ -404,7 +404,7 @@ class Package(PackageSpecification):
     def without_features(self):  # type: () -> "Package"
         return self.with_features([])
 
-    def clone(self) -> "Package":
+    def clone(self):  # type: () -> "Package"
         clone = self.__class__(self.pretty_name, self.version)
         clone.__dict__ = copy.deepcopy(self.__dict__)
         return clone

--- a/poetry/core/packages/package.py
+++ b/poetry/core/packages/package.py
@@ -404,34 +404,9 @@ class Package(PackageSpecification):
     def without_features(self):  # type: () -> "Package"
         return self.with_features([])
 
-    def clone(self):  # type: () -> "Package"
-        if self.is_root():
-            clone = self.__class__(self.pretty_name, self.version)
-        else:
-            clone = self.__class__(
-                self.pretty_name,
-                self.version,
-                source_type=self._source_type,
-                source_url=self._source_url,
-                source_reference=self._source_reference,
-                features=list(self.features),
-            )
-
-        clone.description = self.description
-        clone.category = self.category
-        clone.optional = self.optional
-        clone.python_versions = self.python_versions
-        clone.marker = self.marker
-        clone.extras = self.extras
-        clone.root_dir = self.root_dir
-        clone.develop = self.develop
-
-        for dep in self.requires:
-            clone.requires.append(dep)
-
-        for dep in self.dev_requires:
-            clone.dev_requires.append(dep)
-
+    def clone(self) -> "Package":
+        clone = self.__class__(self.pretty_name, self.version)
+        clone.__dict__ = copy.deepcopy(self.__dict__)
         return clone
 
     def __hash__(self):  # type: () -> int

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -280,3 +280,30 @@ def test_to_dependency_for_url():
     assert "https://example.com/path.tar.gz" == dep.url
     assert "url" == dep.source_type
     assert "https://example.com/path.tar.gz" == dep.source_url
+
+
+def test_package_clone(f):
+    # TODO(nic): this test is not future-proof, in that any attributes added
+    #  to the Package object and not filled out in this test setup might
+    #  cause comparisons to match that otherwise should not.  A factory method
+    #  to create a Package object with all fields fully randomized would be the
+    #  most rigorous test for this, but that's likely overkill.
+    p = Package(
+        "lol_wut",
+        "3.141.5926535",
+        pretty_version="③.⑭.⑮",
+        source_type="git",
+        source_url="http://some.url",
+        source_reference="fe4d2adabf3feb5d32b70ab5c105285fa713b10c",
+        source_resolved_reference="fe4d2adabf3feb5d32b70ab5c105285fa713b10c",
+        features=["abc", "def"],
+        develop=random.choice((True, False)),
+    )
+    p.files = (["file1", "file2", "file3"],)
+    p.homepage = "https://some.other.url"
+    p.repository_url = "http://bug.farm"
+    p.documentation_url = "http://lorem.ipsum/dolor/sit.amet"
+    p2 = p.clone()
+
+    assert p == p2
+    assert p.__dict__ == p2.__dict__

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -297,7 +297,6 @@ def test_package_clone(f):
         source_reference="fe4d2adabf3feb5d32b70ab5c105285fa713b10c",
         source_resolved_reference="fe4d2adabf3feb5d32b70ab5c105285fa713b10c",
         features=["abc", "def"],
-        develop=random.choice((True, False)),
     )
     p.files = (["file1", "file2", "file3"],)
     p.homepage = "https://some.other.url"


### PR DESCRIPTION
Backport https://github.com/python-poetry/poetry-core/pull/159 to poetry-core 1.0 as this is part of an important security fix.

See https://github.com/python-poetry/poetry/pull/3885 and https://github.com/python-poetry/poetry/issues/2422

I think that this fix exposes a preexisting bug in Poetry where `poetry install` fails with the following:

```
$ ~/git/poetry/.venv/bin/poetry install
Creating virtualenv tmp in /Users/pietro/tmp/.venv
Installing dependencies from lock file

Package operations: 1 install, 0 updates, 0 removals

  • Installing attrs (21.2.0): Failed

  AttributeError

  'Link' object has no attribute 'is_absolute'

  at ~/git/poetry/.venv/lib/python3.9/site-packages/poetry/core/packages/file_dependency.py:34 in __init__
       30│         self._base = base or Path.cwd()
       31│         self._full_path = path
       32│
       33│         #raise ValueError(type(path))
    →  34│         if not self._path.is_absolute():
       35│             try:
       36│                 self._full_path = self._base.joinpath(self._path).resolve()
       37│             except FileNotFoundError:
       38│                 raise ValueError("Directory {} does not exist".format(self._path))
```

I think that there is an underlying bug where an object that should be a `Path` is actually a `Link`, and that is exposed by the fact that the `Package.files` attribute gets cloned, and not lost as of now in Poetry 1.1.8.