### PR TITLE
Improve intersection of multi marker union

### DIFF
--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -124,6 +124,24 @@ def test_single_marker_intersect_with_multi_compacts_constraint():
     )
 
 
+def test_single_marker_intersect_with_union_leads_to_single_marker():
+    m = parse_marker('python_version >= "3.6"')
+
+    intersection = m.intersect(
+        parse_marker('python_version < "3.6" or python_version >= "3.7"')
+    )
+    assert str(intersection) == 'python_version >= "3.7"'
+
+
+def test_single_marker_intersect_with_union_leads_to_empty():
+    m = parse_marker('python_version == "3.7"')
+
+    intersection = m.intersect(
+        parse_marker('python_version < "3.7" or python_version >= "3.8"')
+    )
+    assert intersection.is_empty()
+
+
 def test_single_marker_not_in_python_intersection():
     m = parse_marker('python_version not in "2.7, 3.0, 3.1"')
 
@@ -257,6 +275,36 @@ def test_multi_marker_intersect_multi_with_overlapping_constraints():
     assert str(intersection) == (
         'sys_platform == "darwin" and python_version <= "3.4" and os_name == "Windows"'
     )
+
+
+def test_multi_marker_intersect_with_union_drops_union():
+    m = parse_marker('python_version >= "3" and python_version < "4"')
+    m2 = parse_marker('python_version < "2" or python_version >= "3"')
+    assert str(m.intersect(m2)) == str(m)
+    assert str(m2.intersect(m)) == str(m)
+
+
+def test_multi_marker_intersect_with_multi_union_leads_to_empty_in_one_step():
+    # empty marker in one step
+    # py == 2 and (py < 2 or py >= 3) -> empty
+    m = parse_marker('sys_platform == "darwin" and python_version == "2"')
+    m2 = parse_marker(
+        'sys_platform == "darwin" and (python_version < "2" or python_version >= "3")'
+    )
+    assert m.intersect(m2).is_empty()
+    assert m2.intersect(m).is_empty()
+
+
+def test_multi_marker_intersect_with_multi_union_leads_to_empty_in_two_steps():
+    # empty marker in two steps
+    # py >= 2 and (py < 2 or py >= 3) -> py >= 3
+    # py < 3 and py >= 3 -> empty
+    m = parse_marker('python_version >= "2" and python_version < "3"')
+    m2 = parse_marker(
+        'sys_platform == "darwin" and (python_version < "2" or python_version >= "3")'
+    )
+    assert m.intersect(m2).is_empty()
+    assert m2.intersect(m).is_empty()
 
 
 def test_multi_marker_union_multi():


### PR DESCRIPTION
Resolves: python-poetry/poetry#4694

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
Improves the detection of empty markers when building the intersection of multi markers containing unions and single markers.

Therefore, if the list of markers of the intersection contains single markers and marker unions, the intersection of each marker union with each single marker is made. If the intersection is not a marker union but a single or empty marker, the resulting marker can be simplified.

I checked the new code for 100 % statement coverage. That is why the markers in the test cases may look a bit more complicated than in the examples in python-poetry/poetry#4694. (In order to test all paths it was necessary to use multi markers containing marker unions instead of just using marker unions.)

