### PR TITLE
make .pre-commit-config.yaml similar to poetry repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,72 +1,81 @@
-repos:
-  - repo: https://github.com/psf/black
-    rev: 21.9b0
-    hooks:
-      - id: black
-        exclude: ^src/poetry/core/_vendor
-
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-annotations
-          - flake8-bugbear
-          - flake8-comprehensions
-          - flake8-eradicate
-          - flake8-simplify
-          - flake8-tidy-imports
-          - flake8-use-fstring
-
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910
-    hooks:
-      - id: mypy
-        pass_filenames: false
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.9.3
-    hooks:
-      - id: isort
-        additional_dependencies: [toml]
-        exclude: |
+exclude: |
           (?x)(
-              ^.*/?setup\.py$
+              ^tests/.*/fixtures/.*
               | ^src/poetry/core/_vendor
-              | tests/.*\.pyi$
           )
 
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: debug-statements
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-toml
+      - id: check-yaml
+      - id: pretty-format-json
+        args:
+          - --autofix
+          - --no-ensure-ascii
+          - --no-sort-keys
+      - id: check-ast
+      - id: debug-statements
+      - id: check-docstring-first
+
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.9.0
+    hooks:
+      - id: python-check-mock-methods
+      - id: python-use-type-annotations
+      - id: python-check-blanket-type-ignore
+      - id: python-check-blanket-noqa
+
+  - repo: https://github.com/asottile/yesqa
+    rev: v1.3.0
+    hooks:
+      - id: yesqa
+        additional_dependencies: &flake8_deps
+          - flake8-annotations==2.7.0
+          - flake8-bugbear==22.1.11
+          - flake8-comprehensions==3.8.0
+          - flake8-eradicate==1.2.0
+          - flake8-simplify==0.15.1
+          - flake8-tidy-imports==4.6.0
+          - flake8-use-fstring==1.3
+
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.1
+    rev: v2.31.0
     hooks:
       - id: pyupgrade
         args:
           - --py36-plus
-        exclude: ^src/poetry/core/_vendor
 
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
     hooks:
-      - id: trailing-whitespace
+      - id: isort
         exclude: |
           (?x)(
-              ^tests/.*/fixtures/.*
-              | ^src/poetry/core/_vendor
+              ^.*/?setup\.py$
+              | tests/.*\.pyi$
           )
-      - id: end-of-file-fixer
-        exclude: |
-          (?x)(
-              ^tests/.*/fixtures/.*
-              | ^src/poetry/core/_vendor
-          )
-      - id: debug-statements
-        exclude: ^src/poetry/core/_vendor
 
-      - id: check-json
-        exclude: ^src/poetry/core/_vendor
+  - repo: https://github.com/psf/black
+    rev: 21.12b0
+    hooks:
+      - id: black
 
-      - id: pretty-format-json
-        exclude: ^src/poetry/core/_vendor
-        args:
-          - --no-sort-keys
-          - --autofix
+  - repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        additional_dependencies: *flake8_deps
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.931
+    hooks:
+      - id: mypy
+        pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ isort = {version = "^5.9.3", python = "^3.6.1"}
 
 [tool.black]
 line-length = 88
+experimental_string_processing = true
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -423,7 +423,8 @@ class Factory:
                     for extra in extras:
                         if extra not in config["extras"]:
                             result["errors"].append(
-                                f'Script "{name}" requires extra "{extra}" which is not defined.'
+                                f'Script "{name}" requires extra "{extra}" which is not'
+                                " defined."
                             )
 
             # Checking types of all readme files (must match)
@@ -431,7 +432,8 @@ class Factory:
                 readme_types = {readme_content_type(r) for r in config["readme"]}
                 if len(readme_types) > 1:
                     result["errors"].append(
-                        f"Declared README files must be of same type: found {', '.join(sorted(readme_types))}"
+                        "Declared README files must be of same type: found"
+                        f" {', '.join(sorted(readme_types))}"
                     )
 
         return result

--- a/src/poetry/core/masonry/builder.py
+++ b/src/poetry/core/masonry/builder.py
@@ -5,7 +5,7 @@ from typing import Union
 
 
 if TYPE_CHECKING:
-    from poetry.core.poetry import Poetry  # noqa
+    from poetry.core.poetry import Poetry
 
 
 class Builder:

--- a/src/poetry/core/masonry/builders/builder.py
+++ b/src/poetry/core/masonry/builders/builder.py
@@ -14,7 +14,7 @@ from typing import Union
 
 
 if TYPE_CHECKING:
-    from poetry.core.poetry import Poetry  # noqa
+    from poetry.core.poetry import Poetry
 
 
 AUTHOR_REGEX = re.compile(r"(?u)^(?P<name>[- .,\w\d'’\"()]+) <(?P<email>.+?)>$")
