### PR TITLE
merging python_version and python_full_version markers

### DIFF
--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -159,6 +159,14 @@ def test_single_marker_not_in_python_intersection():
     assert str(intersection) == 'python_version not in "2.7, 3.0, 3.1, 3.2"'
 
 
+def test_marker_intersection_of_python_version_and_python_full_version():
+    m = parse_marker('python_version >= "3.6"')
+    m2 = parse_marker('python_full_version >= "3.0.0"')
+    intersection = m.intersect(m2)
+
+    assert str(intersection) == 'python_version >= "3.6"'
+
+
 def test_single_marker_union():
     m = parse_marker('sys_platform == "darwin"')
 
@@ -367,6 +375,14 @@ def test_marker_union_deduplicate():
     )
 
     assert str(m) == 'sys_platform == "darwin" or implementation_name == "cpython"'
+
+
+def test_marker_union_of_python_version_and_python_full_version():
+    m = parse_marker('python_version >= "3.6"')
+    m2 = parse_marker('python_full_version >= "3.0.0"')
+    union = m.union(m2)
+
+    assert str(union) == 'python_full_version >= "3.0.0"'
 
 
 def test_marker_union_intersect_single_marker():


### PR DESCRIPTION
Resolves: python-poetry#<!-- add issue number/link here -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [X] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
recognise that `python_version` and `python_full_version` markers say much the same thing and often can be merged

As an example of the difference this makes, the `poetry export` testcase that I have added in https://github.com/python-poetry/poetry/pull/5156 sees the following diff when using this fix:

```diff
- click-didyoumean==0.3.0 ; python_full_version >= "3.6.2" and python_full_version < "4.0.0" and python_version >= "3.7" and python_version < "4.0"
+ click-didyoumean==0.3.0 ; python_version >= "3.7" and python_full_version < "4.0.0"
- click==7.1.2 ; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.7" or python_version >= "3.6" and python_version < "3.7" and python_full_version >= "3.5.0"
+ click==7.1.2 ; python_version >= "3.6" and python_version < "3.7"
- click==8.0.3 ; python_version >= "3.7" and python_version < "4.0" or python_full_version >= "3.6.2" and python_full_version < "4.0.0" and python_version >= "3.7" and python_version < "4.0"
+ click==8.0.3 ; python_version >= "3.7" and python_version < "4.0" or python_version >= "3.7" and python_full_version < "4.0.0"
```

The last click marker is not quite perfect, in ideal world we'd recognise that `python_version < "4.0"` was the same as `python_full_version < "4.0.0"` and then merge things - but it's a substantial improvement.