### PR TITLE
Fix file:// path handling on Windows

### DIFF
--- a/poetry/core/packages/utils/link.py
+++ b/poetry/core/packages/utils/link.py
@@ -6,7 +6,7 @@ from typing import Any
 from typing import Optional
 from typing import Tuple
 
-from .utils import path_to_url
+from .utils import path_to_url, url_to_path
 from .utils import splitext
 
 
@@ -102,7 +102,12 @@ class Link:
 
     @property
     def path(self) -> str:
-        return urlparse.unquote(urlparse.urlsplit(self.url)[2])
+        # Properly handle file:// paths https://github.com/python-poetry/poetry/issues/4163
+        if self.url.startswith("file:"):
+            p = str(url_to_path(self.url))
+        else:
+            p = urlparse.unquote(urlparse.urlsplit(self.url)[2])
+        return p
 
     def splitext(self) -> Tuple[str, str]:
         return splitext(posixpath.basename(self.path.rstrip("/")))


### PR DESCRIPTION
Resolves: python-poetry#4163

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Same as https://github.com/python-poetry/poetry/pull/4651, just trying to do the legwork to get fixes upstream for a showstopping issue for some users of poetry on Windows.