### PR TITLE
Single marker union simplifications

### DIFF
--- a/src/poetry/core/semver/empty_constraint.py
+++ b/src/poetry/core/semver/empty_constraint.py
@@ -14,6 +14,9 @@ class EmptyConstraint(VersionConstraint):
     def is_any(self) -> bool:
         return False
 
+    def is_simple(self) -> bool:
+        return True
+
     def allows(self, version: "Version") -> bool:
         return False
 

--- a/src/poetry/core/semver/version.py
+++ b/src/poetry/core/semver/version.py
@@ -78,6 +78,9 @@ class Version(PEP440Version, VersionRangeConstraint):
     def is_empty(self) -> bool:
         return False
 
+    def is_simple(self) -> bool:
+        return True
+
     def allows(self, version: "Version") -> bool:
         if version is None:
             return False

--- a/src/poetry/core/semver/version_constraint.py
+++ b/src/poetry/core/semver/version_constraint.py
@@ -16,6 +16,10 @@ class VersionConstraint:
         raise NotImplementedError()
 
     @abstractmethod
+    def is_simple(self) -> bool:
+        raise NotImplementedError()
+
+    @abstractmethod
     def allows(self, version: "Version") -> bool:
         raise NotImplementedError()
 

--- a/src/poetry/core/semver/version_range.py
+++ b/src/poetry/core/semver/version_range.py
@@ -64,6 +64,9 @@ class VersionRange(VersionRangeConstraint):
     def is_any(self) -> bool:
         return self._min is None and self._max is None
 
+    def is_simple(self) -> bool:
+        return self._min is None or self._max is None
+
     def allows(self, other: "Version") -> bool:
         if self._min is not None:
             if other < self._min:

--- a/src/poetry/core/semver/version_union.py
+++ b/src/poetry/core/semver/version_union.py
@@ -80,6 +80,9 @@ class VersionUnion(VersionConstraint):
     def is_any(self) -> bool:
         return False
 
+    def is_simple(self) -> bool:
+        return self.excludes_single_version()
+
     def allows(self, version: "Version") -> bool:
         return any([constraint.allows(version) for constraint in self._ranges])
 

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -173,17 +173,51 @@ def test_single_marker_union():
     union = m.union(parse_marker('implementation_name == "cpython"'))
     assert str(union) == 'sys_platform == "darwin" or implementation_name == "cpython"'
 
+
+def test_single_marker_union_is_any():
     m = parse_marker('python_version >= "3.4"')
 
     union = m.union(parse_marker('python_version < "3.6"'))
     assert union.is_any()
 
 
-def test_single_marker_union_compacts_constraints():
-    m = parse_marker('python_version < "3.6"')
+@pytest.mark.parametrize(
+    ("marker1", "marker2", "expected"),
+    [
+        (
+            'python_version < "3.6"',
+            'python_version < "3.4"',
+            'python_version < "3.6"',
+        ),
+        (
+            'sys_platform == "linux"',
+            'sys_platform != "win32"',
+            'sys_platform != "win32"',
+        ),
+        (
+            'python_version == "3.6"',
+            'python_version > "3.6"',
+            'python_version >= "3.6"',
+        ),
+        (
+            'python_version == "3.6"',
+            'python_version < "3.6"',
+            'python_version <= "3.6"',
+        ),
+        (
+            'python_version < "3.6"',
+            'python_version > "3.6"',
+            'python_version != "3.6"',
+        ),
+    ],
+)
+def test_single_marker_union_is_single_marker(
+    marker1: str, marker2: str, expected: str
+):
+    m = parse_marker(marker1)
 
-    union = m.union(parse_marker('python_version < "3.4"'))
-    assert str(union) == 'python_version < "3.6"'
+    union = m.union(parse_marker(marker2))
+    assert str(union) == expected
 
 
 def test_single_marker_union_with_multi():


### PR DESCRIPTION
Relates-to: python-poetry/poetry#5192

Allows the following new simplifications:
`sys_platform == "linux" or sys_platform != "win32"` -> `sys_platform != "win32"`
`python_version == "3.6" or python_version > "3.6"` -> `python_version >= "3.6"`
`python_version == "3.6" or python_version < "3.6"` -> `python_version <= "3.6"`
`python_version < "3.6" or python_version > "3.6"` -> `python_version != "3.6"`