### PR TITLE
Require that package descriptions not include newlines

### DIFF
--- a/poetry/core/json/schemas/poetry-schema.json
+++ b/poetry/core/json/schemas/poetry-schema.json
@@ -19,7 +19,8 @@
     },
     "description": {
       "type": "string",
-      "description": "Short package description."
+      "description": "Short package description.",
+      "pattern": "^[^\n]*$"
     },
     "keywords": {
       "type": "array",

--- a/tests/json/test_poetry_schema.py
+++ b/tests/json/test_poetry_schema.py
@@ -42,3 +42,12 @@ def test_path_dependencies(base_object):
 
 def test_multi_url_dependencies(multi_url_object):
     assert len(validate_object(multi_url_object, "poetry-schema")) == 0
+
+
+def test_multiline_description(base_object):
+    bad_description = "Some multi-\nline string"
+    base_object["description"] = bad_description
+
+    errors = validate_object(base_object, "poetry-schema")
+    assert len(errors) == 1
+    assert errors[0] == "[description] %r does not match '^[^\\n]*$'" % bad_description


### PR DESCRIPTION
Previously, we would include the description-with-newlines directly as the PKG-INFO summary, which could cause subtly broken builds (for instance, the package may install, but none of the specified dependencies).

Now, raise a validation error during building, like:

    RuntimeError

    The Poetry configuration is invalid:
      - [description] 'First line\nSecond line (BOOOOOM)' does not match '^[^\n]+$'

Resolves: python-poetry/poetry#1372

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
