### PR TITLE
Release 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [1.0.5] - 2021-09-18
+
+### Fixed
+
+- Fixed the copy of `Package` instances which led to file hashes not being available. ([#193](https://github.com/python-poetry/poetry-core/pull/193))
+- Fixed an issue where unsafe parameters could be passed to `git` commands. ([#203](https://github.com/python-poetry/poetry-core/pull/203))
+- Fixed an issue where the wrong `git` executable could be used on Windows. ([#205](https://github.com/python-poetry/poetry-core/pull/205))
+
+
 ## [1.0.4] - 2021-08-19
 
 ### Fixed
@@ -155,7 +164,8 @@ No changes.
 - Fixed support for stub-only packages ([#28](https://github.com/python-poetry/core/pull/28)).
 
 
-[Unreleased]: https://github.com/python-poetry/poetry-core/compare/1.0.4...1.1
+[Unreleased]: https://github.com/python-poetry/poetry-core/compare/1.0.5...1.1
+[1.0.5]: https://github.com/python-poetry/poetry-core/releases/tag/1.0.5
 [1.0.4]: https://github.com/python-poetry/poetry-core/releases/tag/1.0.4
 [1.0.3]: https://github.com/python-poetry/poetry-core/releases/tag/1.0.3
 [1.0.2]: https://github.com/python-poetry/poetry-core/releases/tag/1.0.2

--- a/poetry/core/__init__.py
+++ b/poetry/core/__init__.py
@@ -7,7 +7,7 @@ except ImportError:
     # noinspection PyUnresolvedReferences
     from pathlib2 import Path
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"
 
 __vendor_site__ = (Path(__file__).parent / "_vendor").as_posix()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-core"
-version = "1.0.4"
+version = "1.0.5"
 description = "Poetry PEP 517 Build Backend"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 


### PR DESCRIPTION
### Fixed

- Fixed the copy of `Package` instances which led to file hashes not being available. ([#193](https://github.com/python-poetry/poetry-core/pull/193))
- Fixed an issue where unsafe parameters could be passed to `git` commands. ([#203](https://github.com/python-poetry/poetry-core/pull/203))
- Fixed an issue where the wrong `git` executable could be used on Windows. ([#205](https://github.com/python-poetry/poetry-core/pull/205))
