### PR TITLE
Add __eq__ for VCSDependency

### DIFF
--- a/src/poetry/core/packages/vcs_dependency.py
+++ b/src/poetry/core/packages/vcs_dependency.py
@@ -176,3 +176,15 @@ class VCSDependency(Dependency):
 
     def __hash__(self) -> int:
         return hash((self._name, self._vcs, self._branch, self._tag, self._rev))
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, VCSDependency):
+            return False
+
+        return (self._name, self._vcs, self._branch, self._tag, self._rev) == (
+            other._name,
+            other._vcs,
+            other._branch,
+            other._tag,
+            other._rev,
+        )


### PR DESCRIPTION
VCSDependency already defines `__hash__`, listing only relevant fields for
hashing. However, when doing dictionary lookup, Python will compare not
only hashes, but also equality by `__eq__`. Since `__eq__` was not defined
for VCSDependency, cache for deferred VCS dependencies in Poetry itself
did not work.

See this line in poetry.puzzle.provider:

https://github.com/python-poetry/poetry/blob/5900f3761cd0811c3e717b356b1b877b971c4ff0/src/poetry/puzzle/provider.py#L174

When project has several VCS dependencies AND poetry tries different
solution, the repo will be cloned and parsed for each solution
independently, while this is obviously not what the user wanted.

For our project this fix reduces 'poetry lock --no-update' time from 4
minutes to 1m20s.

This may be related to problems reported in Poetry issues python-poetry#2094, python-poetry#5194
and python-poetry#4924.

Resolves: 


- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
