### PR TITLE
typechecking poetry.core.masonry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,9 +98,6 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = [
   # src modules
-  'poetry.core.masonry.builders.builder',
-  'poetry.core.masonry.builders.sdist',
-  'poetry.core.masonry.builders.wheel',
   'poetry.core.packages.utils.utils',
   'poetry.core.packages.dependency',
   'poetry.core.packages.package',

--- a/src/poetry/core/masonry/api.py
+++ b/src/poetry/core/masonry/api.py
@@ -73,7 +73,7 @@ def build_sdist(
     """Builds an sdist, places it in sdist_directory"""
     poetry = Factory().create_poetry(Path(".").resolve(), with_groups=False)
 
-    path = SdistBuilder(poetry).build(Path(sdist_directory))
+    path = SdistBuilder(poetry, target_dir=Path(sdist_directory)).build()
 
     return path.name
 

--- a/src/poetry/core/masonry/api.py
+++ b/src/poetry/core/masonry/api.py
@@ -73,7 +73,7 @@ def build_sdist(
     """Builds an sdist, places it in sdist_directory"""
     poetry = Factory().create_poetry(Path(".").resolve(), with_groups=False)
 
-    path = SdistBuilder(poetry, target_dir=Path(sdist_directory)).build()
+    path = SdistBuilder(poetry).build(Path(sdist_directory))
 
     return path.name
 

--- a/src/poetry/core/masonry/builders/builder.py
+++ b/src/poetry/core/masonry/builders/builder.py
@@ -40,7 +40,7 @@ class Builder:
 
         self._poetry = poetry
         self._package = poetry.package
-        self._path = poetry.file.parent
+        self._path: Path = poetry.file.parent
         self._excluded_files: set[str] | None = None
         self._executable = Path(executable or sys.executable)
 
@@ -92,6 +92,10 @@ class Builder:
     @property
     def executable(self) -> Path:
         return self._executable
+
+    @property
+    def default_target_dir(self) -> Path:
+        return self._path / "dist"
 
     def build(self, target_dir: Path | None) -> Path:
         raise NotImplementedError()

--- a/src/poetry/core/masonry/builders/builder.py
+++ b/src/poetry/core/masonry/builders/builder.py
@@ -93,7 +93,7 @@ class Builder:
     def executable(self) -> Path:
         return self._executable
 
-    def build(self) -> Path:
+    def build(self, target_dir: Path | None) -> Path:
         raise NotImplementedError()
 
     def find_excluded_files(self, fmt: str | None = None) -> set[str]:

--- a/src/poetry/core/masonry/builders/builder.py
+++ b/src/poetry/core/masonry/builders/builder.py
@@ -32,6 +32,7 @@ class Builder:
     def __init__(
         self,
         poetry: Poetry,
+        ignore_packages_formats: bool = False,
         executable: Path | None = None,
     ) -> None:
         from poetry.core.masonry.metadata import Metadata
@@ -55,7 +56,12 @@ class Builder:
             if not isinstance(formats, list):
                 formats = [formats]
 
-            if formats and self.format and self.format not in formats:
+            if (
+                formats
+                and self.format
+                and self.format not in formats
+                and not ignore_packages_formats
+            ):
                 continue
 
             packages.append(p)
@@ -64,7 +70,12 @@ class Builder:
         for include in self._package.include:
             formats = include.get("format", [])
 
-            if formats and self.format and self.format not in formats:
+            if (
+                formats
+                and self.format
+                and self.format not in formats
+                and not ignore_packages_formats
+            ):
                 continue
 
             includes.append(include)

--- a/src/poetry/core/masonry/builders/sdist.py
+++ b/src/poetry/core/masonry/builders/sdist.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
     from poetry.core.masonry.utils.package_include import PackageInclude
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.project_package import ProjectPackage
-    from poetry.core.poetry import Poetry
 
 SETUP = """\
 # -*- coding: utf-8 -*-
@@ -55,13 +54,6 @@ logger = logging.getLogger(__name__)
 class SdistBuilder(Builder):
 
     format = "sdist"
-
-    def __init__(
-        self,
-        poetry: Poetry,
-        executable: Path | None = None,
-    ) -> None:
-        super().__init__(poetry, executable=executable)
 
     def build(
         self,

--- a/src/poetry/core/masonry/builders/sdist.py
+++ b/src/poetry/core/masonry/builders/sdist.py
@@ -60,14 +60,15 @@ class SdistBuilder(Builder):
         self,
         poetry: Poetry,
         executable: Path | None = None,
-        target_dir: Path | None = None,
     ) -> None:
         super().__init__(poetry, executable=executable)
-        self._target_dir = target_dir
 
-    def build(self) -> Path:
+    def build(
+        self,
+        target_dir: Path | None = None,
+    ) -> Path:
         logger.info("Building <info>sdist</info>")
-        target_dir = self._target_dir or self._path / "dist"
+        target_dir = target_dir or self._path / "dist"
 
         if not target_dir.exists():
             target_dir.mkdir(parents=True)

--- a/src/poetry/core/masonry/builders/sdist.py
+++ b/src/poetry/core/masonry/builders/sdist.py
@@ -60,7 +60,7 @@ class SdistBuilder(Builder):
         target_dir: Path | None = None,
     ) -> Path:
         logger.info("Building <info>sdist</info>")
-        target_dir = target_dir or self._path / "dist"
+        target_dir = target_dir or self.default_target_dir
 
         if not target_dir.exists():
             target_dir.mkdir(parents=True)
@@ -326,15 +326,15 @@ class SdistBuilder(Builder):
         additional_files.update(self.convert_script_files())
 
         # Include project files
-        additional_files.add("pyproject.toml")
+        additional_files.add(Path("pyproject.toml"))
 
         # add readme if it is specified
         if "readme" in self._poetry.local_config:
             additional_files.add(self._poetry.local_config["readme"])
 
-        for file in additional_files:
+        for additional_file in additional_files:
             file = BuildIncludeFile(
-                path=file, project_root=self._path, source_root=self._path
+                path=additional_file, project_root=self._path, source_root=self._path
             )
             if file.path.exists():
                 logger.debug(f"Adding: {file.relative_to_source_root()}")

--- a/src/poetry/core/masonry/builders/wheel.py
+++ b/src/poetry/core/masonry/builders/wheel.py
@@ -91,9 +91,9 @@ class WheelBuilder(Builder):
     ) -> Path:
         logger.info("Building wheel")
 
-        dist_dir = target_dir or (self._poetry.file.parent / "dist")
-        if not dist_dir.exists():
-            dist_dir.mkdir()
+        target_dir = target_dir or self.default_target_dir
+        if not target_dir.exists():
+            target_dir.mkdir()
 
         (fd, temp_path) = tempfile.mkstemp(suffix=".whl")
 
@@ -119,7 +119,7 @@ class WheelBuilder(Builder):
             self._write_metadata(zip_file)
             self._write_record(zip_file)
 
-        wheel_path = dist_dir / self.wheel_filename
+        wheel_path = target_dir / self.wheel_filename
         if wheel_path.exists():
             wheel_path.unlink()
         shutil.move(temp_path, str(wheel_path))

--- a/src/poetry/core/masonry/builders/wheel.py
+++ b/src/poetry/core/masonry/builders/wheel.py
@@ -49,7 +49,6 @@ class WheelBuilder(Builder):
     def __init__(
         self,
         poetry: Poetry,
-        target_dir: Path | None = None,
         original: Path | None = None,
         executable: Path | None = None,
         editable: bool = False,
@@ -58,7 +57,6 @@ class WheelBuilder(Builder):
 
         self._records: list[tuple[str, str, int]] = []
         self._original_path = self._path
-        self._target_dir = target_dir or (self._poetry.file.parent / "dist")
         if original:
             self._original_path = original.parent
         self._editable = editable
@@ -74,12 +72,11 @@ class WheelBuilder(Builder):
     ) -> str:
         wb = WheelBuilder(
             poetry,
-            target_dir=directory,
             original=original,
             executable=executable,
             editable=editable,
         )
-        wb.build()
+        wb.build(target_dir=directory)
 
         return wb.wheel_filename
 
@@ -88,10 +85,13 @@ class WheelBuilder(Builder):
         """Build a wheel in the dist/ directory, and optionally upload it."""
         cls.make_in(poetry, executable=executable)
 
-    def build(self) -> Path:
+    def build(
+        self,
+        target_dir: Path | None = None,
+    ) -> Path:
         logger.info("Building wheel")
 
-        dist_dir = self._target_dir
+        dist_dir = target_dir or (self._poetry.file.parent / "dist")
         if not dist_dir.exists():
             dist_dir.mkdir()
 

--- a/src/poetry/core/masonry/metadata.py
+++ b/src/poetry/core/masonry/metadata.py
@@ -14,7 +14,7 @@ class Metadata:
     metadata_version = "2.1"
     # version 1.0
     name = None
-    version = None
+    version: str
     platforms = ()
     supported_platforms = ()
     summary = None

--- a/src/poetry/core/masonry/utils/package_include.py
+++ b/src/poetry/core/masonry/utils/package_include.py
@@ -17,7 +17,7 @@ class PackageInclude(Include):
         formats: list[str] | None = None,
         source: str | None = None,
     ) -> None:
-        self._package: str | None = None
+        self._package: str
         self._is_package = False
         self._is_module = False
         self._source = source
@@ -29,7 +29,7 @@ class PackageInclude(Include):
         self.check_elements()
 
     @property
-    def package(self) -> str | None:
+    def package(self) -> str:
         return self._package
 
     @property


### PR DESCRIPTION
Resolves: python-poetry#<!-- add issue number/link here -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

I've added mypy to the dev-dependencies and made the poetry.core.masonry code mypy-clean.

Slightly more invasive than some of the typechecking MRs we've seen:
- making the various `.build()` methods have the same signature required changes (and I've removed an unused parameter too)
- since mostly this code wants `Path` rather than `str` I've removed some odd-one-out `Union[Path, str]` 
- I've removed some cleverness where a `BuildIncludeFile` could be equal to a `Path` because it just seemed too much.  I've caught one place where this trickery was being exploited, and re-implemented it in a less magical way, but it's possible that I've missed something.
