### PR TITLE
Set GIT_DIR env when checking for git

### DIFF
--- a/src/poetry/core/vcs/__init__.py
+++ b/src/poetry/core/vcs/__init__.py
@@ -16,9 +16,13 @@ def get_vcs(directory: Path) -> Optional[Git]:
     try:
         from poetry.core.vcs.git import executable
 
+        env = os.environ.copy()
+        env["GIT_DIR"] = str(directory.resolve())
         git_dir = (
             subprocess.check_output(
-                [executable(), "rev-parse", "--show-toplevel"], stderr=subprocess.STDOUT
+                [executable(), "rev-parse", "--show-toplevel"],
+                stderr=subprocess.STDOUT,
+                env=env,
             )
             .decode()
             .strip()


### PR DESCRIPTION
This prevents poetry from traversing beyond project directory

Currently 2 tests are failing, because they expect to be in a git repo (in this case, `poetry-core`); TODO: make them have their own repo, which should have been the case from the start

Resolves: python-poetry/poetry#1946

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
