### PR TITLE
Introduce support for relative include of non-package modules ("workspaces")

### DIFF
--- a/src/poetry/core/masonry/builders/builder.py
+++ b/src/poetry/core/masonry/builders/builder.py
@@ -206,9 +206,15 @@ class Builder:
                     workspace=self._workspace,
                 )
 
-                if self.is_excluded(
-                    include_file.relative_to_project_root()
-                ) and isinstance(include, PackageInclude):
+                include_file_path = (
+                    include_file.relative_to_workspace()
+                    if self._workspace
+                    else include_file.relative_to_project_root()
+                )
+
+                if self.is_excluded(include_file_path) and isinstance(
+                    include, PackageInclude
+                ):
                     continue
 
                 if file.suffix == ".pyc":

--- a/src/poetry/core/masonry/builders/builder.py
+++ b/src/poetry/core/masonry/builders/builder.py
@@ -371,6 +371,9 @@ class Builder:
 
         return {"name": name, "email": email}
 
+    def is_in_workspace(self) -> bool:
+        return self._poetry.workspace is not None
+
 
 class BuildIncludeFile:
     def __init__(
@@ -426,6 +429,9 @@ class BuildIncludeFile:
 
     def calculated_path(self) -> Path:
         if self.workspace:
+            if self.path.is_relative_to(self.project_root):
+                return self.relative_to_project_root()
+
             return namespacing.create_namespaced_path(self.path, self.workspace)
 
         return self.relative_to_source_root()

--- a/src/poetry/core/masonry/builders/builder.py
+++ b/src/poetry/core/masonry/builders/builder.py
@@ -9,6 +9,8 @@ from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from poetry.core.utils import namespacing
+
 
 if TYPE_CHECKING:
     from poetry.core.poetry import Poetry
@@ -415,3 +417,9 @@ class BuildIncludeFile:
             return self.path.relative_to(self.workspace)
 
         return self.path
+
+    def calculated_path(self) -> Path:
+        if self.workspace:
+            return namespacing.create_namespaced_path(self.path, self.workspace)
+
+        return self.relative_to_source_root()

--- a/src/poetry/core/masonry/builders/builder.py
+++ b/src/poetry/core/masonry/builders/builder.py
@@ -431,7 +431,7 @@ class BuildIncludeFile:
     def calculated_path(self) -> Path:
         if self.workspace is not None:
             if helpers.is_path_relative_to_other(self.path, self.project_root):
-                return self.relative_to_project_root()
+                return self.relative_to_source_root()
 
             return namespacing.create_namespaced_path(self.path, self.workspace)
 

--- a/src/poetry/core/masonry/builders/builder.py
+++ b/src/poetry/core/masonry/builders/builder.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from poetry.core.utils import helpers
 from poetry.core.utils import namespacing
 
 
@@ -429,7 +430,7 @@ class BuildIncludeFile:
 
     def calculated_path(self) -> Path:
         if self.workspace:
-            if self.path.is_relative_to(self.project_root):
+            if helpers.is_path_relative_to_other(self.path, self.project_root):
                 return self.relative_to_project_root()
 
             return namespacing.create_namespaced_path(self.path, self.workspace)

--- a/src/poetry/core/masonry/builders/builder.py
+++ b/src/poetry/core/masonry/builders/builder.py
@@ -429,7 +429,7 @@ class BuildIncludeFile:
         return self.path
 
     def calculated_path(self) -> Path:
-        if self.workspace:
+        if self.workspace is not None:
             if helpers.is_path_relative_to_other(self.path, self.project_root):
                 return self.relative_to_project_root()
 

--- a/src/poetry/core/masonry/builders/builder.py
+++ b/src/poetry/core/masonry/builders/builder.py
@@ -193,7 +193,7 @@ class Builder:
                             if not current_file.is_dir():
                                 include_file_path = (
                                     include_file.relative_to_workspace()
-                                    if self._workspace
+                                    if self.is_in_workspace()
                                     else include_file.relative_to_source_root()
                                 )
                                 if not self.is_excluded(include_file_path):
@@ -209,7 +209,7 @@ class Builder:
 
                 include_file_path = (
                     include_file.relative_to_workspace()
-                    if self._workspace
+                    if self.is_in_workspace()
                     else include_file.relative_to_project_root()
                 )
 
@@ -373,7 +373,7 @@ class Builder:
         return {"name": name, "email": email}
 
     def is_in_workspace(self) -> bool:
-        return self._poetry.workspace is not None
+        return self._workspace is not None
 
 
 class BuildIncludeFile:

--- a/src/poetry/core/masonry/builders/sdist.py
+++ b/src/poetry/core/masonry/builders/sdist.py
@@ -141,7 +141,11 @@ class SdistBuilder(Builder):
                     if self.is_in_workspace():
                         ns_path = include.get_namespace_path()
                         pkg_dir = include.get_package_dir()
-                        _packages = _packages if pkg_dir else [namespacing.convert_to_namespace(ns_path)]
+                        _packages = (
+                            _packages
+                            if pkg_dir
+                            else [namespacing.convert_to_namespace(ns_path)]
+                        )
 
                     if pkg_dir is not None:
                         pkg_root = os.path.relpath(pkg_dir, str(self._path))

--- a/src/poetry/core/masonry/builders/sdist.py
+++ b/src/poetry/core/masonry/builders/sdist.py
@@ -19,6 +19,7 @@ from typing import Iterator
 from poetry.core.masonry.builders.builder import Builder
 from poetry.core.masonry.builders.builder import BuildIncludeFile
 from poetry.core.masonry.utils.helpers import distribution_name
+from poetry.core.utils import namespacing
 
 
 if TYPE_CHECKING:
@@ -136,6 +137,11 @@ class SdistBuilder(Builder):
             if isinstance(include, PackageInclude):
                 if include.is_package():
                     pkg_dir, _packages, _package_data = self.find_packages(include)
+
+                    if self.is_in_workspace():
+                        ns_path = include.get_namespace_path()
+                        pkg_dir = None
+                        _packages = [namespacing.convert_to_namespace(ns_path)]
 
                     if pkg_dir is not None:
                         pkg_root = os.path.relpath(pkg_dir, str(self._path))

--- a/src/poetry/core/masonry/builders/sdist.py
+++ b/src/poetry/core/masonry/builders/sdist.py
@@ -78,10 +78,10 @@ class SdistBuilder(Builder):
 
             files_to_add = self.find_files_to_add(exclude_build=False)
 
-            for file in sorted(files_to_add, key=lambda x: x.relative_to_source_root()):
+            for file in sorted(files_to_add, key=lambda x: x.calculated_path()):
                 tar_info = tar.gettarinfo(
                     str(file.path),
-                    arcname=pjoin(tar_dir, str(file.relative_to_source_root())),
+                    arcname=pjoin(tar_dir, str(file.calculated_path())),
                 )
                 tar_info = self.clean_tarinfo(tar_info)
 
@@ -339,7 +339,7 @@ class SdistBuilder(Builder):
                 path=additional_file, project_root=self._path, source_root=self._path, workspace=self._workspace
             )
             if file.path.exists():
