### PR TITLE
build: do not generate setup.py by default

### DIFF
--- a/src/poetry/core/json/schemas/poetry-schema.json
+++ b/src/poetry/core/json/schemas/poetry-schema.json
@@ -635,7 +635,7 @@
         "generate-setup-file": {
           "type": "boolean",
           "description": "Generate and include a setup.py file in sdist.",
-          "default": true
+          "default": false
         },
         "script": {
           "$ref": "#/definitions/build-script"

--- a/src/poetry/core/packages/project_package.py
+++ b/src/poetry/core/packages/project_package.py
@@ -87,4 +87,4 @@ class ProjectPackage(Package):
         return super(Package, self).__hash__()
 
     def build_should_generate_setup(self) -> bool:
-        return self.build_config.get("generate-setup-file", True)
+        return self.build_config.get("generate-setup-file", False)

--- a/tests/masonry/builders/fixtures/extended/pyproject.toml
+++ b/tests/masonry/builders/fixtures/extended/pyproject.toml
@@ -13,3 +13,4 @@ homepage = "https://python-poetry.org/"
 
 [tool.poetry.build]
 script = "build.py"
+generate-setup-file = true

--- a/tests/masonry/builders/fixtures/src_extended/pyproject.toml
+++ b/tests/masonry/builders/fixtures/src_extended/pyproject.toml
@@ -11,4 +11,6 @@ readme = "README.rst"
 
 homepage = "https://python-poetry.org/"
 
-build = "build.py"
+[tool.poetry.build]
+script = "build.py"
+generate-setup-file = true

--- a/tests/masonry/builders/test_complete.py
+++ b/tests/masonry/builders/test_complete.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import ast
 import os
 import platform
 import re
@@ -12,7 +11,6 @@ import zipfile
 
 from pathlib import Path
 from typing import TYPE_CHECKING
-from typing import Any
 from typing import Iterator
 
 import pytest
@@ -540,29 +538,9 @@ def test_package_with_include(mocker: MockerFixture) -> None:
         assert "with_include-1.2.3/package_with_include/__init__.py" in names
         assert "with_include-1.2.3/tests/__init__.py" in names
         assert "with_include-1.2.3/pyproject.toml" in names
-        assert "with_include-1.2.3/setup.py" in names
         assert "with_include-1.2.3/PKG-INFO" in names
         assert "with_include-1.2.3/for_wheel_only/__init__.py" not in names
         assert "with_include-1.2.3/src/src_package/__init__.py" in names
-
-        file = tar.extractfile("with_include-1.2.3/setup.py")
-        assert file
-        setup = file.read()
-        setup_ast = ast.parse(setup)
-
-        setup_ast.body = [n for n in setup_ast.body if isinstance(n, ast.Assign)]
-        ns: dict[str, Any] = {}
-        exec(compile(setup_ast, filename="setup.py", mode="exec"), ns)
-        assert ns["package_dir"] == {"": "src"}
-        assert ns["packages"] == [
-            "extra_dir",
-            "extra_dir.sub_pkg",
-            "package_with_include",
-            "src_package",
-            "tests",
-        ]
-        assert ns["package_data"] == {"": ["*"]}
-        assert ns["modules"] == ["my_module"]
 
     whl = module_path / "dist" / "with_include-1.2.3-py3-none-any.whl"
 
@@ -612,7 +590,6 @@ def test_respect_format_for_explicit_included_files() -> None:
             in names
         )
         assert "exclude_whl_include_sdist-0.1.0/pyproject.toml" in names
-        assert "exclude_whl_include_sdist-0.1.0/setup.py" in names
         assert "exclude_whl_include_sdist-0.1.0/PKG-INFO" in names
 
     whl = module_path / "dist" / "exclude_whl_include_sdist-0.1.0-py3-none-any.whl"
@@ -625,5 +602,3 @@ def test_respect_format_for_explicit_included_files() -> None:
         assert "exclude_whl_include_sdist/compiled/source.c" not in names
         assert "exclude_whl_include_sdist/compiled/source.h" not in names
         assert "exclude_whl_include_sdist/cython_code.pyx" not in names
-
-    pass

--- a/tests/masonry/builders/test_sdist.py
+++ b/tests/masonry/builders/test_sdist.py
@@ -492,7 +492,6 @@ def test_default_with_excluded_data(mocker: MockerFixture) -> None:
         assert "my_package-1.2.3/my_package/__init__.py" in names
         assert "my_package-1.2.3/my_package/data/data1.txt" in names
         assert "my_package-1.2.3/pyproject.toml" in names
-        assert "my_package-1.2.3/setup.py" in names
         assert "my_package-1.2.3/PKG-INFO" in names
         # all last modified times should be set to a valid timestamp
         for tarinfo in tar.getmembers():
@@ -523,7 +522,6 @@ def test_src_excluded_nested_data() -> None:
         assert "my_package-1.2.3/LICENSE" in names
         assert "my_package-1.2.3/README.rst" in names
         assert "my_package-1.2.3/pyproject.toml" in names
-        assert "my_package-1.2.3/setup.py" in names
         assert "my_package-1.2.3/PKG-INFO" in names
         assert "my_package-1.2.3/my_package/__init__.py" in names
         assert "my_package-1.2.3/my_package/data/sub_data/data2.txt" not in names


### PR DESCRIPTION
This is the first step in removing setup file generation from Poetry
projects. With this change, projects that require a setup.py to be
generated when a build script is used needs to explicitly set
`tool.poetry.build.generate-setup-file`, introduced in #26, to `true`
in `pyproject.toml`.

**References:**
- #26 
- https://github.com/python-poetry/poetry/issues/1338#issuecomment-657860111

**Warning** :warning: 
This is a breaking change for users relying on setuptools to run their build script without explicitly configuring the generation.