### PR TITLE
Release 1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [1.0.7] - 2021-10-04
+
+### Fixed
+
+- Fixed an issue where the wrong `git` executable could be used on Windows. ([#213](https://github.com/python-poetry/poetry-core/pull/213))
+- Fixed an issue where the Python 3.10 classifier was not automatically added. ([#215](https://github.com/python-poetry/poetry-core/pull/215))
+
+
 ## [1.0.6] - 2021-09-21
 
 ### Added
@@ -171,7 +179,8 @@ No changes.
 - Fixed support for stub-only packages ([#28](https://github.com/python-poetry/core/pull/28)).
 
 
-[Unreleased]: https://github.com/python-poetry/poetry-core/compare/1.0.6...1.1
+[Unreleased]: https://github.com/python-poetry/poetry-core/compare/1.0.7...1.0
+[1.0.7]: https://github.com/python-poetry/poetry-core/releases/tag/1.0.7
 [1.0.6]: https://github.com/python-poetry/poetry-core/releases/tag/1.0.6
 [1.0.5]: https://github.com/python-poetry/poetry-core/releases/tag/1.0.5
 [1.0.4]: https://github.com/python-poetry/poetry-core/releases/tag/1.0.4

--- a/poetry/core/__init__.py
+++ b/poetry/core/__init__.py
@@ -7,7 +7,7 @@ except ImportError:
     # noinspection PyUnresolvedReferences
     from pathlib2 import Path
 
-__version__ = "1.0.6"
+__version__ = "1.0.7"
 
 __vendor_site__ = (Path(__file__).parent / "_vendor").as_posix()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-core"
-version = "1.0.6"
+version = "1.0.7"
 description = "Poetry PEP 517 Build Backend"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 


### PR DESCRIPTION
### Fixed

- Fixed an issue where the wrong `git` executable could be used on Windows. ([#213](https://github.com/python-poetry/poetry-core/pull/213))
- Fixed an issue where the Python 3.10 classifier was not automatically added. ([#215](https://github.com/python-poetry/poetry-core/pull/215))