### PR TITLE
Improve constraint union

### DIFF
--- a/src/poetry/core/packages/constraints/constraint.py
+++ b/src/poetry/core/packages/constraints/constraint.py
@@ -3,6 +3,7 @@ import operator
 from typing import Any
 from typing import Union
 
+from poetry.core.packages.constraints import AnyConstraint
 from poetry.core.packages.constraints.base_constraint import BaseConstraint
 from poetry.core.packages.constraints.empty_constraint import EmptyConstraint
 
@@ -106,7 +107,19 @@ class Constraint(BaseConstraint):
                 UnionConstraint,
             )
 
-            return UnionConstraint(self, other)
+            if other == self:
+                return self
+
+            if self.operator == "!=" and other.operator == "==" and self.allows(other):
+                return self
+
+            if other.operator == "!=" and self.operator == "==" and other.allows(self):
+                return other
+
+            if other.operator == "==" and self.operator == "==":
+                return UnionConstraint(self, other)
+
+            return AnyConstraint()
 
         return other.union(self)
 

--- a/tests/packages/constraints/test_constraint.py
+++ b/tests/packages/constraints/test_constraint.py
@@ -54,6 +54,11 @@ def test_allows_all():
     [
         (
             Constraint("win32"),
+            Constraint("win32"),
+            Constraint("win32"),
+        ),
+        (
+            Constraint("win32"),
             Constraint("linux"),
             EmptyConstraint(),
         ),
@@ -71,6 +76,11 @@ def test_allows_all():
             Constraint("win32"),
             Constraint("linux", "!="),
             Constraint("win32"),
+        ),
+        (
+            Constraint("win32", "!="),
+            Constraint("linux"),
+            Constraint("linux"),
         ),
         (
             Constraint("win32", "!="),

--- a/tests/packages/constraints/test_constraint.py
+++ b/tests/packages/constraints/test_constraint.py
@@ -1,7 +1,15 @@
+from typing import TYPE_CHECKING
+
+import pytest
+
 from poetry.core.packages.constraints.constraint import Constraint
 from poetry.core.packages.constraints.empty_constraint import EmptyConstraint
 from poetry.core.packages.constraints.multi_constraint import MultiConstraint
 from poetry.core.packages.constraints.union_constraint import UnionConstraint
+
+
+if TYPE_CHECKING:
+    from poetry.core.packages.constraints import BaseConstraint
 
 
 def test_allows():
@@ -41,46 +49,74 @@ def test_allows_all():
     assert not c.allows_all(UnionConstraint(Constraint("win32"), Constraint("linux")))
 
 
-def test_intersect():
-    c = Constraint("win32")
+@pytest.mark.parametrize(
+    ("constraint1", "constraint2", "expected"),
+    [
+        (
+            Constraint("win32"),
+            Constraint("linux"),
+            EmptyConstraint(),
+        ),
+        (
+            Constraint("win32"),
+            UnionConstraint(Constraint("win32"), Constraint("linux")),
+            Constraint("win32"),
+        ),
+        (
+            Constraint("win32"),
+            UnionConstraint(Constraint("linux"), Constraint("linux2")),
+            EmptyConstraint(),
+        ),
+        (
+            Constraint("win32"),
+            Constraint("linux", "!="),
+            Constraint("win32"),
+        ),
+        (
+            Constraint("win32", "!="),
+            Constraint("linux", "!="),
+            MultiConstraint(Constraint("win32", "!="), Constraint("linux", "!=")),
+        ),
+    ],
+)
+def test_intersect(
+    constraint1: "BaseConstraint",
+    constraint2: "BaseConstraint",
+    expected: "BaseConstraint",
+):
+    intersection = constraint1.intersect(constraint2)
+    assert intersection == expected
 
-    intersection = c.intersect(Constraint("linux"))
-    assert intersection == EmptyConstraint()
 
-    intersection = c.intersect(
-        UnionConstraint(Constraint("win32"), Constraint("linux"))
-    )
-    assert intersection == Constraint("win32")
-
-    intersection = c.intersect(
-        UnionConstraint(Constraint("linux"), Constraint("linux2"))
-    )
-    assert intersection == EmptyConstraint()
-
-    intersection = c.intersect(Constraint("linux", "!="))
-    assert intersection == c
-
-    c = Constraint("win32", "!=")
-
-    intersection = c.intersect(Constraint("linux", "!="))
-    assert intersection == MultiConstraint(
-        Constraint("win32", "!="), Constraint("linux", "!=")
-    )
-
-
-def test_union():
-    c = Constraint("win32")
-
-    union = c.union(Constraint("linux"))
-    assert union == UnionConstraint(Constraint("win32"), Constraint("linux"))
-
-    union = c.union(UnionConstraint(Constraint("win32"), Constraint("linux")))
-    assert union == UnionConstraint(Constraint("win32"), Constraint("linux"))
-
-    union = c.union(UnionConstraint(Constraint("linux"), Constraint("linux2")))
-    assert union == UnionConstraint(
-        Constraint("win32"), Constraint("linux"), Constraint("linux2")
-    )
+@pytest.mark.parametrize(
+    ("constraint1", "constraint2", "expected"),
+    [
+        (
+            Constraint("win32"),
+            Constraint("linux"),
+            UnionConstraint(Constraint("win32"), Constraint("linux")),
+        ),
+        (
+            Constraint("win32"),
+            UnionConstraint(Constraint("win32"), Constraint("linux")),
+            UnionConstraint(Constraint("win32"), Constraint("linux")),
+        ),
+        (
+            Constraint("win32"),
+            UnionConstraint(Constraint("linux"), Constraint("linux2")),
+            UnionConstraint(
+                Constraint("win32"), Constraint("linux"), Constraint("linux2")
+            ),
+        ),
+    ],
+)
+def test_union(
+    constraint1: "BaseConstraint",
+    constraint2: "BaseConstraint",
+    expected: "BaseConstraint",
+):
+    union = constraint1.union(constraint2)
+    assert union == expected
 
 
 def test_difference():

--- a/tests/packages/constraints/test_constraint.py
+++ b/tests/packages/constraints/test_constraint.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from poetry.core.packages.constraints import AnyConstraint
 from poetry.core.packages.constraints.constraint import Constraint
 from poetry.core.packages.constraints.empty_constraint import EmptyConstraint
 from poetry.core.packages.constraints.multi_constraint import MultiConstraint
@@ -103,6 +104,11 @@ def test_intersect(
     [
         (
             Constraint("win32"),
+            Constraint("win32"),
+            Constraint("win32"),
+        ),
+        (
+            Constraint("win32"),
             Constraint("linux"),
             UnionConstraint(Constraint("win32"), Constraint("linux")),
         ),
@@ -117,6 +123,21 @@ def test_intersect(
             UnionConstraint(
                 Constraint("win32"), Constraint("linux"), Constraint("linux2")
             ),
+        ),
+        (
+            Constraint("win32"),
+            Constraint("linux", "!="),
+            Constraint("linux", "!="),
+        ),
+        (
+            Constraint("win32", "!="),
+            Constraint("linux"),
+            Constraint("win32", "!="),
+        ),
+        (
+            Constraint("win32", "!="),
+            Constraint("linux", "!="),
+            AnyConstraint(),
         ),
     ],
 )


### PR DESCRIPTION
Preliminary step for improving the union of markers.

Allows the following new simplifications:
```
Constraint("win32").union(Constraint("win32")) == Constraint("win32")
Constraint("win32").union(Constraint("linux", "!=")) == Constraint("linux", "!=")
Constraint("win32", "!=").union(Constraint("linux")) == Constraint("win32", "!=")
Constraint("win32", "!=").union(Constraint("linux", "!=")) == AnyConstraint()
```