@@ -290,7 +290,8 @@ class Builder:
 
             if "callable" in specification:
                 warnings.warn(
-                    f"Use of callable in script specification ({name}) is deprecated. Use reference instead.",
+                    f"Use of callable in script specification ({name}) is deprecated."
+                    " Use reference instead.",
                     DeprecationWarning,
                 )
                 specification = {
@@ -328,7 +329,8 @@ class Builder:
 
                 if Path(source).is_absolute():
                     raise RuntimeError(
-                        f"{source} in {name} is an absolute path. Expected relative path."
+                        f"{source} in {name} is an absolute path. Expected relative"
+                        " path."
                     )
 
                 abs_path = Path.joinpath(self._path, source)

--- a/src/poetry/core/masonry/builders/wheel.py
+++ b/src/poetry/core/masonry/builders/wheel.py
@@ -31,7 +31,7 @@ from poetry.core.semver.helpers import parse_constraint
 
 
 if TYPE_CHECKING:
-    from poetry.core.poetry import Poetry  # noqa
+    from poetry.core.poetry import Poetry
 
 wheel_file_template = """\
 Wheel-Version: 1.0

--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -19,10 +19,10 @@ from poetry.core.version.markers import parse_marker
 if TYPE_CHECKING:
     from poetry.core.packages.dependency_group import DependencyGroup
     from poetry.core.packages.types import DependencyTypes
-    from poetry.core.semver.helpers import VersionTypes  # noqa
-    from poetry.core.semver.version import Version  # noqa
-    from poetry.core.spdx.license import License  # noqa
-    from poetry.core.version.markers import BaseMarker  # noqa
+    from poetry.core.semver.helpers import VersionTypes
+    from poetry.core.semver.version import Version
+    from poetry.core.spdx.license import License
+    from poetry.core.version.markers import BaseMarker
 
 AUTHOR_REGEX = re.compile(r"(?u)^(?P<name>[- .,\w\d'’\"()&]+)(?: <(?P<email>.+?)>)?$")
 
@@ -268,7 +268,7 @@ class Package(PackageSpecification):
     @license.setter
     def license(self, value: Optional[Union[str, "License"]]) -> None:
         from poetry.core.spdx.helpers import license_by_id
-        from poetry.core.spdx.license import License  # noqa
+        from poetry.core.spdx.license import License
 
         if value is None or isinstance(value, License):
             self._license = value
@@ -277,7 +277,7 @@ class Package(PackageSpecification):
 
     @property
     def all_classifiers(self) -> List[str]:
-        from poetry.core.semver.version import Version  # noqa
+        from poetry.core.semver.version import Version
 
         classifiers = copy.copy(self.classifiers)
 
@@ -347,7 +347,8 @@ class Package(PackageSpecification):
         import warnings
 
         warnings.warn(
-            "`readme` is deprecated: you are getting only the first readme file. Please use the plural form `readmes`.",
+            "`readme` is deprecated: you are getting only the first readme file. Please"
+            " use the plural form `readmes`.",
             DeprecationWarning,
         )
         return next(iter(self.readmes), None)
@@ -357,7 +358,8 @@ class Package(PackageSpecification):
         import warnings
 
         warnings.warn(
-            "`readme` is deprecated. Please assign a tuple to the plural form `readmes`.",
+            "`readme` is deprecated. Please assign a tuple to the plural form"
+            " `readmes`.",
             DeprecationWarning,
         )
         self.readmes = (path,)

--- a/src/poetry/core/packages/utils/utils.py
+++ b/src/poetry/core/packages/utils/utils.py
@@ -15,13 +15,12 @@ from urllib.request import url2pathname
 
 
 if TYPE_CHECKING:
-    from poetry.core.packages.constraints import BaseConstraint  # noqa
-    from poetry.core.semver.helpers import VersionTypes  # noqa
-    from poetry.core.semver.version import Version  # noqa
-    from poetry.core.semver.version_constraint import VersionConstraint  # noqa
-    from poetry.core.semver.version_range import VersionRange  # noqa
-    from poetry.core.semver.version_union import VersionUnion  # noqa
-    from poetry.core.version.markers import BaseMarker  # noqa
+    from poetry.core.packages.constraints import BaseConstraint
+    from poetry.core.semver.helpers import VersionTypes
+    from poetry.core.semver.version import Version
+    from poetry.core.semver.version_constraint import VersionConstraint
+    from poetry.core.semver.version_union import VersionUnion
+    from poetry.core.version.markers import BaseMarker
 
 
 BZ2_EXTENSIONS = (".tar.bz2", ".tbz")
@@ -32,7 +31,7 @@ ARCHIVE_EXTENSIONS = ZIP_EXTENSIONS + BZ2_EXTENSIONS + TAR_EXTENSIONS + XZ_EXTEN
 SUPPORTED_EXTENSIONS = ZIP_EXTENSIONS + TAR_EXTENSIONS
 
 try:
-    import bz2  # noqa
+    import bz2  # noqa: F401
 
     SUPPORTED_EXTENSIONS += BZ2_EXTENSIONS
 except ImportError:
@@ -40,7 +39,7 @@ except ImportError:
 
 try:
     # Only for Python 3.3+
-    import lzma  # noqa
+    import lzma  # noqa: F401
 
     SUPPORTED_EXTENSIONS += XZ_EXTENSIONS
 except ImportError:
@@ -300,7 +299,7 @@ def get_python_constraint_from_marker(
     from poetry.core.semver.empty_constraint import EmptyConstraint
     from poetry.core.semver.helpers import parse_constraint
     from poetry.core.semver.version import Version
-    from poetry.core.semver.version_range import VersionRange  # noqa
+    from poetry.core.semver.version_range import VersionRange
 
     python_marker = marker.only("python_version", "python_full_version")
     if python_marker.is_any():

--- a/src/poetry/core/semver/empty_constraint.py
+++ b/src/poetry/core/semver/empty_constraint.py
@@ -4,8 +4,8 @@ from poetry.core.semver.version_constraint import VersionConstraint
 
 
 if TYPE_CHECKING:
-    from poetry.core.semver import VersionTypes  # noqa
-    from poetry.core.semver.version import Version  # noqa
+    from poetry.core.semver import VersionTypes
+    from poetry.core.semver.version import Version
 
 
 class EmptyConstraint(VersionConstraint):

--- a/src/poetry/core/semver/helpers.py
+++ b/src/poetry/core/semver/helpers.py
@@ -5,10 +5,10 @@ from typing import Union
 
 
 if TYPE_CHECKING:
-    from poetry.core.semver.empty_constraint import EmptyConstraint  # noqa
-    from poetry.core.semver.version import Version  # noqa
-    from poetry.core.semver.version_range import VersionRange  # noqa
-    from poetry.core.semver.version_union import VersionUnion  # noqa
+    from poetry.core.semver.empty_constraint import EmptyConstraint
+    from poetry.core.semver.version import Version
+    from poetry.core.semver.version_range import VersionRange
+    from poetry.core.semver.version_union import VersionUnion
 
 
 VersionTypes = Union["Version", "VersionRange", "VersionUnion", "EmptyConstraint"]

--- a/src/poetry/core/spdx/data/licenses.json
+++ b/src/poetry/core/spdx/data/licenses.json
@@ -1040,17 +1040,17 @@
     false
   ],
   "LiLiQ-P-1.1": [
-    "Licence Libre du Qu\u00e9bec \u2013 Permissive version 1.1",
+    "Licence Libre du Québec – Permissive version 1.1",
     true,
     false
   ],
   "LiLiQ-R-1.1": [
-    "Licence Libre du Qu\u00e9bec \u2013 R\u00e9ciprocit\u00e9 version 1.1",
+    "Licence Libre du Québec – Réciprocité version 1.1",
     true,
     false
   ],
   "LiLiQ-Rplus-1.1": [
-    "Licence Libre du Qu\u00e9bec \u2013 R\u00e9ciprocit\u00e9 forte version 1.1",
+    "Licence Libre du Québec – Réciprocité forte version 1.1",
     true,
     false
   ],

--- a/src/poetry/core/toml/file.py
+++ b/src/poetry/core/toml/file.py
@@ -7,7 +7,7 @@ from tomlkit.toml_file import TOMLFile as BaseTOMLFile
 
 
 if TYPE_CHECKING:
-    from tomlkit.toml_document import TOMLDocument  # noqa
+    from tomlkit.toml_document import TOMLDocument
 
 
 class TOMLFile(BaseTOMLFile):

--- a/src/poetry/core/utils/_compat.py
+++ b/src/poetry/core/utils/_compat.py
@@ -12,7 +12,7 @@ WINDOWS = sys.platform == "win32"
 try:
     FileNotFoundError
 except NameError:
-    FileNotFoundError = IOError  # noqa
+    FileNotFoundError = IOError
 
 
 def list_to_shell_command(cmd: List[str]) -> str:

--- a/src/poetry/core/version/helpers.py
+++ b/src/poetry/core/version/helpers.py
@@ -7,7 +7,7 @@ from poetry.core.semver.version_union import VersionUnion
 
 
 if TYPE_CHECKING:
-    from poetry.core.semver.version_constraint import VersionConstraint  # noqa
+    from poetry.core.semver.version_constraint import VersionConstraint
 
 PYTHON_VERSION = [
     "2.7.*",

--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -12,9 +12,9 @@ from poetry.core.version.parser import Parser
 
 
 if TYPE_CHECKING:
-    from lark import Tree  # noqa
+    from lark import Tree
 
-    from poetry.core.semver.helpers import VersionTypes  # noqa
+    from poetry.core.semver.helpers import VersionTypes
 
 MarkerTypes = Union[
     "AnyMarker", "EmptyMarker", "SingleMarker", "MultiMarker", "MarkerUnion"

--- a/src/poetry/core/version/pep440/version.py
+++ b/src/poetry/core/version/pep440/version.py
@@ -15,9 +15,9 @@ from poetry.core.version.pep440.segments import ReleaseTag
 
 
 # we use the phase "z" to ensure we always sort this after other phases
-_INF_TAG = ReleaseTag("z", math.inf)  # noqa
+_INF_TAG = ReleaseTag("z", math.inf)
 # we use the phase "" to ensure we always sort this before other phases
-_NEG_INF_TAG = ReleaseTag("", -math.inf)  # noqa
+_NEG_INF_TAG = ReleaseTag("", -math.inf)
 
 
 @dataclasses.dataclass(frozen=True, eq=True, order=True)

--- a/src/poetry/core/version/requirements.py
+++ b/src/poetry/core/version/requirements.py
@@ -34,7 +34,8 @@ class Requirement:
             parsed = _parser.parse(requirement_string)
         except (UnexpectedCharacters, UnexpectedToken) as e:
             raise InvalidRequirement(
-                f"The requirement is invalid: Unexpected character at column {e.column}\n\n{e.get_context(requirement_string)}"
+                "The requirement is invalid: Unexpected character at column"
+                f" {e.column}\n\n{e.get_context(requirement_string)}"
             )
 
         self.name = next(parsed.scan_values(lambda t: t.type == "NAME")).value

--- a/tests/masonry/builders/test_builder.py
+++ b/tests/masonry/builders/test_builder.py
@@ -111,7 +111,8 @@ def test_get_metadata_content():
     assert requires == [
         "cachy[msgpack] (>=0.2.0,<0.3.0)",
         "cleo (>=0.6,<0.7)",
-        'pendulum (>=1.4,<2.0); (python_version ~= "2.7" and sys_platform == "win32" or python_version in "3.4 3.5") and (extra == "time")',
+        'pendulum (>=1.4,<2.0); (python_version ~= "2.7" and sys_platform == "win32" or'
+        ' python_version in "3.4 3.5") and (extra == "time")',
     ]
 
     urls = parsed.get_all("Project-URL")
@@ -159,7 +160,8 @@ def test_metadata_with_url_dependencies():
 
     assert (
         requires_dist
-        == "demo @ https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
+        == "demo @"
+        " https://python-poetry.org/distributions/demo-0.1.0-py2.py3-none-any.whl"
     )
 
 

--- a/tests/masonry/builders/test_sdist.py
+++ b/tests/masonry/builders/test_sdist.py
@@ -325,7 +325,7 @@ def test_prelease():
     assert sdist.exists()
 
 
-@pytest.mark.parametrize("directory", [("extended"), ("extended_legacy_config")])
+@pytest.mark.parametrize("directory", ["extended", "extended_legacy_config"])
 def test_with_c_extensions(directory: str):
     poetry = Factory().create_poetry(project("extended"))
 

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -89,7 +89,8 @@ def test_to_pep_508():
 
     result = dependency.to_pep_508()
     assert (
-        result == "Django (>=1.23,<2.0); "
+        result
+        == "Django (>=1.23,<2.0); "
         'python_version >= "2.7" and python_version < "2.8" '
         'or python_version >= "3.6" and python_version < "4.0"'
     )
@@ -120,8 +121,9 @@ def test_to_pep_508_in_extras():
     dependency.python_versions = "~2.7 || ^3.6"
 
     result = dependency.to_pep_508()
-    assert result == (
-        "Django (>=1.23,<2.0); "
+    assert (
+        result
+        == "Django (>=1.23,<2.0); "
         "("
         'python_version >= "2.7" and python_version < "2.8" '
         'or python_version >= "3.6" and python_version < "4.0"'
@@ -130,8 +132,9 @@ def test_to_pep_508_in_extras():
     )
 
     result = dependency.to_pep_508(with_extras=False)
-    assert result == (
-        "Django (>=1.23,<2.0); "
+    assert (
+        result
+        == "Django (>=1.23,<2.0); "
         'python_version >= "2.7" and python_version < "2.8" '
         'or python_version >= "3.6" and python_version < "4.0"'
     )

--- a/tests/packages/test_main.py
+++ b/tests/packages/test_main.py
@@ -90,8 +90,9 @@ def test_dependency_from_pep_508_complex():
     assert str(dep.constraint) == "2.18.0"
     assert dep.in_extras == ["foo"]
     assert dep.python_versions == ">=2.7 !=3.2.*"
-    assert str(dep.marker) == (
-        'python_version >= "2.7" and python_version != "3.2" '
+    assert (
+        str(dep.marker)
+        == 'python_version >= "2.7" and python_version != "3.2" '
         'and (sys_platform == "win32" or sys_platform == "darwin") '
         'and extra == "foo"'
     )
@@ -149,16 +150,16 @@ def test_dependency_from_pep_508_with_python_version_union_of_multi():
     assert str(dep.constraint) == "2.18.0"
     assert dep.extras == frozenset()
     assert dep.python_versions == ">=2.7 <2.8 || >=3.4 <3.5"
-    assert str(dep.marker) == (
-        'python_version >= "2.7" and python_version < "2.8" '
+    assert (
+        str(dep.marker)
+        == 'python_version >= "2.7" and python_version < "2.8" '
         'or python_version >= "3.4" and python_version < "3.5"'
     )
 
 
 def test_dependency_from_pep_508_with_not_in_op_marker():
     name = (
-        "jinja2 (>=2.7,<2.8)"
-        '; python_version not in "3.0,3.1,3.2" and extra == "export"'
+        'jinja2 (>=2.7,<2.8); python_version not in "3.0,3.1,3.2" and extra == "export"'
     )
 
     dep = Dependency.create_from_pep_508(name)
@@ -185,7 +186,10 @@ def test_dependency_from_pep_508_with_git_url():
 
 
 def test_dependency_from_pep_508_with_git_url_and_subdirectory():
-    name = "django-utils @ git+ssh://git@corp-gitlab.com/corp-utils.git@1.2#subdirectory=package-dir"
+    name = (
+        "django-utils @"
+        " git+ssh://git@corp-gitlab.com/corp-utils.git@1.2#subdirectory=package-dir"
+    )
 
     dep = Dependency.create_from_pep_508(name)
 
@@ -246,8 +250,9 @@ def test_dependency_from_pep_508_with_python_full_version():
     assert str(dep.constraint) == "2.18.0"
     assert dep.extras == frozenset()
     assert dep.python_versions == ">=2.7 <2.8 || >=3.4 <3.5.4"
-    assert str(dep.marker) == (
-        'python_version >= "2.7" and python_version < "2.8" '
+    assert (
+        str(dep.marker)
+        == 'python_version >= "2.7" and python_version < "2.8" '
         'or python_full_version >= "3.4" and python_full_version < "3.5.4"'
     )
 
@@ -271,7 +276,10 @@ def test_dependency_from_pep_508_with_python_full_version_pep440_compatible_rele
 
 
 def test_dependency_from_pep_508_should_not_produce_empty_constraints_for_correct_markers():
-    name = 'pytest-mypy; python_implementation != "PyPy" and python_version <= "3.10" and python_version > "3"'
+    name = (
+        'pytest-mypy; python_implementation != "PyPy" and python_version <= "3.10" and'
+        ' python_version > "3"'
+    )
     dep = Dependency.create_from_pep_508(name)
 
     assert dep.name == "pytest-mypy"
@@ -283,5 +291,6 @@ def test_dependency_from_pep_508_should_not_produce_empty_constraints_for_correc
     assert dep.python_constraint.allows(Version.parse("3.0.1"))
     assert (
         str(dep.marker)
-        == 'platform_python_implementation != "PyPy" and python_version <= "3.10" and python_version > "3"'
+        == 'platform_python_implementation != "PyPy" and python_version <= "3.10" and'
+        ' python_version > "3"'
     )

--- a/tests/packages/test_url_dependency.py
+++ b/tests/packages/test_url_dependency.py
@@ -8,7 +8,10 @@ def test_to_pep_508():
         "https://download.pytorch.org/whl/cpu/torch-1.5.1%2Bcpu-cp38-cp38-linux_x86_64.whl",
     )
 
-    expected = "pytorch @ https://download.pytorch.org/whl/cpu/torch-1.5.1%2Bcpu-cp38-cp38-linux_x86_64.whl"
+    expected = (
+        "pytorch @"
+        " https://download.pytorch.org/whl/cpu/torch-1.5.1%2Bcpu-cp38-cp38-linux_x86_64.whl"
+    )
     assert expected == dependency.to_pep_508()
 
 
@@ -19,5 +22,9 @@ def test_to_pep_508_with_marker():
     )
     dependency.marker = SingleMarker("sys.platform", "linux")
 
-    expected = 'pytorch @ https://download.pytorch.org/whl/cpu/torch-1.5.1%2Bcpu-cp38-cp38-linux_x86_64.whl ; sys_platform == "linux"'
+    expected = (
+        "pytorch @"
+        " https://download.pytorch.org/whl/cpu/torch-1.5.1%2Bcpu-cp38-cp38-linux_x86_64.whl"
+        ' ; sys_platform == "linux"'
+    )
     assert expected == dependency.to_pep_508()

--- a/tests/packages/test_vcs_dependency.py
+++ b/tests/packages/test_vcs_dependency.py
@@ -60,7 +60,10 @@ def test_to_pep_508_in_extras():
     )
     dependency.in_extras.append("foo;")
 
-    expected = 'poetry @ git+https://github.com/python-poetry/poetry.git@b;ar; ; extra == "foo;"'
+    expected = (
+        "poetry @ git+https://github.com/python-poetry/poetry.git@b;ar; ; extra =="
+        ' "foo;"'
+    )
 
     assert expected == dependency.to_pep_508()
 

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -8,9 +8,9 @@ from poetry.core.version.markers import parse_marker
 
 def test_convert_markers():
     marker = parse_marker(
-        'sys_platform == "win32" and python_version < "3.6" '
-        'or sys_platform == "win32" and python_version < "3.6" and python_version >= "3.3" '
-        'or sys_platform == "win32" and python_version < "3.3"'
+        'sys_platform == "win32" and python_version < "3.6" or sys_platform == "win32"'
+        ' and python_version < "3.6" and python_version >= "3.3" or sys_platform =='
+        ' "win32" and python_version < "3.3"'
     )
 
     converted = convert_markers(marker)

--- a/tests/pyproject/test_pyproject_toml.py
+++ b/tests/pyproject/test_pyproject_toml.py
@@ -1,6 +1,6 @@
 import uuid
 
-from pathlib import Path  # noqa
+from pathlib import Path
 
 import pytest
 

--- a/tests/spdx/test_license.py
+++ b/tests/spdx/test_license.py
@@ -25,8 +25,9 @@ def test_classifier_name_no_classifer():
 def test_classifier():
     license = license_by_id("lgpl-3.0-or-later")
 
-    assert license.classifier == (
-        "License :: "
+    assert (
+        license.classifier
+        == "License :: "
         "OSI Approved :: "
         "GNU Lesser General Public License v3 or later (LGPLv3+)"
     )

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -93,7 +93,8 @@ def test_create_poetry():
     assert functools32.pretty_constraint == "^3.2.3"
     assert (
         str(functools32.marker)
-        == 'python_version ~= "2.7" and sys_platform == "win32" or python_version in "3.4 3.5"'
+        == 'python_version ~= "2.7" and sys_platform == "win32" or python_version in'
+        ' "3.4 3.5"'
     )
 
     dataclasses = dependencies["dataclasses"]
@@ -196,7 +197,8 @@ def test_strict_validation_fails_on_readme_files_with_unmatching_types():
 
     assert Factory.validate(content, strict=True) == {
         "errors": [
-            "Declared README files must be of same type: found text/markdown, text/x-rst"
+            "Declared README files must be of same type: found text/markdown,"
+            " text/x-rst"
         ],
         "warnings": [],
     }

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -56,11 +56,17 @@ isort@ git+git://github.com/timothycrosley/isort.git@e63ae06ec7d70b06df9e5283576
         "msgpack-python>=0.5.0.0,<0.6.0.0",
         "pyparsing>=2.2.0.0,<3.0.0.0",
         "requests-toolbelt>=0.8.0.0,<0.9.0.0",
-        'typing>=3.6.0.0,<4.0.0.0 ; (python_version >= "2.7.0.0" and python_version < "2.8.0.0") or (python_version >= "3.4.0.0" and python_version < "3.5.0.0")',
-        'virtualenv>=15.2.0.0,<16.0.0.0 ; python_version >= "2.7.0.0" and python_version < "2.8.0.0"',
-        'pathlib2>=2.3.0.0,<3.0.0.0 ; python_version >= "2.7.0.0" and python_version < "2.8.0.0"',
-        'zipfile36>=0.1.0.0,<0.2.0.0 ; python_version >= "3.4.0.0" and python_version < "3.6.0.0"',
-        'isort@ git+git://github.com/timothycrosley/isort.git@e63ae06ec7d70b06df9e528357650281a3d3ec22#egg=isort ; extra == "dev"',
+        'typing>=3.6.0.0,<4.0.0.0 ; (python_version >= "2.7.0.0" and python_version <'
+        ' "2.8.0.0") or (python_version >= "3.4.0.0" and python_version < "3.5.0.0")',
+        'virtualenv>=15.2.0.0,<16.0.0.0 ; python_version >= "2.7.0.0" and'
+        ' python_version < "2.8.0.0"',
+        'pathlib2>=2.3.0.0,<3.0.0.0 ; python_version >= "2.7.0.0" and python_version <'
+        ' "2.8.0.0"',
+        'zipfile36>=0.1.0.0,<0.2.0.0 ; python_version >= "3.4.0.0" and python_version <'
+        ' "3.6.0.0"',
+        "isort@"
+        " git+git://github.com/timothycrosley/isort.git@e63ae06ec7d70b06df9e528357650281a3d3ec22#egg=isort"
+        ' ; extra == "dev"',
     ]
     assert result == expected
 

--- a/tests/vcs/test_vcs.py
+++ b/tests/vcs/test_vcs.py
@@ -382,7 +382,10 @@ def test_git_rev_parse_raises_error_on_invalid_repository():
 
 @pytest.mark.skipif(
     not WINDOWS,
-    reason="Retrieving the complete path to git is only necessary on Windows, for security reasons",
+    reason=(
+        "Retrieving the complete path to git is only necessary on Windows, for security"
+        " reasons"
+    ),
 )
 def test_ensure_absolute_path_to_git(mocker: "MockerFixture"):
     _reset_executable()
@@ -410,7 +413,10 @@ def test_ensure_absolute_path_to_git(mocker: "MockerFixture"):
 
 @pytest.mark.skipif(
     not WINDOWS,
-    reason="Retrieving the complete path to git is only necessary on Windows, for security reasons",
+    reason=(
+        "Retrieving the complete path to git is only necessary on Windows, for security"
+        " reasons"
+    ),
 )
 def test_ensure_existing_git_executable_is_found(mocker: "MockerFixture"):
     mock = mocker.patch.object(subprocess, "check_output", return_value=b"")

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -41,7 +41,8 @@ def test_single_marker():
     assert str(m.constraint) == "<2.7.0 || >=2.8.0,<3.0.0 || >=3.2.0"
 
     m = parse_marker(
-        "platform_machine in 'x86_64 X86_64 aarch64 AARCH64 ppc64le PPC64LE amd64 AMD64 win32 WIN32'"
+        "platform_machine in 'x86_64 X86_64 aarch64 AARCH64 ppc64le PPC64LE amd64 AMD64"
+        " win32 WIN32'"
     )
 
     assert isinstance(m, SingleMarker)
@@ -50,22 +51,28 @@ def test_single_marker():
         m.constraint_string
         == "in x86_64 X86_64 aarch64 AARCH64 ppc64le PPC64LE amd64 AMD64 win32 WIN32"
     )
-    assert str(m.constraint) == (
-        "x86_64 || X86_64 || aarch64 || AARCH64 || ppc64le || PPC64LE || amd64 || AMD64 || win32 || WIN32"
+    assert (
+        str(m.constraint)
+        == "x86_64 || X86_64 || aarch64 || AARCH64 || ppc64le || PPC64LE || amd64 ||"
+        " AMD64 || win32 || WIN32"
     )
 
     m = parse_marker(
-        "platform_machine not in 'x86_64 X86_64 aarch64 AARCH64 ppc64le PPC64LE amd64 AMD64 win32 WIN32'"
+        "platform_machine not in 'x86_64 X86_64 aarch64 AARCH64 ppc64le PPC64LE amd64"
+        " AMD64 win32 WIN32'"
     )
 
     assert isinstance(m, SingleMarker)
     assert m.name == "platform_machine"
     assert (
         m.constraint_string
-        == "not in x86_64 X86_64 aarch64 AARCH64 ppc64le PPC64LE amd64 AMD64 win32 WIN32"
+        == "not in x86_64 X86_64 aarch64 AARCH64 ppc64le PPC64LE amd64 AMD64 win32"
+        " WIN32"
     )
-    assert str(m.constraint) == (
-        "!=x86_64, !=X86_64, !=aarch64, !=AARCH64, !=ppc64le, !=PPC64LE, !=amd64, !=AMD64, !=win32, !=WIN32"
+    assert (
+        str(m.constraint)
+        == "!=x86_64, !=X86_64, !=aarch64, !=AARCH64, !=ppc64le, !=PPC64LE, !=amd64,"
+        " !=AMD64, !=win32, !=WIN32"
     )
 
 
@@ -99,7 +106,8 @@ def test_single_marker_intersect_with_multi():
     )
     assert (
         str(intersection)
-        == 'implementation_name == "cpython" and python_version >= "3.6" and sys_platform == "darwin"'
+        == 'implementation_name == "cpython" and python_version >= "3.6" and'
+        ' sys_platform == "darwin"'
     )
 
 
@@ -163,7 +171,8 @@ def test_single_marker_union_with_multi():
     )
     assert (
         str(union)
-        == 'implementation_name == "cpython" and python_version >= "3.6" or sys_platform == "darwin"'
+        == 'implementation_name == "cpython" and python_version >= "3.6" or'
+        ' sys_platform == "darwin"'
     )
 
 
@@ -184,7 +193,8 @@ def test_single_marker_union_with_union():
     )
     assert (
         str(union)
-        == 'implementation_name == "cpython" or python_version >= "3.6" or sys_platform == "darwin"'
+        == 'implementation_name == "cpython" or python_version >= "3.6" or sys_platform'
+        ' == "darwin"'
     )
 
 
@@ -240,8 +250,9 @@ def test_multi_marker_intersect_multi():
     intersection = m.intersect(
         parse_marker('python_version >= "3.6" and os_name == "Windows"')
     )
-    assert str(intersection) == (
-        'sys_platform == "darwin" and implementation_name == "cpython" '
+    assert (
+        str(intersection)
+        == 'sys_platform == "darwin" and implementation_name == "cpython" '
         'and python_version >= "3.6" and os_name == "Windows"'
     )
 
@@ -251,11 +262,14 @@ def test_multi_marker_intersect_multi_with_overlapping_constraints():
 
     intersection = m.intersect(
         parse_marker(
-            'python_version <= "3.4" and os_name == "Windows" and sys_platform == "darwin"'
+            'python_version <= "3.4" and os_name == "Windows" and sys_platform =='
+            ' "darwin"'
         )
     )
-    assert str(intersection) == (
-        'sys_platform == "darwin" and python_version <= "3.4" and os_name == "Windows"'
+    assert (
+        str(intersection)
+        == 'sys_platform == "darwin" and python_version <= "3.4" and os_name =='
+        ' "Windows"'
     )
 
 
@@ -265,8 +279,9 @@ def test_multi_marker_union_multi():
     intersection = m.union(
         parse_marker('python_version >= "3.6" and os_name == "Windows"')
     )
-    assert str(intersection) == (
-        'sys_platform == "darwin" and implementation_name == "cpython" '
+    assert (
+        str(intersection)
+        == 'sys_platform == "darwin" and implementation_name == "cpython" '
         'or python_version >= "3.6" and os_name == "Windows"'
     )
 
@@ -277,8 +292,9 @@ def test_multi_marker_union_with_union():
     intersection = m.union(
         parse_marker('python_version >= "3.6" or os_name == "Windows"')
     )
-    assert str(intersection) == (
-        'python_version >= "3.6" or os_name == "Windows"'
+    assert (
+        str(intersection)
+        == 'python_version >= "3.6" or os_name == "Windows"'
         ' or sys_platform == "darwin" and implementation_name == "cpython"'
     )
 
@@ -295,7 +311,8 @@ def test_marker_union():
 
 def test_marker_union_deduplicate():
     m = parse_marker(
-        'sys_platform == "darwin" or implementation_name == "cpython" or sys_platform == "darwin"'
+        'sys_platform == "darwin" or implementation_name == "cpython" or sys_platform'
+        ' == "darwin"'
     )
 
     assert str(m) == 'sys_platform == "darwin" or implementation_name == "cpython"'
@@ -305,8 +322,9 @@ def test_marker_union_intersect_single_marker():
     m = parse_marker('sys_platform == "darwin" or python_version < "3.4"')
 
     intersection = m.intersect(parse_marker('implementation_name == "cpython"'))
-    assert str(intersection) == (
-        'sys_platform == "darwin" and implementation_name == "cpython" '
+    assert (
+        str(intersection)
+        == 'sys_platform == "darwin" and implementation_name == "cpython" '
         'or python_version < "3.4" and implementation_name == "cpython"'
     )
 
@@ -317,14 +335,16 @@ def test_marker_union_intersect_single_with_overlapping_constraints():
     intersection = m.intersect(parse_marker('python_version <= "3.6"'))
     assert (
         str(intersection)
-        == 'sys_platform == "darwin" and python_version <= "3.6" or python_version < "3.4"'
+        == 'sys_platform == "darwin" and python_version <= "3.6" or python_version <'
+        ' "3.4"'
     )
 
     m = parse_marker('sys_platform == "darwin" or python_version < "3.4"')
     intersection = m.intersect(parse_marker('sys_platform == "darwin"'))
     assert (
         str(intersection)
-        == 'sys_platform == "darwin" or python_version < "3.4" and sys_platform == "darwin"'
+        == 'sys_platform == "darwin" or python_version < "3.4" and sys_platform =='
+        ' "darwin"'
     )
 
 
@@ -334,8 +354,9 @@ def test_marker_union_intersect_marker_union():
     intersection = m.intersect(
         parse_marker('implementation_name == "cpython" or os_name == "Windows"')
     )
-    assert str(intersection) == (
-        'sys_platform == "darwin" and implementation_name == "cpython" '
+    assert (
+        str(intersection)
+        == 'sys_platform == "darwin" and implementation_name == "cpython" '
         'or sys_platform == "darwin" and os_name == "Windows" or '
         'python_version < "3.4" and implementation_name == "cpython" or '
         'python_version < "3.4" and os_name == "Windows"'
@@ -366,9 +387,11 @@ def test_marker_union_intersect_multi_marker():
     intersection = m.intersect(
         parse_marker('implementation_name == "cpython" and os_name == "Windows"')
     )
-    assert str(intersection) == (
-        'implementation_name == "cpython" and os_name == "Windows" and sys_platform == "darwin" '
-        'or implementation_name == "cpython" and os_name == "Windows" and python_version < "3.4"'
+    assert (
+        str(intersection)
+        == 'implementation_name == "cpython" and os_name == "Windows" and sys_platform'
+        ' == "darwin" or implementation_name == "cpython" and os_name == "Windows"'
+        ' and python_version < "3.4"'
     )
 
 
@@ -378,8 +401,9 @@ def test_marker_union_union_with_union():
     union = m.union(
         parse_marker('implementation_name == "cpython" or os_name == "Windows"')
     )
-    assert str(union) == (
-        'sys_platform == "darwin" or python_version < "3.4" '
+    assert (
+        str(union)
+        == 'sys_platform == "darwin" or python_version < "3.4" '
         'or implementation_name == "cpython" or os_name == "Windows"'
     )
 
@@ -388,19 +412,22 @@ def test_marker_union_union_duplicates():
     m = parse_marker('sys_platform == "darwin" or python_version < "3.4"')
 
     union = m.union(parse_marker('sys_platform == "darwin" or os_name == "Windows"'))
-    assert str(union) == (
-        'sys_platform == "darwin" or python_version < "3.4" or os_name == "Windows"'
+    assert (
+        str(union)
+        == 'sys_platform == "darwin" or python_version < "3.4" or os_name == "Windows"'
     )
 
     m = parse_marker('sys_platform == "darwin" or python_version < "3.4"')
 
     union = m.union(
         parse_marker(
-            'sys_platform == "darwin" or os_name == "Windows" or python_version <= "3.6"'
+            'sys_platform == "darwin" or os_name == "Windows" or python_version <='
+            ' "3.6"'
         )
     )
-    assert str(union) == (
-        'sys_platform == "darwin" or python_version <= "3.6" or os_name == "Windows"'
+    assert (
+        str(union)
+        == 'sys_platform == "darwin" or python_version <= "3.6" or os_name == "Windows"'
     )
 
 
@@ -434,13 +461,15 @@ def test_marker_str_conversion_skips_empty_and_any():
     union = MarkerUnion(
         parse_marker("<empty>"),
         parse_marker(
-            'sys_platform == "darwin" or python_version <= "3.6" or os_name == "Windows"'
+            'sys_platform == "darwin" or python_version <= "3.6" or os_name =='
+            ' "Windows"'
         ),
         parse_marker(""),
     )
 
-    assert str(union) == (
-        'sys_platform == "darwin" or python_version <= "3.6" or os_name == "Windows"'
+    assert (
+        str(union)
+        == 'sys_platform == "darwin" or python_version <= "3.6" or os_name == "Windows"'
     )
 
 
@@ -478,17 +507,17 @@ def test_multi_marker_removes_duplicates():
             True,
         ),
         (
-            "python_version ~= '2.7.0' and (os_name == 'foo' or " "os_name == 'bar')",
+            "python_version ~= '2.7.0' and (os_name == 'foo' or os_name == 'bar')",
             {"os_name": "foo", "python_version": "2.7.4"},
             True,
         ),
         (
-            "python_version ~= '2.7.0' and (os_name == 'foo' or " "os_name == 'bar')",
+            "python_version ~= '2.7.0' and (os_name == 'foo' or os_name == 'bar')",
             {"os_name": "bar", "python_version": "2.7.4"},
             True,
         ),
         (
-            "python_version ~= '2.7.0' and (os_name == 'foo' or " "os_name == 'bar')",
+            "python_version ~= '2.7.0' and (os_name == 'foo' or os_name == 'bar')",
             {"os_name": "other", "python_version": "2.7.4"},
             False,
         ),
@@ -504,27 +533,31 @@ def test_multi_marker_removes_duplicates():
             False,
         ),
         (
-            "python_version == '2.5' and platform.python_implementation" "!= 'Jython'",
+            "python_version == '2.5' and platform.python_implementation!= 'Jython'",
             {"python_version": "2.7"},
             False,
         ),
         (
-            "platform_machine in 'x86_64 X86_64 aarch64 AARCH64 ppc64le PPC64LE amd64 AMD64 win32 WIN32'",
+            "platform_machine in 'x86_64 X86_64 aarch64 AARCH64 ppc64le PPC64LE amd64"
+            " AMD64 win32 WIN32'",
             {"platform_machine": "foo"},
             False,
         ),
         (
-            "platform_machine in 'x86_64 X86_64 aarch64 AARCH64 ppc64le PPC64LE amd64 AMD64 win32 WIN32'",
+            "platform_machine in 'x86_64 X86_64 aarch64 AARCH64 ppc64le PPC64LE amd64"
+            " AMD64 win32 WIN32'",
             {"platform_machine": "x86_64"},
             True,
         ),
         (
-            "platform_machine not in 'x86_64 X86_64 aarch64 AARCH64 ppc64le PPC64LE amd64 AMD64 win32 WIN32'",
+            "platform_machine not in 'x86_64 X86_64 aarch64 AARCH64 ppc64le PPC64LE"
+            " amd64 AMD64 win32 WIN32'",
             {"platform_machine": "foo"},
             True,
         ),
         (
-            "platform_machine not in 'x86_64 X86_64 aarch64 AARCH64 ppc64le PPC64LE amd64 AMD64 win32 WIN32'",
+            "platform_machine not in 'x86_64 X86_64 aarch64 AARCH64 ppc64le PPC64LE"
+            " amd64 AMD64 win32 WIN32'",
             {"platform_machine": "x86_64"},
             False,
         ),
@@ -563,15 +596,18 @@ def test_parse_version_like_markers(marker: str, env: Dict[str, str]):
             'python_version >= "3.6"',
         ),
         (
-            'python_version >= "3.6" and (extra == "foo" or extra == "bar") or implementation_name == "pypy"',
+            'python_version >= "3.6" and (extra == "foo" or extra == "bar") or'
+            ' implementation_name == "pypy"',
             'python_version >= "3.6" or implementation_name == "pypy"',
         ),
         (
-            'python_version >= "3.6" and extra == "foo" or implementation_name == "pypy" and extra == "bar"',
+            'python_version >= "3.6" and extra == "foo" or implementation_name =='
+            ' "pypy" and extra == "bar"',
             'python_version >= "3.6" or implementation_name == "pypy"',
         ),
         (
-            'python_version >= "3.6" or extra == "foo" and implementation_name == "pypy" or extra == "bar"',
+            'python_version >= "3.6" or extra == "foo" and implementation_name =='
+            ' "pypy" or extra == "bar"',
             'python_version >= "3.6" or implementation_name == "pypy"',
         ),
     ],
@@ -598,17 +634,20 @@ def test_without_extras(marker: str, expected: str):
             '(extra == "foo" or extra == "bar")',
         ),
         (
-            'python_version >= "3.6" and (extra == "foo" or extra == "bar") or implementation_name == "pypy"',
+            'python_version >= "3.6" and (extra == "foo" or extra == "bar") or'
+            ' implementation_name == "pypy"',
             "python_version",
             '(extra == "foo" or extra == "bar") or implementation_name == "pypy"',
         ),
         (
-            'python_version >= "3.6" and extra == "foo" or implementation_name == "pypy" and extra == "bar"',
+            'python_version >= "3.6" and extra == "foo" or implementation_name =='
+            ' "pypy" and extra == "bar"',
             "implementation_name",
             'python_version >= "3.6" and extra == "foo" or extra == "bar"',
         ),
         (
-            'python_version >= "3.6" or extra == "foo" and implementation_name == "pypy" or extra == "bar"',
+            'python_version >= "3.6" or extra == "foo" and implementation_name =='
+            ' "pypy" or extra == "bar"',
             "implementation_name",
             'python_version >= "3.6" or extra == "foo" or extra == "bar"',
         ),
@@ -638,22 +677,26 @@ def test_exclude(marker: str, excluded: str, expected: str):
             '(extra == "foo" or extra == "bar")',
         ),
         (
-            'python_version >= "3.6" and (extra == "foo" or extra == "bar") or implementation_name == "pypy"',
+            'python_version >= "3.6" and (extra == "foo" or extra == "bar") or'
+            ' implementation_name == "pypy"',
             ["implementation_name"],
             'implementation_name == "pypy"',
         ),
         (
-            'python_version >= "3.6" and extra == "foo" or implementation_name == "pypy" and extra == "bar"',
+            'python_version >= "3.6" and extra == "foo" or implementation_name =='
+            ' "pypy" and extra == "bar"',
             ["implementation_name"],
             'implementation_name == "pypy"',
         ),
         (
-            'python_version >= "3.6" or extra == "foo" and implementation_name == "pypy" or extra == "bar"',
+            'python_version >= "3.6" or extra == "foo" and implementation_name =='
+            ' "pypy" or extra == "bar"',
             ["implementation_name"],
             'implementation_name == "pypy"',
         ),
         (
-            'python_version >= "3.6" or extra == "foo" and implementation_name == "pypy" or extra == "bar"',
+            'python_version >= "3.6" or extra == "foo" and implementation_name =='
+            ' "pypy" or extra == "bar"',
             ["implementation_name", "python_version"],
             'python_version >= "3.6" or implementation_name == "pypy"',
         ),
@@ -711,7 +754,8 @@ def test_invert(marker: str, inverse: str):
     "marker, expected",
     [
         (
-            'python_version >= "3.6" or python_version < "3.7" or python_version < "3.6"',
+            'python_version >= "3.6" or python_version < "3.7" or python_version <'
+            ' "3.6"',
             'python_version >= "3.6" or python_version < "3.7"',
         ),
     ],

--- a/tests/version/test_requirements.py
+++ b/tests/version/test_requirements.py
@@ -89,7 +89,8 @@ def assert_requirement(
             },
         ),
         (
-            "foo @ https://example.com/name;v=1.1/?query=foo&bar=baz#blah ; python_version=='3.4'",
+            "foo @ https://example.com/name;v=1.1/?query=foo&bar=baz#blah ;"
+            " python_version=='3.4'",
             {
                 "name": "foo",
                 "url": "https://example.com/name;v=1.1/?query=foo&bar=baz#blah",
@@ -97,11 +98,15 @@ def assert_requirement(
             },
         ),
         (
-            'foo (>=1.2.3) ; python_version >= "2.7" and python_version < "2.8" or python_version >= "3.4" and python_version < "3.5"',
+            'foo (>=1.2.3) ; python_version >= "2.7" and python_version < "2.8" or'
+            ' python_version >= "3.4" and python_version < "3.5"',
             {
                 "name": "foo",
                 "constraint": ">=1.2.3",
-                "marker": 'python_version >= "2.7" and python_version < "2.8" or python_version >= "3.4" and python_version < "3.5"',
+                "marker": (
+                    'python_version >= "2.7" and python_version < "2.8" or'
+                    ' python_version >= "3.4" and python_version < "3.5"'
+                ),
             },
         ),
     ],

--- a/tests/version/test_version_pep440.py
+++ b/tests/version/test_version_pep440.py
@@ -170,7 +170,7 @@ def test_pep440_parse_text(text: str, result: PEP440Version):
 
 
 @pytest.mark.parametrize(
-    "text", ["1.2.3.dev1-1" "example-1" "1.2.3-random1" "1.2.3-1-1"]
+    "text", ["1.2.3.dev1-1", "example-1", "1.2.3-random1", "1.2.3-1-1"]
 )
 def test_pep440_parse_text_invalid_versions(text: str):
     with pytest.raises(InvalidVersion):


### PR DESCRIPTION
* sort and update pre-commit repos to be similar to the one used in `poetry`.
* add some more `pre-commit` ids
* add `yesqa`repo
* add `pygrep` repo
* use `experimental_string_processing` parameter for `black

Relates to: https://github.com/python-poetry/poetry/issues/4776