### PR TITLE
[Hotfix] Transform Link back into Path inside FileDependency

### DIFF
--- a/poetry/core/packages/file_dependency.py
+++ b/poetry/core/packages/file_dependency.py
@@ -2,13 +2,14 @@ import hashlib
 import io
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from typing import FrozenSet
 from typing import List
 from typing import Optional
 from typing import Union
 
 from poetry.core.packages.utils.utils import path_to_url
+from poetry.core.packages.utils.link import Link
 
 from .dependency import Dependency
 
@@ -30,6 +31,12 @@ class FileDependency(Dependency):
         self._path = path
         self._base = base or Path.cwd()
         self._full_path = path
+
+        if isinstance(self._path, Link):
+            link = cast(Link, self._path)
+            self._path = Path(link.filename)
+            if self._path.is_absolute():
+                self._full_path = self._path
 
         if not self._path.is_absolute():
             try:


### PR DESCRIPTION
Resolves: python-poetry/poetry#4541 (& related issues)

## Context
Whenever I try installing dependencies with `poetry-core 1.0.7`, I run into an `AttributeError` since a `Link` object is passed to `FileDependency` instead of a `Path` object.

I saw that the [code that initializes the class in Poetry performs a cast](https://github.com/python-poetry/poetry/blob/82459bd6f38785882a8eff0fbce2a8b0119b205c/poetry/installation/executor.py#L678), but for some reason this cast is not working on my local machine. The fix I performed directly inside the `FileDependency` class is the only thing that made Poetry work consistently on my machine.

I tried running every Poetry version in the range `1.1.6 -> 1.1.11`, without success.

My local machine is a MacOS, not sure if this is the cause since I saw lots of issues about this behaviour in the Poetry repo.

## Checklist

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
