### PR TITLE
build whl using shutil move with copy instead of copy2

### DIFF
--- a/src/poetry/core/masonry/builders/wheel.py
+++ b/src/poetry/core/masonry/builders/wheel.py
@@ -122,7 +122,7 @@ class WheelBuilder(Builder):
         wheel_path = dist_dir / self.wheel_filename
         if wheel_path.exists():
             wheel_path.unlink()
-        shutil.move(temp_path, str(wheel_path))
+        shutil.move(temp_path, str(wheel_path), copy_function=shutil.copy)
 
         logger.info(f"Built {self.wheel_filename}")
 


### PR DESCRIPTION
Resolves: I have not created an issue for this and seems like no one else has. See issue description below.

I have an issue using "poetry build" inside a pipeline container run with podman.
I get permission errors when poetry uses shutils copystat function.
The copystat function copies "extended attributes" which fails in a podman container with mounted drives due to permission issues.

When changing the shutil.move function to use copy instead of copy2 the "extended attributes" will not be transfered and the build process will succeed in podman containers without breaking existing functionality.