### PR TITLE
remove dataclasses from build-system requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,6 @@ appdirs = []
 pyrsistent = "https://raw.githubusercontent.com/tobgu/pyrsistent/master/LICENSE.mit"
 
 [build-system]
-requires = ["dataclasses>=0.6;python_version < '3.7'"]
+requires = []
 build-backend = "poetry.core.masonry.api"
 backend-path = ["src"]


### PR DESCRIPTION
With Python 3.6 deprecated in #263, the `build-system.requires` entries for `dataclasses` is not required.
