### PR TITLE
Use flake8-eradicate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
           - flake8-annotations
           - flake8-bugbear
           - flake8-comprehensions
+          - flake8-eradicate
           - flake8-simplify
           - flake8-tidy-imports
           - flake8-use-fstring

--- a/tests/semver/test_helpers.py
+++ b/tests/semver/test_helpers.py
@@ -18,7 +18,6 @@ from poetry.core.version.pep440 import ReleaseTag
         ("v*.*", VersionRange()),
         ("*.x.*", VersionRange()),
         ("x.X.x.*", VersionRange()),
-        # ('!=1.0.0', Constraint('!=', '1.0.0.0')),
         (">1.0.0", VersionRange(min=Version.from_parts(1, 0, 0))),
         ("<1.2.3", VersionRange(max=Version.from_parts(1, 2, 3))),
         ("<=1.2.3", VersionRange(max=Version.from_parts(1, 2, 3), include_max=True)),


### PR DESCRIPTION
Relates-to: python-poetry/poetry#4776

flake8-eradicate has already been introduced for poetry in python-poetry/poetry#4806