-                logger.debug(f"Adding: {file.relative_to_source_root()}")
+                logger.debug(f"Adding: {file.calculated_path()}")
                 to_add.add(file)
 
         return to_add

--- a/src/poetry/core/masonry/builders/sdist.py
+++ b/src/poetry/core/masonry/builders/sdist.py
@@ -336,7 +336,7 @@ class SdistBuilder(Builder):
 
         for additional_file in additional_files:
             file = BuildIncludeFile(
-                path=additional_file, project_root=self._path, source_root=self._path
+                path=additional_file, project_root=self._path, source_root=self._path, workspace=self._workspace
             )
             if file.path.exists():
                 logger.debug(f"Adding: {file.relative_to_source_root()}")

--- a/src/poetry/core/masonry/builders/sdist.py
+++ b/src/poetry/core/masonry/builders/sdist.py
@@ -97,26 +97,17 @@ class SdistBuilder(Builder):
                 dist_pyproject = create_valid_dist_project_file(
                     self._poetry.pyproject.data
                 )
-                tar_info = tarfile.TarInfo(pjoin(tar_dir, "pyproject.toml"))
-                tar_info.size = len(dist_pyproject)
-                tar_info.mtime = 0
-                tar_info = self.clean_tarinfo(tar_info)
+                tar_info = self.create_tarinfo(tar_dir, "pyproject.toml", dist_pyproject)
                 tar.addfile(tar_info, BytesIO(dist_pyproject))
 
             if self._poetry.package.build_should_generate_setup():
                 setup = self.build_setup()
-                tar_info = tarfile.TarInfo(pjoin(tar_dir, "setup.py"))
-                tar_info.size = len(setup)
-                tar_info.mtime = 0
-                tar_info = self.clean_tarinfo(tar_info)
+                tar_info = self.create_tarinfo(tar_dir, "setup.py", setup)
                 tar.addfile(tar_info, BytesIO(setup))
 
             pkg_info = self.build_pkg_info()
 
-            tar_info = tarfile.TarInfo(pjoin(tar_dir, "PKG-INFO"))
-            tar_info.size = len(pkg_info)
-            tar_info.mtime = 0
-            tar_info = self.clean_tarinfo(tar_info)
+            tar_info = self.create_tarinfo(tar_dir, "PKG-INFO", pkg_info)
             tar.addfile(tar_info, BytesIO(pkg_info))
         finally:
             tar.close()
@@ -124,6 +115,12 @@ class SdistBuilder(Builder):
 
         logger.info(f"Built <comment>{target.name}</comment>")
         return target
+
+    def create_tarinfo(self, tar_dir: str, name: str, data: bytes) -> tarfile.TarInfo:
+        tar_info = tarfile.TarInfo(pjoin(tar_dir, name))
+        tar_info.size = len(data)
+        tar_info.mtime = 0
+        return self.clean_tarinfo(tar_info)
 
     def build_setup(self) -> bytes:
         from poetry.core.masonry.utils.package_include import PackageInclude

--- a/src/poetry/core/masonry/builders/sdist.py
+++ b/src/poetry/core/masonry/builders/sdist.py
@@ -138,15 +138,6 @@ class SdistBuilder(Builder):
                 if include.is_package():
                     pkg_dir, _packages, _package_data = self.find_packages(include)
 
-                    if self.is_in_workspace():
-                        ns_path = include.get_namespace_path()
-                        pkg_dir = include.get_package_dir()
-                        _packages = (
-                            _packages
-                            if pkg_dir
-                            else [namespacing.convert_to_namespace(ns_path)]
-                        )
-
                     if pkg_dir is not None:
                         pkg_root = os.path.relpath(pkg_dir, str(self._path))
                         if "" in package_dir:
