### PR TITLE
Fix special case of get_python_constraint_from_marker() and SingleMarker.only()

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -294,9 +294,9 @@ class SingleMarker(BaseMarker):
 
         return self
 
-    def only(self, *marker_names: str) -> Union["SingleMarker", EmptyMarker]:
+    def only(self, *marker_names: str) -> Union["SingleMarker", AnyMarker]:
         if self.name not in marker_names:
-            return EmptyMarker()
+            return AnyMarker()
 
         return self
 

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -35,6 +35,7 @@ def test_convert_markers():
             'python_full_version >= "3.6.1" and python_full_version < "4.0.0"',
             ">=3.6.1, <4.0.0",
         ),
+        ('sys_platform == "linux"', "*"),
     ],
 )
 def test_get_python_constraint_from_marker(marker: str, constraint: str):

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -738,6 +738,7 @@ def test_exclude(marker: str, excluded: str, expected: str):
     "marker, only, expected",
     [
         ('python_version >= "3.6"', ["python_version"], 'python_version >= "3.6"'),
+        ('python_version >= "3.6"', ["sys_platform"], ""),
         (
             'python_version >= "3.6" and extra == "foo"',
             ["python_version"],


### PR DESCRIPTION
- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

This PR fixes the util function `get_python_constraint_from_marker()` by fixing `SingleMarker.only()`.

Given a marker not containing `python_version` or `python_full_version` (e.g. `'sys_platform == "linux"'`), any python version should be allowed. Thus, `get_python_constraint_from_marker()` should return `"*"`. Analogously, `only("python_version")` on a `SingleMarker` `'sys_platform == "linux"'` should return `AnyMarker()` instead of `EmptyMarker()` because if `python_version` is not mentioned, any version is fine.

If the last point seems counterintuitive, keep in mind that `""` (empty string) **does not represent** `EmptyMarker` **but** `AnyMarker`.

Rationale: This fix enables further improvements to reduce the number of overrides in poetry's dependency resolution.