### PR TITLE
tidy black config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,21 +54,7 @@ isort = {version = "^5.9.3", python = "^3.6.1"}
 [tool.black]
 line-length = 88
 include = '\.pyi?$'
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | buck-out
-  | build
-  | dist
-  | src/poetry/core/_vendor/*
-)/
-'''
+extend-exclude = "src/poetry/core/_vendor/*"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
the 'extend' ignore config option means we don't need to reinvent black's default ignore list