@@ -325,6 +316,15 @@ class SdistBuilder(Builder):
 
         # Sort values in pkg_data
         pkg_data = {k: sorted(v) for (k, v) in pkg_data.items() if v}
+
+        if self.is_in_workspace():
+            pkgdir = include.get_package_dir()
+            ns_path = include.get_namespace_path()
+            packages = (
+                packages
+                if pkgdir
+                else [namespacing.convert_to_namespace(ns_path)]
+            )
 
         return pkgdir, sorted(packages), pkg_data
 

--- a/src/poetry/core/masonry/builders/sdist.py
+++ b/src/poetry/core/masonry/builders/sdist.py
@@ -140,8 +140,8 @@ class SdistBuilder(Builder):
 
                     if self.is_in_workspace():
                         ns_path = include.get_namespace_path()
-                        pkg_dir = None
-                        _packages = [namespacing.convert_to_namespace(ns_path)]
+                        pkg_dir = include.get_package_dir()
+                        _packages = _packages if pkg_dir else [namespacing.convert_to_namespace(ns_path)]
 
                     if pkg_dir is not None:
                         pkg_root = os.path.relpath(pkg_dir, str(self._path))

--- a/src/poetry/core/masonry/builders/sdist.py
+++ b/src/poetry/core/masonry/builders/sdist.py
@@ -336,7 +336,10 @@ class SdistBuilder(Builder):
 
         for additional_file in additional_files:
             file = BuildIncludeFile(
-                path=additional_file, project_root=self._path, source_root=self._path, workspace=self._workspace
+                path=additional_file,
+                project_root=self._path,
+                source_root=self._path,
+                workspace=self._workspace,
             )
             if file.path.exists():
                 logger.debug(f"Adding: {file.calculated_path()}")

--- a/src/poetry/core/masonry/builders/sdist.py
+++ b/src/poetry/core/masonry/builders/sdist.py
@@ -321,9 +321,7 @@ class SdistBuilder(Builder):
             pkgdir = include.get_package_dir()
             ns_path = include.get_namespace_path()
             packages = (
-                packages
-                if pkgdir
-                else [namespacing.convert_to_namespace(ns_path)]
+                packages if pkgdir else [namespacing.convert_to_namespace(ns_path)]
             )
 
         return pkgdir, sorted(packages), pkg_data

--- a/src/poetry/core/masonry/builders/sdist.py
+++ b/src/poetry/core/masonry/builders/sdist.py
@@ -97,7 +97,9 @@ class SdistBuilder(Builder):
                 dist_pyproject = create_valid_dist_project_file(
                     self._poetry.pyproject.data
                 )
-                tar_info = self.create_tarinfo(tar_dir, "pyproject.toml", dist_pyproject)
+                tar_info = self.create_tarinfo(
+                    tar_dir, "pyproject.toml", dist_pyproject
+                )
                 tar.addfile(tar_info, BytesIO(dist_pyproject))
 
             if self._poetry.package.build_should_generate_setup():
@@ -331,14 +333,14 @@ class SdistBuilder(Builder):
 
         return pkgdir, sorted(packages), pkg_data
 
-    def find_packages_for_workspace(self, include: PackageInclude) -> tuple[str | None, list[str], dict[str, list[str]]]:
+    def find_packages_for_workspace(
+        self, include: PackageInclude
+    ) -> tuple[str | None, list[str], dict[str, list[str]]]:
         _, packages, package_data = self.find_packages(include)
 
         pkgdir = include.get_package_dir()
         ns_path = include.get_namespace_path()
-        packages = (
-            packages if pkgdir else [namespacing.convert_to_namespace(ns_path)]
-        )
+        packages = packages if pkgdir else [namespacing.convert_to_namespace(ns_path)]
 
         return pkgdir, sorted(packages), package_data
 

--- a/src/poetry/core/masonry/builders/sdist.py
+++ b/src/poetry/core/masonry/builders/sdist.py
@@ -94,7 +94,9 @@ class SdistBuilder(Builder):
                     tar.addfile(tar_info)  # Symlinks & ?
 
             if self.is_in_workspace():
-                dist_pyproject = create_valid_dist_project_file(self._poetry.pyproject.data)
+                dist_pyproject = create_valid_dist_project_file(
+                    self._poetry.pyproject.data
+                )
                 tar_info = tarfile.TarInfo(pjoin(tar_dir, "pyproject.toml"))
                 tar_info.size = len(dist_pyproject)
                 tar_info.mtime = 0

--- a/src/poetry/core/masonry/builders/wheel.py
+++ b/src/poetry/core/masonry/builders/wheel.py
@@ -223,7 +223,7 @@ class WheelBuilder(Builder):
         # Walk the files and compress them,
         # sorting everything so the order is stable.
         for file in sorted(to_add, key=lambda x: x.path):
