### PR TITLE
factory: consider "python" and "system" in create_dependency() even if "markers" are present

### DIFF
--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
     from poetry.core.packages.types import DependencyTypes
     from poetry.core.poetry import Poetry
     from poetry.core.spdx.license import License
-    from poetry.core.version.markers import BaseMarker
 
     DependencyConstraint = Union[str, Dict[str, Any]]
     DependencyConfig = Mapping[
@@ -335,27 +334,25 @@ class Factory:
                     extras=constraint.get("extras", []),
                 )
 
-            if not markers:
-                marker: BaseMarker = AnyMarker()
-                if python_versions:
-                    marker = marker.intersect(
-                        parse_marker(
-                            create_nested_marker(
-                                "python_version", parse_constraint(python_versions)
-                            )
-                        )
-                    )
+            marker = parse_marker(markers) if markers else AnyMarker()
 
-                if platform:
-                    marker = marker.intersect(
-                        parse_marker(
-                            create_nested_marker(
-                                "sys_platform", parse_generic_constraint(platform)
-                            )
+            if python_versions:
+                marker = marker.intersect(
+                    parse_marker(
+                        create_nested_marker(
+                            "python_version", parse_constraint(python_versions)
                         )
                     )
-            else:
-                marker = parse_marker(markers)
+                )
+
+            if platform:
+                marker = marker.intersect(
+                    parse_marker(
+                        create_nested_marker(
+                            "sys_platform", parse_generic_constraint(platform)
+                        )
+                    )
+                )
 
             if not marker.is_any():
                 dependency.marker = marker


### PR DESCRIPTION
Resolves: python-poetry/poetry#3444
Resolves: python-poetry/poetry#3639
Resolves: python-poetry/poetry#4959
Resolves: python-poetry/poetry#4965

If `markers` are present in a dependency specification, `python` and `system` should not be ignored. There's even an [example in the docs](https://python-poetry.org/docs/master/dependency-specification/#expanded-dependency-specification-syntax) that does not work at the moment.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
