### PR TITLE
Fix an issue where dependencies with an epoch are parsed as empty

### DIFF
--- a/src/poetry/core/semver/version.py
+++ b/src/poetry/core/semver/version.py
@@ -48,9 +48,6 @@ class Version(PEP440Version, VersionRangeConstraint):
 
         return self.stable.next_major()
 
-    def first_pre_release(self) -> Version:
-        return self.__class__(release=self.release, pre=ReleaseTag("alpha"))
-
     @property
     def min(self) -> Version:
         return self

--- a/src/poetry/core/semver/version_range.py
+++ b/src/poetry/core/semver/version_range.py
@@ -30,7 +30,7 @@ class VersionRange(VersionRangeConstraint):
             and not full_max.is_postrelease()
             and (min is None or min.is_stable() or min.release != full_max.release)
         ):
-            full_max = full_max.first_pre_release()
+            full_max = full_max.first_prerelease()
 
         self._min = min
         self._max = max

--- a/tests/semver/test_helpers.py
+++ b/tests/semver/test_helpers.py
@@ -275,6 +275,33 @@ def test_parse_constraint_multi(input: str):
 
 
 @pytest.mark.parametrize(
+    "input, output",
+    [
+        (
+            ">1!2,<=2!3",
+            VersionRange(
+                Version.from_parts(2, 0, 0, epoch=1),
+                Version.from_parts(3, 0, 0, epoch=2),
+                include_min=False,
+                include_max=True,
+            ),
+        ),
+        (
+            ">=1!2,<2!3",
+            VersionRange(
+                Version.from_parts(2, 0, 0, epoch=1),
+                Version.from_parts(3, 0, 0, epoch=2),
+                include_min=True,
+                include_max=False,
+            ),
+        ),
+    ],
+)
+def test_parse_constraint_multi_with_epochs(input: str, output: VersionRange):
+    assert parse_constraint(input) == output
+
+
+@pytest.mark.parametrize(
     "input",
     [">=2.7,!=3.0.*,!=3.1.*", ">=2.7, !=3.0.*, !=3.1.*", ">= 2.7, != 3.0.*, != 3.1.*"],
 )


### PR DESCRIPTION
* remove duplicated and buggy method of first_pre_release() and use correct method first_prerelase()

Resolves: python-poetry/poetry#5374

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