-            self._add_file(wheel, file.path, file.relative_to_source_root())
+            self._add_file(wheel, file.path, file.calculated_path())
 
     def _write_metadata(self, wheel: zipfile.ZipFile) -> None:
         if (

--- a/src/poetry/core/masonry/utils/dist_toml.py
+++ b/src/poetry/core/masonry/utils/dist_toml.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+
 if TYPE_CHECKING:
     import tomlkit
 

--- a/src/poetry/core/masonry/utils/dist_toml.py
+++ b/src/poetry/core/masonry/utils/dist_toml.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from io import StringIO
-
 import tomlkit
 
 
@@ -42,7 +40,7 @@ def to_valid_dist_packages(data: tomlkit.toml.TOMLDocument) -> list[dict[str, st
     return [to_valid_dist_package(p) for p in packages]
 
 
-def create_valid_dist_project_file(data: tomlkit.toml.TOMLDocument) -> StringIO:
+def create_valid_dist_project_file(data: tomlkit.toml.TOMLDocument) -> bytes:
     """Create a project file
 
     Returns a project file with any relative package includes rearranged,
@@ -60,6 +58,6 @@ def create_valid_dist_project_file(data: tomlkit.toml.TOMLDocument) -> StringIO:
 
     copy["tool"]["poetry"]["packages"].multiline(True)
 
-    content = tomlkit.dumps(copy)
+    content = tomlkit.dumps(copy) or ""
 
-    return StringIO(content)
+    return content.encode()

--- a/src/poetry/core/masonry/utils/dist_toml.py
+++ b/src/poetry/core/masonry/utils/dist_toml.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import tomlkit
+
+
+def to_valid_dist_package(package: dict[str, str]) -> dict[str, str]:
+    """Returns a [tool.poetry] packages list item.
+
+    Rearranges the "include" and "from" attributes for relative included packages,
+    adapting to the sdist build output.
+
+    The output from this function will reflect the build output to:
+    {"include": "foo/bar"}
+    """
+    if ".." not in package.get("from", ""):
+        return package
+
+    return {"include": package["include"]}
+
+
+def to_valid_dist_packages(data: tomlkit.toml.TOMLDocument) -> list[dict[str, str]]:
+    """Returns a [tool.poetry] packages section.
+
+    Rearrange packages with relative paths, to reflect the sdist build output.
+
+    Example: a pyproject.toml with relative packages.
+    packages = [{"include": "foo/bar", from: "../../components"}]
+
+    When building an sdist (using the "poetry build" command),
+    the packages will be collected and copied into a local directory.
+    /dist
+      /setup.py
+      /foo/bar
+
+    The end result in a toml file from running this function would be:
+    packages = [{"include" = "foo/bar"}]
+    """
+    packages = data["tool"]["poetry"]["packages"]
+
+    return [to_valid_dist_package(p) for p in packages]

--- a/src/poetry/core/masonry/utils/include.py
+++ b/src/poetry/core/masonry/utils/include.py
@@ -35,6 +35,10 @@ class Include:
         return self._base
 
     @property
+    def include(self) -> str:
+        return self._include
+
+    @property
     def elements(self) -> list[Path]:
         return self._elements
 

--- a/src/poetry/core/masonry/utils/package_include.py
+++ b/src/poetry/core/masonry/utils/package_include.py
@@ -93,7 +93,10 @@ class PackageInclude(Include):
         return self
 
     def get_namespace_path(self) -> str:
-        if self.source and ".." not in self.source:
-            return "/".join([self.source, self.include])
-
         return self.include
+
+    def get_package_dir(self) -> str | None:
+        if self.source and ".." not in self.source:
+            return self.source
+
+        return None

--- a/src/poetry/core/masonry/utils/package_include.py
+++ b/src/poetry/core/masonry/utils/package_include.py
@@ -91,3 +91,9 @@ class PackageInclude(Include):
                 self._is_module = True
 
         return self
+
+    def get_namespace_path(self) -> str:
+        if self.source and ".." not in self.source:
+            return "/".join([self.source, self.include])
+
+        return self.include

--- a/src/poetry/core/poetry.py
+++ b/src/poetry/core/poetry.py
@@ -6,6 +6,7 @@ from typing import Any
 
 if TYPE_CHECKING:
     from pathlib import Path
+
     from poetry.core.packages.project_package import ProjectPackage
     from poetry.core.pyproject.toml import PyProjectTOML
     from poetry.core.toml import TOMLFile

--- a/src/poetry/core/poetry.py
+++ b/src/poetry/core/poetry.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-
 from typing import TYPE_CHECKING
 from typing import Any
 

--- a/src/poetry/core/poetry.py
+++ b/src/poetry/core/poetry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+
 from typing import TYPE_CHECKING
 from typing import Any
 
@@ -18,8 +19,6 @@ class Poetry:
         local_config: dict[str, Any],
         package: ProjectPackage,
     ) -> None:
-        from pathlib import Path
-
         from poetry.core.pyproject.toml import PyProjectTOML
         from poetry.core.utils import workspaces
 

--- a/src/poetry/core/poetry.py
+++ b/src/poetry/core/poetry.py
@@ -19,6 +19,7 @@ class Poetry:
         package: ProjectPackage,
     ) -> None:
         from pathlib import Path
+
         from poetry.core.pyproject.toml import PyProjectTOML
         from poetry.core.utils import workspaces
 

--- a/src/poetry/core/poetry.py
+++ b/src/poetry/core/poetry.py
@@ -24,7 +24,7 @@ class Poetry:
         self._pyproject = PyProjectTOML(file)
         self._package = package
         self._local_config = local_config
-        self._workspace = workspaces.find_workspace_root(Path.cwd())
+        self._workspace = workspaces.find_workspace_root(file.parent)
 
     @property
     def pyproject(self) -> PyProjectTOML:

--- a/src/poetry/core/poetry.py
+++ b/src/poetry/core/poetry.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
 
 
 if TYPE_CHECKING:
+    from pathlib import Path
     from poetry.core.packages.project_package import ProjectPackage
     from poetry.core.pyproject.toml import PyProjectTOML
     from poetry.core.toml import TOMLFile

--- a/src/poetry/core/poetry.py
+++ b/src/poetry/core/poetry.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Union
 
 
 if TYPE_CHECKING:

--- a/src/poetry/core/poetry.py
+++ b/src/poetry/core/poetry.py
@@ -18,6 +18,7 @@ class Poetry:
         local_config: dict[str, Any],
         package: ProjectPackage,
     ) -> None:
+        from pathlib import Path
         from poetry.core.pyproject.toml import PyProjectTOML
         from poetry.core.utils import workspaces
 

--- a/src/poetry/core/poetry.py
+++ b/src/poetry/core/poetry.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Union
 
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from poetry.core.packages.project_package import ProjectPackage
     from poetry.core.pyproject.toml import PyProjectTOML
     from poetry.core.toml import TOMLFile
@@ -20,8 +19,6 @@ class Poetry:
         local_config: dict[str, Any],
         package: ProjectPackage,
     ) -> None:
-        from pathlib import Path
-
         from poetry.core.pyproject.toml import PyProjectTOML
         from poetry.core.utils import workspaces
 
@@ -47,7 +44,7 @@ class Poetry:
         return self._local_config
 
     @property
-    def workspace(self) -> Union[Path, None]:
+    def workspace(self) -> Path | None:
         return self._workspace
 
     def get_project_config(self, config: str, default: Any = None) -> Any:

--- a/src/poetry/core/poetry.py
+++ b/src/poetry/core/poetry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Union
 
 
 if TYPE_CHECKING:
@@ -20,10 +21,12 @@ class Poetry:
         package: ProjectPackage,
     ) -> None:
         from poetry.core.pyproject.toml import PyProjectTOML
+        from poetry.core.utils import workspaces
 
         self._pyproject = PyProjectTOML(file)
         self._package = package
         self._local_config = local_config
+        self._workspace = workspaces.find_workspace_root(Path.cwd())
 
     @property
     def pyproject(self) -> PyProjectTOML:
@@ -40,6 +43,10 @@ class Poetry:
     @property
     def local_config(self) -> dict[str, Any]:
         return self._local_config
+
+    @property
+    def workspace(self) -> Union[Path, None]:
+        return self._workspace
 
     def get_project_config(self, config: str, default: Any = None) -> Any:
         return self._local_config.get("config", {}).get(config, default)

--- a/src/poetry/core/poetry.py
+++ b/src/poetry/core/poetry.py
@@ -20,6 +20,8 @@ class Poetry:
         local_config: dict[str, Any],
         package: ProjectPackage,
     ) -> None:
+        from pathlib import Path
+
         from poetry.core.pyproject.toml import PyProjectTOML
         from poetry.core.utils import workspaces
 

--- a/src/poetry/core/utils/helpers.py
+++ b/src/poetry/core/utils/helpers.py
@@ -105,3 +105,19 @@ def readme_content_type(path: str | Path) -> str:
         return "text/markdown"
     else:
         return "text/plain"
+
+
+def is_path_relative_to_other(path: Path, other: Path) -> bool:
+    """Return True if the path is relative to another path or False.
+
+    Note:
+    this is a custom implementation of Path.is_relative_to
+    that was introduced to pathlib in Python 3.9.
+
+    This is needed because Poetry support Python versions prior to that.
+    """
+    try:
+        path.relative_to(other)
+        return True
+    except ValueError:
+        return False

--- a/src/poetry/core/utils/namespacing.py
+++ b/src/poetry/core/utils/namespacing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Union
 

--- a/src/poetry/core/utils/namespacing.py
+++ b/src/poetry/core/utils/namespacing.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+from typing import Union
+
+
+def extract_namespace(path: Path, workspace: Path) -> Union[str, None]:
+    grandparent = path.parent.parent
+
+    return grandparent.name if len(grandparent.relative_to(workspace).name) else None
+
+
+def create_namespaced_path(path: Path, workspace: Path) -> Path:
+    namespace = extract_namespace(path, workspace) or ""
+    package_name = path.parent.name
+    module_name = path.name
+
+    namespaced_path = "/".join([namespace, package_name, module_name])
+
+    return Path(namespaced_path)

--- a/src/poetry/core/utils/namespacing.py
+++ b/src/poetry/core/utils/namespacing.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Union
 
 
-def extract_namespace(path: Path, workspace: Path) -> Union[str, None]:
+def extract_namespace(path: Path, workspace: Path) -> str | None:
     grandparent = path.parent.parent
 
     return grandparent.name if len(grandparent.relative_to(workspace).name) else None

--- a/src/poetry/core/utils/namespacing.py
+++ b/src/poetry/core/utils/namespacing.py
@@ -17,3 +17,9 @@ def create_namespaced_path(path: Path, workspace: Path) -> Path:
     namespaced_path = "/".join([namespace, package_name, module_name])
 
     return Path(namespaced_path)
+
+
+def convert_to_namespace(dirs: str) -> str:
+    parts = dirs.split("/")
+
+    return ".".join(parts)

--- a/src/poetry/core/utils/namespacing.py
+++ b/src/poetry/core/utils/namespacing.py
@@ -10,6 +10,23 @@ def extract_namespace(path: Path, workspace: Path) -> str | None:
 
 
 def create_namespaced_path(path: Path, workspace: Path) -> Path:
+    """Create a namespaced path for a package, relative to a workspace.
+
+    Example:
+
+    Given a workspace structure
+    /workspace
+       /components
+         /foo
+          /bar
+           baz.py
+
+    The input:
+    path my_workspace/components/foo/bar/baz.py
+    workspace components
+
+    Returns: foo/bar/baz.py
+    """
     namespace = extract_namespace(path, workspace) or ""
     package_name = path.parent.name
     module_name = path.name
@@ -20,6 +37,10 @@ def create_namespaced_path(path: Path, workspace: Path) -> Path:
 
 
 def convert_to_namespace(dirs: str) -> str:
+    """Convert a directory path string to a Python namespace string
+
+    Example: from foo/bar to foo.bar
+    """
     parts = dirs.split("/")
 
     return ".".join(parts)

--- a/src/poetry/core/utils/workspaces.py
+++ b/src/poetry/core/utils/workspaces.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Union
 

--- a/src/poetry/core/utils/workspaces.py
+++ b/src/poetry/core/utils/workspaces.py
@@ -38,4 +38,8 @@ def find_upwards_dir(cwd: Path, name: str) -> Path | None:
 
 
 def find_workspace_root(cwd: Path) -> Path | None:
+    """Find the workspace root path.
+
+    Navigates upwards a drive directory to find a workspace identifier, if existing.
+    """
     return find_upwards_dir(cwd, workspace_file)

--- a/src/poetry/core/utils/workspaces.py
+++ b/src/poetry/core/utils/workspaces.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
-
-import tomlkit
+from typing import TYPE_CHECKING
 
 from poetry.core.toml import TOMLFile
+
+
+if TYPE_CHECKING:
+    import tomlkit
 
 
 workspace_file = "workspace.toml"

--- a/src/poetry/core/utils/workspaces.py
+++ b/src/poetry/core/utils/workspaces.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+from typing import Union
+
+
+workspace_file = "workspace.toml"
+
+
+def is_repo_root(cwd: Path) -> bool:
+    fullpath = cwd / ".git"
+
+    return fullpath.exists()
+
+
+def find_upwards(cwd: Path, name: str) -> Union[Path, None]:
+    if cwd == Path(cwd.root):
+        return None
+
+    fullpath = cwd / name
+
+    if fullpath.exists():
+        return fullpath
+
+    if is_repo_root(cwd):
+        return None
+
+    return find_upwards(cwd.parent, name)
+
+
+def find_upwards_dir(cwd: Path, name: str) -> Union[Path, None]:
+    fullpath = find_upwards(cwd, name)
+
+    return fullpath.parent if fullpath else None
+
+
+def find_workspace_root(cwd: Path) -> Union[Path, None]:
+    return find_upwards_dir(cwd, workspace_file)

--- a/src/poetry/core/utils/workspaces.py
+++ b/src/poetry/core/utils/workspaces.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Union
 
 
 workspace_file = "workspace.toml"
@@ -13,7 +12,7 @@ def is_repo_root(cwd: Path) -> bool:
     return fullpath.exists()
 
 
-def find_upwards(cwd: Path, name: str) -> Union[Path, None]:
+def find_upwards(cwd: Path, name: str) -> Path | None:
     if cwd == Path(cwd.root):
         return None
 
@@ -28,11 +27,11 @@ def find_upwards(cwd: Path, name: str) -> Union[Path, None]:
     return find_upwards(cwd.parent, name)
 
 
-def find_upwards_dir(cwd: Path, name: str) -> Union[Path, None]:
+def find_upwards_dir(cwd: Path, name: str) -> Path | None:
     fullpath = find_upwards(cwd, name)
 
     return fullpath.parent if fullpath else None
 
 
-def find_workspace_root(cwd: Path) -> Union[Path, None]:
+def find_workspace_root(cwd: Path) -> Path | None:
     return find_upwards_dir(cwd, workspace_file)

--- a/src/poetry/core/utils/workspaces.py
+++ b/src/poetry/core/utils/workspaces.py
@@ -6,6 +6,10 @@ from pathlib import Path
 workspace_file = "workspace.toml"
 
 
+def is_drive_root(cwd: Path) -> bool:
+    return cwd == Path(cwd.root) or cwd == cwd.parent
+
+
 def is_repo_root(cwd: Path) -> bool:
     fullpath = cwd / ".git"
 
@@ -13,7 +17,7 @@ def is_repo_root(cwd: Path) -> bool:
 
 
 def find_upwards(cwd: Path, name: str) -> Path | None:
-    if cwd == Path(cwd.root):
+    if is_drive_root(cwd):
         return None
 
     fullpath = cwd / name

--- a/tests/masonry/builders/test_buildincludefile.py
+++ b/tests/masonry/builders/test_buildincludefile.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+
+from poetry.core.masonry.builders.builder import BuildIncludeFile
+
+
+def test_path_is_relative_to_workspace() -> None:
+    expected = "components/foo/bar.py"
+
+    path = Path(f"workspace/{expected}").resolve()
+    project_root = Path("workspace/projects/my_project").resolve()
+    source_root = None
+    workspace = Path("workspace").resolve()
+
+    bif = BuildIncludeFile(path, project_root, source_root, workspace)
+
+    assert bif.relative_to_workspace() == Path(expected)
+
+
+def test_relative_path_with_source_root_is_relative_to_workspace() -> None:
+    expected = "components/foo/bar.py"
+
+    project_root = Path("workspace/projects/my_project").resolve()
+    source_root = Path("workspace").resolve()
+    workspace = Path("workspace").resolve()
+
+    bif = BuildIncludeFile(expected, project_root, source_root, workspace)
+
+    assert bif.relative_to_workspace() == Path(expected)
+
+
+def test_path_is_relative_to_workspace_when_not_in_workspace() -> None:
+    path = Path("my_repo/my_app/foo/bar.py").resolve()
+    project_root = Path("my_repo").resolve()
+    source_root = None
+    workspace = None
+
+    bif = BuildIncludeFile(path, project_root, source_root, workspace)
+
+    assert bif.relative_to_workspace() == path

--- a/tests/masonry/builders/test_buildincludefile.py
+++ b/tests/masonry/builders/test_buildincludefile.py
@@ -4,27 +4,17 @@ from pathlib import Path
 from poetry.core.masonry.builders.builder import BuildIncludeFile
 
 
+ws_path = "my_workspace"
+
+
 def test_path_is_relative_to_workspace() -> None:
     expected = "components/foo/bar.py"
 
-    path = Path(f"workspace/{expected}").resolve()
-    project_root = Path("workspace/projects/my_project").resolve()
-    source_root = None
-    workspace = Path("workspace").resolve()
+    path = Path(f"{ws_path}/{expected}").resolve()
+    project_root = Path(f"{ws_path}/projects/my_project").resolve()
+    workspace = Path(ws_path).resolve()
 
-    bif = BuildIncludeFile(path, project_root, source_root, workspace)
-
-    assert bif.relative_to_workspace() == Path(expected)
-
-
-def test_relative_path_with_source_root_is_relative_to_workspace() -> None:
-    expected = "components/foo/bar.py"
-
-    project_root = Path("workspace/projects/my_project").resolve()
-    source_root = Path("workspace").resolve()
-    workspace = Path("workspace").resolve()
-
-    bif = BuildIncludeFile(expected, project_root, source_root, workspace)
+    bif = BuildIncludeFile(path, project_root, None, workspace)
 
     assert bif.relative_to_workspace() == Path(expected)
 
@@ -32,9 +22,28 @@ def test_relative_path_with_source_root_is_relative_to_workspace() -> None:
 def test_path_is_relative_to_workspace_when_not_in_workspace() -> None:
     path = Path("my_repo/my_app/foo/bar.py").resolve()
     project_root = Path("my_repo").resolve()
-    source_root = None
-    workspace = None
 
-    bif = BuildIncludeFile(path, project_root, source_root, workspace)
+    bif = BuildIncludeFile(path, project_root, None, None)
 
     assert bif.relative_to_workspace() == path
+
+
+def test_calculated_path() -> None:
+    expected = "components/foo/bar.py"
+
+    path = Path(f"{ws_path}/{expected}").resolve()
+    project_root = Path(f"{ws_path}/projects/my_project").resolve()
+    workspace = Path(ws_path).resolve()
+
+    bif = BuildIncludeFile(path, project_root, None, workspace)
+
+    assert bif.calculated_path() == Path(expected)
+
+
+def test_calculated_path_when_not_in_workspace() -> None:
+    path = Path("my_repo/my_app/foo/bar.py").resolve()
+    project_root = Path("my_repo").resolve()
+
+    bif = BuildIncludeFile(path, project_root, None, None)
+
+    assert bif.calculated_path() == path

--- a/tests/masonry/builders/test_buildincludefile.py
+++ b/tests/masonry/builders/test_buildincludefile.py
@@ -1,5 +1,6 @@
-from pathlib import Path
+from __future__ import annotations
 
+from pathlib import Path
 
 from poetry.core.masonry.builders.builder import BuildIncludeFile
 

--- a/tests/masonry/utils/test_dist_toml.py
+++ b/tests/masonry/utils/test_dist_toml.py
@@ -5,7 +5,6 @@ import tomlkit
 from poetry.core.masonry.utils.dist_toml import create_valid_dist_project_file
 from poetry.core.masonry.utils.dist_toml import to_valid_dist_package
 from poetry.core.masonry.utils.dist_toml import to_valid_dist_packages
-from poetry.core.pyproject.toml import PyProjectTOML
 
 
 def test_to_valid_dist_package() -> None:

--- a/tests/masonry/utils/test_dist_toml.py
+++ b/tests/masonry/utils/test_dist_toml.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import tomlkit
 
+from poetry.core.masonry.utils.dist_toml import create_valid_dist_project_file
 from poetry.core.masonry.utils.dist_toml import to_valid_dist_package
 from poetry.core.masonry.utils.dist_toml import to_valid_dist_packages
+from poetry.core.pyproject.toml import PyProjectTOML
 
 
 def test_to_valid_dist_package() -> None:
@@ -59,3 +61,20 @@ def test_to_valid_dist_packages_with_mixed_includes() -> None:
     res = to_valid_dist_packages(data)
 
     assert res == [{"include": "foo/bar"}, {"include": "foo", "from": "bar"}]
+
+
+def test_create_valid_dist_project_file() -> None:
+    content = """
+    [tool.poetry]
+    packages = [
+       {"include" = "foo/bar", from = "../../components"}
+    ]
+    """
+
+    data = tomlkit.parse(content)
+
+    in_memory_file = create_valid_dist_project_file(data)
+
+    parsed = tomlkit.parse(in_memory_file.getvalue())
+
+    assert parsed["tool"]["poetry"]["packages"] == [{"include": "foo/bar"}]

--- a/tests/masonry/utils/test_dist_toml.py
+++ b/tests/masonry/utils/test_dist_toml.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 import tomlkit
 
-from poetry.core.masonry.utils.dist_toml import (
-    to_valid_dist_package,
-    to_valid_dist_packages,
-)
+from poetry.core.masonry.utils.dist_toml import to_valid_dist_package
+from poetry.core.masonry.utils.dist_toml import to_valid_dist_packages
 
 
 def test_to_valid_dist_package() -> None:

--- a/tests/masonry/utils/test_dist_toml.py
+++ b/tests/masonry/utils/test_dist_toml.py
@@ -74,6 +74,6 @@ def test_create_valid_dist_project_file() -> None:
 
     in_memory_file = create_valid_dist_project_file(data)
 
-    parsed = tomlkit.parse(in_memory_file.getvalue())
+    parsed = tomlkit.parse(in_memory_file.decode())
 
     assert parsed["tool"]["poetry"]["packages"] == [{"include": "foo/bar"}]

--- a/tests/masonry/utils/test_dist_toml.py
+++ b/tests/masonry/utils/test_dist_toml.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import tomlkit
+
+from poetry.core.masonry.utils.dist_toml import (
+    to_valid_dist_package,
+    to_valid_dist_packages,
+)
+
+
+def test_to_valid_dist_package() -> None:
+    content = """
+    [tool.poetry]
+    packages = [{"include" = "foo/bar", from = "../../components"}]
+    """
+    data = tomlkit.parse(content)
+
+    package = data["tool"]["poetry"]["packages"][0]
+
+    res = to_valid_dist_package(package)
+
+    assert res == {"include": "foo/bar"}
+
+
+def test_to_valid_dist_package_without_relative_include() -> None:
+    content = """
+    [tool.poetry]
+    packages = [{"include" = "foo", from = "bar"}]
+    """
+    data = tomlkit.parse(content)
+
+    package = data["tool"]["poetry"]["packages"][0]
+
+    res = to_valid_dist_package(package)
+
+    assert res == {"include": "foo", "from": "bar"}
+
+
+def test_to_valid_dist_packages() -> None:
+    content = """
+    [tool.poetry]
+    packages = [{"include" = "foo/bar", from = "../../components"}]
+    """
+    data = tomlkit.parse(content)
+
+    res = to_valid_dist_packages(data)
+
+    assert res == [{"include": "foo/bar"}]
+
+
+def test_to_valid_dist_packages_with_mixed_includes() -> None:
+    content = """
+    [tool.poetry]
+    packages = [
+       {"include" = "foo/bar", from = "../../components"},
+       {"include" = "foo", from = "bar"}
+    ]
+    """
+    data = tomlkit.parse(content)
+
+    res = to_valid_dist_packages(data)
+
+    assert res == [{"include": "foo/bar"}, {"include": "foo", "from": "bar"}]

--- a/tests/utils/test_namespacing.py
+++ b/tests/utils/test_namespacing.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from poetry.core.utils.namespacing import convert_to_namespace
+from poetry.core.utils.namespacing import create_namespaced_path
+
+
+def test_create_namespaced_path() -> None:
+    expected = "my_namespace/my_package/my_module.py"
+
+    path = Path(f"my_workspace/{expected}")
+    workspace = Path("my_workspace")
+
+    assert create_namespaced_path(path, workspace).as_posix() == expected
+
+
+def test_convert_to_namespace() -> None:
+    assert convert_to_namespace("foo/bar") == "foo.bar"

--- a/tests/utils/test_workspaces.py
+++ b/tests/utils/test_workspaces.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import tomlkit
+
+import poetry.core.utils.workspaces
+
+
+def test_is_poetry_workspace() -> None:
+    content = """[tool.poetry.workspace]"""
+    data = tomlkit.parse(content)
+
+    res = poetry.core.utils.workspaces.is_poetry_workspace(data)
+
+    assert res is True
+
+
+def test_is_poetry_workspace_should_return_false_when_missing_keys() -> None:
+    content = """[tool.other]"""
+    data = tomlkit.parse(content)
+
+    res = poetry.core.utils.workspaces.is_poetry_workspace(data)
+
+    assert res is False


### PR DESCRIPTION
The purpose of the changes here is to enable Workspace support. A workspace is a place for code and projects. Within the workspace, code can be shared. A workspace is usually at the root of your repository.

To identify a workspace in a Python repo, an empty `workspace.toml` file is put at the top of the workspace. Future plugins that extends workspaces could use that file to store configuration and settings.

The feature in this pull request will make this [this plugin](https://github.com/DavidVujic/poetry-multiproject-plugin) redundant 😄 (I am the author of that plugin)

Why workspaces?
A workspace can contain more than one project. Different projects will likely use the same code. A very simplistic example would be a logger.  To avoid code duplication, code could be moved out from the project into packages, and each project can reference the package from the project specific `pyproject.toml` file. 

This requires that Poetry allows __package includes__ (note the difference from dependencies) that are "outside" of the project path, but within a __workspace__. That's what this pull request will do.

An example & simplified tree workspace structure (note the namespacing for shared package includes):
```
projects/
  my_app/
    pyproject.toml (including a shared package)

  my_service/
    pyproject.toml (including other shared packages)

shared/
  my_namespace/
    my_package/
      __init__.py
      code.py

    my_other_package/
      __init__.py
      code.py

workspace.toml (a file that tells the plugin where to find the workspace root)
```

I think this feature resolves the issues raised in: 
https://github.com/python-poetry/poetry/issues/936
and probably also
https://github.com/python-poetry/poetry/issues/2270


- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

