### PR TITLE
support specifying algorithm when calculating file dependency hash.

### DIFF
--- a/poetry/core/packages/file_dependency.py
+++ b/poetry/core/packages/file_dependency.py
@@ -69,8 +69,8 @@ class FileDependency(Dependency):
     def is_file(self) -> bool:
         return True
 
-    def hash(self) -> str:
-        h = hashlib.sha256()
+    def hash(self, algorithm: str = "sha256") -> str:
+        h = hashlib.new(algorithm)
         with self._full_path.open("rb") as fp:
             for content in iter(lambda: fp.read(io.DEFAULT_BUFFER_SIZE), b""):
                 h.update(content)


### PR DESCRIPTION
Signed-off-by: Andreas Stenius <andreas.stenius@svenskaspel.se>

Pre-work for: python-poetry/poetry#4085

- [x] Added **tests** for changed code.

Currently, poetry assumes all archive file hashes are using `sha256`. This opens for the ability to support other algorithms. (I have a real use case, where the archive uses md5, for instance.)
