### PR TITLE
Marker name is a string, not a lexer token

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -737,7 +737,9 @@ def _compact_markers(tree_elements: "Tree", tree_prefix: str = "") -> MarkerType
                 )
 
             value = value[1:-1]
-            groups[-1] = MultiMarker.of(groups[-1], SingleMarker(name, f"{op}{value}"))
+            groups[-1] = MultiMarker.of(
+                groups[-1], SingleMarker(str(name), f"{op}{value}")
+            )
         elif token.data == f"{tree_prefix}BOOL_OP" and token.children[0] == "or":
             groups.append(MultiMarker())
 


### PR DESCRIPTION
Discovered incidentally while working on https://github.com/python-poetry/poetry/pull/5156 - sometimes a marker name was set to a lexer token rather than a string which, for instance, defeats comparisons for equality.