### PR TITLE
specification: make is_same_package_as() commutative and …

### DIFF
--- a/src/poetry/core/packages/specification.py
+++ b/src/poetry/core/packages/specification.py
@@ -75,9 +75,10 @@ class PackageSpecification:
         if other.complete_name != self.complete_name:
             return False
 
+        if self._source_type != other.source_type:
+            return False
+
         if self._source_type:
-            if self._source_type != other.source_type:
-                return False
 
             if (
                 self._source_url or other.source_url

--- a/tests/packages/test_specification.py
+++ b/tests/packages/test_specification.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pytest
+
+from poetry.core.packages.specification import PackageSpecification
+
+
+@pytest.mark.parametrize(
+    "spec1, spec2, expected",
+    [
+        (PackageSpecification("a"), PackageSpecification("a"), True),
+        (PackageSpecification("a", "type1"), PackageSpecification("a", "type1"), True),
+        (PackageSpecification("a", "type1"), PackageSpecification("a", "type2"), False),
+        (PackageSpecification("a"), PackageSpecification("a", "type1"), False),
+        (PackageSpecification("a", "type1"), PackageSpecification("a"), False),
+    ],
+)
+def test_is_same_package_source_type(
+    spec1: PackageSpecification,
+    spec2: PackageSpecification,
+    expected: bool,
+) -> None:
+    assert spec1.is_same_package_as(spec2) == expected


### PR DESCRIPTION
always return False if source_types do not match

Fixes an issue where `p1.is_same_package_as(p2)` returns `True`, but `p2.is_same_package_as(p1)` return `False`.

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
