### PR TITLE
Ensure that authors and maintainers are normalized.

### DIFF
--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -9,6 +9,7 @@ from typing import Optional
 from typing import Union
 from warnings import warn
 
+from poetry.core.utils.helpers import combine_unicode
 from poetry.core.utils.helpers import readme_content_type
 
 
@@ -76,10 +77,10 @@ class Factory:
         package.root_dir = root
 
         for author in config["authors"]:
-            package.authors.append(author)
+            package.authors.append(combine_unicode(author))
 
         for maintainer in config.get("maintainers", []):
-            package.maintainers.append(maintainer)
+            package.maintainers.append(combine_unicode(maintainer))
 
         package.description = config.get("description", "")
         package.homepage = config.get("homepage")

--- a/src/poetry/core/utils/helpers.py
+++ b/src/poetry/core/utils/helpers.py
@@ -3,6 +3,7 @@ import re
 import shutil
 import stat
 import tempfile
+import unicodedata
 
 from collections.abc import Mapping
 from contextlib import contextmanager
@@ -18,6 +19,10 @@ from poetry.core.version.pep440 import PEP440Version
 
 
 _canonicalize_regex = re.compile(r"[-_]+")
+
+
+def combine_unicode(string: str) -> str:
+    return unicodedata.normalize("NFC", string)
 
 
 def canonicalize_name(name: str) -> str:

--- a/tests/fixtures/sample_project/pyproject.toml
+++ b/tests/fixtures/sample_project/pyproject.toml
@@ -3,7 +3,7 @@ name = "my-package"
 version = "1.2.3"
 description = "Some description."
 authors = [
-    "Sébastien Eustace <sebastien@eustace.io>"
+    "Sébastien Eustace <sebastien@eustace.io>"
 ]
 license = "MIT"
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -7,6 +7,7 @@ from typing import Union
 import pytest
 
 from poetry.core.utils.helpers import canonicalize_name
+from poetry.core.utils.helpers import combine_unicode
 from poetry.core.utils.helpers import parse_requires
 from poetry.core.utils.helpers import readme_content_type
 from poetry.core.utils.helpers import temporary_directory
@@ -74,6 +75,15 @@ isort@ git+git://github.com/timothycrosley/isort.git@e63ae06ec7d70b06df9e5283576
 @pytest.mark.parametrize("raw", ["a-b-c", "a_b-c", "a_b_c", "a-b_c"])
 def test_utils_helpers_canonical_names(raw: str):
     assert canonicalize_name(raw) == "a-b-c"
+
+
+def test_utils_helpers_combine_unicode():
+    combined_expected = "é"
+    decomposed = "é"
+    assert combined_expected != decomposed
+
+    combined = combine_unicode(decomposed)
+    assert combined == combined_expected
 
 
 def test_utils_helpers_temporary_directory_readonly_file():


### PR DESCRIPTION
This is a bugfix from my point of view, but feel free to reject if you feel this is expected.

# Steps to reproduce
1. Insert a decomposed unicode string as an author in `pyproject.toml`.
2. `poetry install`.

Expected outcome is that the installation takes place but instead you get a mismatch on the `AUTHOR_REGEX`.

An alternative way to reproduce is to update `user.name` in `~/.gitconfig` and create a new project with `poetry new`. Since poetry seems to read the author name from the git config, you will have the same issue with the generated `pyproject.toml`.

While this sounds evil or an attempt to break things on purpose, I actually had such a string in my `.gitconfig` but unfortunately I don't remember how it got there, I blame one of the git UIs. 

# Explanation
Unicode can represent characters in one of two ways, combined or decomposed. My surname contains the letter Ç:
* Combined: `LATIN CAPITAL LETTER C WITH CEDILLA`
* Decomposed: `LATIN CAPITAL LETTER C` + `COMBINING CEDILLA`.

When I have the decomposed version, looks like it is a mismatch with the [`AUTHOR_REGEX`](https://github.com/python-poetry/poetry-core/blob/d9ed333ef0c98e185a79e0f98093e7c5c4d817be/src/poetry/core/packages/package.py#L27).

# Fix
I [normalized](https://docs.python.org/3/library/unicodedata.html#unicodedata.normalize) the authors and maintainers which seemed to solve the issue. Note that you will see I've decomposed the `é` in the [`sample_project`](https://github.com/python-poetry/poetry-core/blob/3bdd0cff9a3968f60457e7bea343cf42c69fb91b/tests/fixtures/sample_project/pyproject.toml#L6) but I have not changed the assert in the related test case, thus, the same test case serves my purpose.

Please note that the output is rendered same for the both versions of the strings, thus the diff seems funny.






