### PR TITLE
special case union of single marker with inverse

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -284,6 +284,9 @@ class SingleMarker(BaseMarker):
             if self == other:
                 return self
 
+            if self == other.invert():
+                return AnyMarker()
+
             return MarkerUnion.of(self, other)
 
         return other.union(self)

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -212,6 +212,12 @@ def test_single_marker_union_with_union_duplicate():
     assert str(union) == 'sys_platform == "darwin" or python_version <= "3.6"'
 
 
+def test_single_marker_union_with_inverse():
+    m = parse_marker('sys_platform == "darwin"')
+    union = m.union(parse_marker('sys_platform != "darwin"'))
+    assert union.is_any()
+
+
 def test_multi_marker():
     m = parse_marker('sys_platform == "darwin" and implementation_name == "cpython"')
 


### PR DESCRIPTION
To avoid ending up with constraints like:

bar==7.8.9; platform_system != 'Windows' or platform_system == 'Windows'

Resolves: python-poetry#<!-- add issue number/link here -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

Per comment at https://github.com/python-poetry/poetry/pull/4824#issuecomment-981058498.

I have verified that this has the desired effect in the testcase added at https://github.com/python-poetry/poetry/pull/4686
