### PR TITLE
recalculate python markers on dependency more often

### DIFF
--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -179,6 +179,8 @@ class Dependency(PackageSpecification):
                 for _, extra in or_:
                     self.in_extras.append(extra)
 
+        # Recalculate python versions.
+        self._python_versions = "*"
         if "python_version" in markers:
             ors = []
             for or_ in markers["python_version"]:
@@ -213,7 +215,8 @@ class Dependency(PackageSpecification):
                 ors.append(" ".join(ands))
 
             self._python_versions = " || ".join(ors)
-            self._python_constraint = parse_constraint(self._python_versions)
+
+        self._python_constraint = parse_constraint(self._python_versions)
 
     @property
     def transitive_marker(self) -> "BaseMarker":

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -305,3 +305,13 @@ def test_dependency_markers_are_the_same_as_markers():
     marker = parse_marker('extra=="bar"')
 
     assert dependency.marker == marker
+
+
+def test_marker_properly_unsets_python_constraint():
+    dependency = Dependency("foo", "^1.2.3")
+
+    dependency.marker = 'python_version >= "3.6"'
+    assert str(dependency.python_constraint) == ">=3.6"
+
+    dependency.marker = "*"
+    assert str(dependency.python_constraint) == "*"


### PR DESCRIPTION
Updating a marker in a way that removes python version constraints fails to remove the python version constraint

Not for merging, until there's a fix!  This is a demonstration of "bug 2" per https://github.com/python-poetry/poetry/pull/5154
