### PR TITLE
lint and fix pep8 naming conventions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
           - flake8-simplify
           - flake8-tidy-imports
           - flake8-use-fstring
+          - pep8-naming
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.910

--- a/src/poetry/core/exceptions/__init__.py
+++ b/src/poetry/core/exceptions/__init__.py
@@ -1,4 +1,4 @@
-from poetry.core.exceptions.base import PoetryCoreException
+from poetry.core.exceptions.base import PoetryCoreError
 
 
-__all__ = ["PoetryCoreException"]
+__all__ = ["PoetryCoreError"]

--- a/src/poetry/core/exceptions/base.py
+++ b/src/poetry/core/exceptions/base.py
@@ -1,2 +1,2 @@
-class PoetryCoreException(Exception):
+class PoetryCoreError(Exception):
     pass

--- a/src/poetry/core/pyproject/exceptions.py
+++ b/src/poetry/core/pyproject/exceptions.py
@@ -1,5 +1,5 @@
-from poetry.core.exceptions import PoetryCoreException
+from poetry.core.exceptions import PoetryCoreError
 
 
-class PyProjectException(PoetryCoreException):
+class PyProjectError(PoetryCoreError):
     pass

--- a/src/poetry/core/pyproject/toml.py
+++ b/src/poetry/core/pyproject/toml.py
@@ -65,20 +65,20 @@ class PyProjectTOML:
         try:
             return self.data["tool"]["poetry"]
         except NonExistentKey as e:
-            from poetry.core.pyproject.exceptions import PyProjectException
+            from poetry.core.pyproject.exceptions import PyProjectError
 
-            raise PyProjectException(
+            raise PyProjectError(
                 f"[tool.poetry] section not found in {self._file}"
             ) from e
 
     def is_poetry_project(self) -> bool:
-        from poetry.core.pyproject.exceptions import PyProjectException
+        from poetry.core.pyproject.exceptions import PyProjectError
 
         if self.file.exists():
             try:
                 _ = self.poetry_config
                 return True
-            except PyProjectException:
+            except PyProjectError:
                 pass
 
         return False

--- a/src/poetry/core/toml/exceptions.py
+++ b/src/poetry/core/toml/exceptions.py
@@ -1,7 +1,7 @@
 from tomlkit.exceptions import TOMLKitError
 
-from poetry.core.exceptions import PoetryCoreException
+from poetry.core.exceptions import PoetryCoreError
 
 
-class TOMLError(TOMLKitError, PoetryCoreException):
+class TOMLError(TOMLKitError, PoetryCoreError):
     pass

--- a/tests/packages/test_file_dependency.py
+++ b/tests/packages/test_file_dependency.py
@@ -31,14 +31,16 @@ def test_file_dependency_dir():
 def test_default_hash():
     path = DIST_PATH / TEST_FILE
     dep = FileDependency("demo", path)
-    SHA_256 = "72e8531e49038c5f9c4a837b088bfcb8011f4a9f76335c8f0654df6ac539b3d6"
-    assert dep.hash() == SHA_256
+    sha_256 = "72e8531e49038c5f9c4a837b088bfcb8011f4a9f76335c8f0654df6ac539b3d6"
+    assert dep.hash() == sha_256
 
 
 try:
-    from hashlib import algorithms_guaranteed as ALGORITHMS_GUARANTEED
+    from hashlib import algorithms_guaranteed as ALGORITHMS_GUARANTEED  # noqa: N812
 except ImportError:
-    ALGORITHMS_GUARANTEED = "md5,sha1,sha224,sha256,sha384,sha512".split(",")
+    ALGORITHMS_GUARANTEED = "md5,sha1,sha224,sha256,sha384,sha512".split(
+        ","
+    )  # noqa: N812
 
 
 @pytest.mark.parametrize(

--- a/tests/pyproject/test_pyproject_toml.py
+++ b/tests/pyproject/test_pyproject_toml.py
@@ -7,7 +7,7 @@ import pytest
 from tomlkit.toml_document import TOMLDocument
 from tomlkit.toml_file import TOMLFile
 
-from poetry.core.pyproject.exceptions import PyProjectException
+from poetry.core.pyproject.exceptions import PyProjectError
 from poetry.core.pyproject.toml import PyProjectTOML
 
 
@@ -23,7 +23,7 @@ def test_pyproject_toml_no_poetry_config(pyproject_toml: Path):
 
     assert not pyproject.is_poetry_project()
 
-    with pytest.raises(PyProjectException) as excval:
+    with pytest.raises(PyProjectError) as excval:
         _ = pyproject.poetry_config
 
     assert f"[tool.poetry] section not found in {pyproject_toml.as_posix()}" in str(

--- a/tests/pyproject/test_pyproject_toml_file.py
+++ b/tests/pyproject/test_pyproject_toml_file.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from poetry.core.exceptions import PoetryCoreException
+from poetry.core.exceptions import PoetryCoreError
 from poetry.core.toml import TOMLFile
 
 
@@ -26,7 +26,7 @@ def test_pyproject_toml_file_invalid(pyproject_toml: "Path"):
     with pyproject_toml.open(mode="a") as f:
         f.write("<<<<<<<<<<<")
 
-    with pytest.raises(PoetryCoreException) as excval:
+    with pytest.raises(PoetryCoreError) as excval:
         _ = TOMLFile(pyproject_toml).read()
 
     assert f"Invalid TOML file {pyproject_toml.as_posix()}" in str(excval.value)


### PR DESCRIPTION
i'll see what the CI does, but i'm expecting there's a reasonable chance this is a breaking change for downstream