### PR TITLE
tighten whitelist in masonry.builder

### DIFF
--- a/poetry/core/masonry/builder.py
+++ b/poetry/core/masonry/builder.py
@@ -24,7 +24,7 @@ class Builder:
         if fmt in self._formats:
             builders = [self._formats[fmt]]
         elif fmt == "all":
-            builders = self._formats.values()
+            builders = list(self._formats.values())
         else:
             raise ValueError("Invalid format: {}".format(fmt))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,6 @@ module = [
   'poetry.core.factory.*',
   'poetry.core.masonry.builders.*',
   'poetry.core.masonry.utils.*',
-  'poetry.core.masonry.api',
   'poetry.core.masonry.metadata',
   'poetry.core.packages.*',
   'poetry.core.poetry.*',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,9 @@ exclude = "poetry/core/_vendor"
 module = [
   'poetry.core.factory.*',
   'poetry.core.masonry.builders.*',
-  'poetry.core.masonry.utils.*',
+  'poetry.core.masonry.utils.include',
+  'poetry.core.masonry.utils.module',
+  'poetry.core.masonry.utils.package_include',
   'poetry.core.masonry.metadata',
   'poetry.core.packages.*',
   'poetry.core.poetry.*',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,10 @@ exclude = "poetry/core/_vendor"
 [[tool.mypy.overrides]]
 module = [
   'poetry.core.factory.*',
-  'poetry.core.masonry.*',
+  'poetry.core.masonry.builders.*',
+  'poetry.core.masonry.utils.*',
+  'poetry.core.masonry.api',
+  'poetry.core.masonry.metadata',
   'poetry.core.packages.*',
   'poetry.core.poetry.*',
   'poetry.core.pyproject.*',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,6 @@ exclude = "poetry/core/_vendor"
 module = [
   'poetry.core.factory.*',
   'poetry.core.masonry.builders.*',
-  'poetry.core.masonry.utils.include',
   'poetry.core.masonry.utils.module',
   'poetry.core.masonry.utils.package_include',
   'poetry.core.masonry.metadata',


### PR DESCRIPTION
remove some of the globs from the whitelist of the `masonry` module to reduce the total scope of the whitelist