### PR TITLE
canonicalize package name correctly

### DIFF
--- a/src/poetry/core/utils/helpers.py
+++ b/src/poetry/core/utils/helpers.py
@@ -17,7 +17,7 @@ from typing import no_type_check
 from poetry.core.version.pep440 import PEP440Version
 
 
-_canonicalize_regex = re.compile(r"[-_]+")
+_canonicalize_regex = re.compile(r"[-_.]+")
 
 
 def combine_unicode(string: str) -> str:

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -73,7 +73,7 @@ isort@ git+git://github.com/timothycrosley/isort.git@e63ae06ec7d70b06df9e5283576
     assert result == expected
 
 
-@pytest.mark.parametrize("raw", ["a-b-c", "a_b-c", "a_b_c", "a-b_c"])
+@pytest.mark.parametrize("raw", ["a-b-c", "a_b-c", "a_b_c", "a-b_c", "a.b-c"])
 def test_utils_helpers_canonical_names(raw: str) -> None:
     assert canonicalize_name(raw) == "a-b-c"
 


### PR DESCRIPTION
Resolves: https://github.com/python-poetry/poetry/issues/5474, https://github.com/python-poetry/poetry/issues/3132, https://github.com/python-poetry/poetry/issues/3200

looks like this regex was probably just badly copied from https://github.com/pypa/packaging/blob/ba124324e866e518ebfe0378a25b6ba4816e5880/packaging/utils.py#L27

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [X] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
