### PR TITLE
Fix multiple packages build

### DIFF
--- a/src/poetry/core/masonry/builders/builder.py
+++ b/src/poetry/core/masonry/builders/builder.py
@@ -170,21 +170,6 @@ class Builder:
                 if "__pycache__" in str(file):
                     continue
 
-                if file.is_dir():
-                    if self.format in formats:
-                        for current_file in file.glob("**/*"):
-                            include_file = BuildIncludeFile(
-                                path=current_file,
-                                project_root=self._path,
-                                source_root=self._path,
-                            )
-
-                            if not current_file.is_dir() and not self.is_excluded(
-                                include_file.relative_to_source_root()
-                            ):
-                                to_add.add(include_file)
-                    continue
-
                 if (
                     isinstance(include, PackageInclude)
                     and include.source
@@ -193,6 +178,21 @@ class Builder:
                     source_root = include.base
                 else:
                     source_root = self._path
+
+                if file.is_dir():
+                    if self.format in formats:
+                        for current_file in file.glob("**/*"):
+                            include_file = BuildIncludeFile(
+                                path=current_file,
+                                project_root=self._path,
+                                source_root=source_root,
+                            )
+
+                            if not current_file.is_dir() and not self.is_excluded(
+                                include_file.relative_to_source_root()
+                            ):
+                                to_add.add(include_file)
+                    continue
 
                 include_file = BuildIncludeFile(
                     path=file, project_root=self._path, source_root=source_root

--- a/tests/masonry/builders/test_complete.py
+++ b/tests/masonry/builders/test_complete.py
@@ -465,6 +465,32 @@ def test_package_src():
         zip.close()
 
 
+def test_split_source():
+    module_path = fixtures_dir / "split_source"
+    builder = Builder(Factory().create_poetry(module_path))
+    builder.build(fmt="all")
+
+    sdist = module_path / "dist" / "split-source-0.1.tar.gz"
+
+    assert sdist.exists()
+
+    with tarfile.open(str(sdist), "r") as tar:
+        assert "split-source-0.1/lib_a/module_a/__init__.py" in tar.getnames()
+        assert "split-source-0.1/lib_b/module_b/__init__.py" in tar.getnames()
+
+    whl = module_path / "dist" / "split_source-0.1-py3-none-any.whl"
+
+    assert whl.exists()
+
+    zip = zipfile.ZipFile(str(whl))
+
+    try:
+        assert "module_a/__init__.py" in zip.namelist()
+        assert "module_b/__init__.py" in zip.namelist()
+    finally:
+        zip.close()
+
+
 def test_package_with_include(mocker: "MockerFixture"):
     module_path = fixtures_dir / "with-include"
 


### PR DESCRIPTION
Resolves: multiple packages build

When there are multiple packages with the "from" keyword, the `poetry build` command, doesn't install the packages as expected.
Ex: 
```
packages = [
    { include = "XXX", from = "path/to/dir1" },
    { include = "YYY", from = "path/to/dir2" },
    { include = "ZZZ", from = "path/to/dir3" },
    { include = "A" }
]
```
In fact, when poetry build, its find all the files and directories inside the path specified by the keyword 'from' (['find_files_to_add' function](https://github.com/python-poetry/poetry-core/blob/4e5207e4d41c0c4f1844b1389eef79276af47a49/src/poetry/core/masonry/builders/builder.py#L157) from poetry/core/masonry/builders/builder.py#L157) .
Next, if it's a directory, it find all files and add them with the 'BuildIncludeFile' class using the current path (self._path).
[BuildIncludeFile with self._path](https://github.com/python-poetry/poetry-core/blob/4e5207e4d41c0c4f1844b1389eef79276af47a49/src/poetry/core/masonry/builders/builder.py#L176-L180)
poetry/core/masonry/builders/builder.py#L176-L180
 ```
  include_file = BuildIncludeFile(
      path=current_file,
      project_root=self._path,
      source_root=self._path,
  )
```
If it's a file, it add it with the 'BuildIncludeFile'  BUT using the 'specified **from** keyword' (include.base) if it is defined.
[BuildIncludeFile with include.base](https://github.com/python-poetry/poetry-core/blob/4e5207e4d41c0c4f1844b1389eef79276af47a49/src/poetry/core/masonry/builders/builder.py#L188-L199)
poetry/core/masonry/builders/builder.py#L188-L199
```
  if (
      isinstance(include, PackageInclude)
      and include.source
      and self.format == "wheel"
  ):
      source_root = include.base
  else:
      source_root = self._path


  include_file = BuildIncludeFile(
      path=file, project_root=self._path, source_root=source_root
  )
```

This Pr is intented to use the 'include.base' when it's the directory (if from is defined).
So only move up to the line #L172
```
  if (
      isinstance(include, PackageInclude)
      and include.source
      and self.format == "wheel"
  ):
      source_root = include.base
  else:
      source_root = self._path
```
And use ```source_root=source_root``` for the 'BuildIncludeFile' class in the directory part (#L179).
 
<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
