### PR TITLE
specification: add ignore_features flag to is_same_package_as

### DIFF
--- a/src/poetry/core/packages/specification.py
+++ b/src/poetry/core/packages/specification.py
@@ -71,9 +71,15 @@ class PackageSpecification:
     def features(self) -> frozenset[str]:
         return self._features
 
-    def is_same_package_as(self, other: PackageSpecification) -> bool:
-        if other.complete_name != self.complete_name:
-            return False
+    def is_same_package_as(
+        self, other: PackageSpecification, *, ignore_features: bool = False
+    ) -> bool:
+        if ignore_features:
+            if other.name != self.name:
+                return False
+        else:
+            if other.complete_name != self.complete_name:
+                return False
 
         if self._source_type:
             if self._source_type != other.source_type:

--- a/tests/packages/test_specification.py
+++ b/tests/packages/test_specification.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from poetry.core.packages.specification import PackageSpecification
+
+
+@pytest.mark.parametrize(
+    "spec1, spec2, expected_exact, expected_ignore_features",
+    [
+        (PackageSpecification("a"), PackageSpecification("a"), True, True),
+        (PackageSpecification("a"), PackageSpecification("ab"), False, False),
+        (
+            PackageSpecification("a"),
+            PackageSpecification("a", features=["c"]),
+            False,
+            True,
+        ),
+        (
+            PackageSpecification("a", features=["c"]),
+            PackageSpecification("a", features=["c", "d"]),
+            False,
+            True,
+        ),
+    ],
+)
+def test_is_same_package_ignore_features(
+    spec1: PackageSpecification,
+    spec2: PackageSpecification,
+    expected_exact: bool,
+    expected_ignore_features: bool,
+) -> None:
+    assert spec1.is_same_package_as(spec2) == expected_exact
+    assert (
+        spec1.is_same_package_as(spec2, ignore_features=True)
+        == expected_ignore_features
+    )


### PR DESCRIPTION
... as proposed in https://github.com/python-poetry/poetry/pull/5435#discussion_r846855182

**Update:** Since `allow_similar` is too ambiguous the parameter is called `ignore_features`.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
