### PR TITLE
Marker simplifications

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -449,8 +449,8 @@ class MultiMarker(BaseMarker):
         if any(m.is_empty() for m in new_markers) or not new_markers:
             return EmptyMarker()
 
-        if len(new_markers) == 1 and new_markers[0].is_any():
-            return AnyMarker()
+        if len(new_markers) == 1:
+            return new_markers[0]
 
         return MultiMarker(*new_markers)
 

--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -470,6 +470,9 @@ class MultiMarker(BaseMarker):
         return MultiMarker.of(*new_markers)
 
     def union(self, other: MarkerTypes) -> MarkerTypes:
+        if other in self._markers:
+            return other
+
         if isinstance(other, (SingleMarker, MultiMarker)):
             return MarkerUnion.of(self, other)
 

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -773,6 +773,14 @@ def test_union_of_a_single_marker_is_the_single_marker():
     assert SingleMarker("python_version", ">= 2.7") == union
 
 
+def test_union_of_multi_with_a_containing_single():
+    single = parse_marker('python_version >= "2.7"')
+    multi = parse_marker('python_version >= "2.7" and extra == "foo"')
+    union = multi.union(single)
+
+    assert union == single
+
+
 @pytest.mark.parametrize(
     "marker, inverse",
     [

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -685,13 +685,13 @@ def test_without_extras(marker: str, expected: str):
         (
             'python_version >= "3.6" and (extra == "foo" or extra == "bar")',
             "python_version",
-            '(extra == "foo" or extra == "bar")',
+            'extra == "foo" or extra == "bar"',
         ),
         (
             'python_version >= "3.6" and (extra == "foo" or extra == "bar") or'
             ' implementation_name == "pypy"',
             "python_version",
-            '(extra == "foo" or extra == "bar") or implementation_name == "pypy"',
+            'extra == "foo" or extra == "bar" or implementation_name == "pypy"',
         ),
         (
             'python_version >= "3.6" and extra == "foo" or implementation_name =='
@@ -704,6 +704,11 @@ def test_without_extras(marker: str, expected: str):
             ' "pypy" or extra == "bar"',
             "implementation_name",
             'python_version >= "3.6" or extra == "foo" or extra == "bar"',
+        ),
+        (
+            'extra == "foo" and python_version >= "3.6" or python_version >= "3.6"',
+            "extra",
+            'python_version >= "3.6"',
         ),
     ],
 )
@@ -728,7 +733,7 @@ def test_exclude(marker: str, excluded: str, expected: str):
         (
             'python_version >= "3.6" and (extra == "foo" or extra == "bar")',
             ["extra"],
-            '(extra == "foo" or extra == "bar")',
+            'extra == "foo" or extra == "bar"',
         ),
         (
             'python_version >= "3.6" and (extra == "foo" or extra == "bar") or'


### PR DESCRIPTION
Resolves: python-poetry#<!-- add issue number/link here -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

Markers get complicated; I've no intention of trying to solve this in full generality but here are a couple of pieces of low-hanging fruit to improve some cases.

In particular the first commit was motivated by a real life project in which `poetry export` gave the marker `python_version >= "3.6" or python_version >= "3.6"`, which looked a bit sad.