### PR TITLE
Improve union of multi markers

### DIFF
--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -10,22 +10,27 @@ from poetry.core.version.markers import parse_marker
 
 def test_convert_markers():
     marker = parse_marker(
-        'sys_platform == "win32" and python_version < "3.6" or sys_platform == "win32"'
+        'sys_platform == "win32" and python_version < "3.6" or sys_platform == "linux"'
         ' and python_version < "3.6" and python_version >= "3.3" or sys_platform =='
-        ' "win32" and python_version < "3.3"'
+        ' "darwin" and python_version < "3.3"'
     )
-
     converted = convert_markers(marker)
-
     assert converted["python_version"] == [
         [("<", "3.6")],
         [("<", "3.6"), (">=", "3.3")],
         [("<", "3.3")],
     ]
 
+    marker = parse_marker(
+        'sys_platform == "win32" and python_version < "3.6" or sys_platform == "win32"'
+        ' and python_version < "3.6" and python_version >= "3.3" or sys_platform =='
+        ' "win32" and python_version < "3.3"'
+    )
+    converted = convert_markers(marker)
+    assert converted["python_version"] == [[("<", "3.6")]]
+
     marker = parse_marker('python_version == "2.7" or python_version == "2.6"')
     converted = convert_markers(marker)
-
     assert converted["python_version"] == [[("==", "2.7")], [("==", "2.6")]]
 
 


### PR DESCRIPTION
Relates-to: https://github.com/python-poetry/poetry/issues/5192

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Improves the union of multi markers with all kinds of markers. See added test cases for new simplifications that were not possible before.

Improving the union of multi markers is similar but a bit more complicated than #226. That's because both `MarkerUnion.intersect()` and `MarkerUnion.union()` as well as `MultiMarker.union()` prefer to return a `MarkerUnion` of `MultiMarkers` instead of a `MultiMarker` of `MarkerUnions`. Therefore, in addition to the standard `MultiMarker.union()` method a `MultiMarker.union_simplify() `method is introduced. This method prefers to return a `MultiMarker` instead of a `MarkerUnion`, but returns `None` if no simplification is possible in order to avoid an endless recursion.
