### PR TITLE
black: remove deprecated option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ pep517 = "^0.11.0"
 
 [tool.black]
 line-length = 88
-experimental_string_processing = true
+preview = true
 include = '\.pyi?$'
 extend-exclude = "src/poetry/core/_vendor/*"
 


### PR DESCRIPTION
```console
/.cache/pre-commit/repopvubzgse/py_env-python3.9/lib/python3.9/site-packages/black/mode.py:151: Deprecated: `experimental string processing` has been included in `preview` and deprecated. Use `preview` instead.
  warn(
```
