### PR TITLE
add set_version() to PackageProject

### DIFF
--- a/src/poetry/core/packages/project_package.py
+++ b/src/poetry/core/packages/project_package.py
@@ -4,12 +4,12 @@ from typing import TYPE_CHECKING
 from typing import Any
 
 from poetry.core.semver.helpers import parse_constraint
+from poetry.core.semver.version import Version
 from poetry.core.version.markers import parse_marker
 
 
 if TYPE_CHECKING:
     from poetry.core.packages.types import DependencyTypes
-    from poetry.core.semver.version_constraint import VersionConstraint
 
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.utils import create_nested_marker
@@ -19,16 +19,16 @@ class ProjectPackage(Package):
     def __init__(
         self,
         name: str,
-        version: str | VersionConstraint,
+        version: str | Version,
         pretty_version: str | None = None,
     ) -> None:
         super().__init__(name, version, pretty_version)
 
-        self.build_config = {}
-        self.packages = []
-        self.include = []
-        self.exclude = []
-        self.custom_urls = {}
+        self.build_config: dict[str, Any] = {}
+        self.packages: list[dict[str, Any]] = []
+        self.include: list[dict[str, Any]] = []
+        self.exclude: list[dict[str, Any]] = []
+        self.custom_urls: dict[str, str] = {}
 
         if self._python_versions == "*":
             self._python_constraint = parse_constraint("~2.7 || >=3.4")
@@ -64,7 +64,7 @@ class ProjectPackage(Package):
         )
 
     @property
-    def urls(self) -> dict[str, Any]:
+    def urls(self) -> dict[str, str]:
         urls = super().urls
 
         urls.update(self.custom_urls)
@@ -73,3 +73,12 @@ class ProjectPackage(Package):
 
     def build_should_generate_setup(self) -> bool:
         return self.build_config.get("generate-setup-file", True)
+
+    def set_version(
+        self, version: str | Version, pretty_version: str | None = None
+    ) -> None:
+        if not isinstance(version, Version):
+            version = Version.parse(version)
+
+        self._version = version
+        self._pretty_version = pretty_version or version.text


### PR DESCRIPTION
Let's get rid of https://github.com/python-poetry/poetry/blob/master/src/poetry/packages/project_package.py.  If set_version() is useful, put it here.