### PR TITLE
Dependency's identity should include marker

### DIFF
--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -607,15 +607,21 @@ class Dependency(PackageSpecification):
 
         return (
             self.is_same_package_as(other)
-            and self._constraint == other.constraint
-            and self._extras == other.extras
+            and self._constraint == other._constraint
+            and self._extras == other._extras
+            and self._marker == other._marker
         )
 
     def __ne__(self, other: Any) -> bool:
         return not self.__eq__(other)
 
     def __hash__(self) -> int:
-        return super().__hash__() ^ hash(self._constraint) ^ hash(self._extras)
+        return (
+            super().__hash__()
+            ^ hash(self._constraint)
+            ^ hash(self._extras)
+            ^ hash(self._marker)
+        )
 
     def __str__(self) -> str:
         if self.is_root:

--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -737,7 +737,7 @@ def _compact_markers(tree_elements: "Tree", tree_prefix: str = "") -> MarkerType
                 )
 
             value = value[1:-1]
-            groups[-1] = MultiMarker.of(groups[-1], SingleMarker(name, f"{op}{value}"))
+            groups[-1] = MultiMarker.of(groups[-1], SingleMarker(str(name), f"{op}{value}"))
         elif token.data == f"{tree_prefix}BOOL_OP" and token.children[0] == "or":
             groups.append(MultiMarker())
 

--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -737,7 +737,9 @@ def _compact_markers(tree_elements: "Tree", tree_prefix: str = "") -> MarkerType
                 )
 
             value = value[1:-1]
-            groups[-1] = MultiMarker.of(groups[-1], SingleMarker(str(name), f"{op}{value}"))
+            groups[-1] = MultiMarker.of(
+                groups[-1], SingleMarker(str(name), f"{op}{value}")
+            )
         elif token.data == f"{tree_prefix}BOOL_OP" and token.children[0] == "or":
             groups.append(MultiMarker())
 


### PR DESCRIPTION
Per https://github.com/python-poetry/poetry/pull/5156, this is needed to get poetry export working properly - else we wrongly think that the same requirement but with different markers is really the same