### PR TITLE
Fix editable installations using `setup.py`.

### DIFF
--- a/src/poetry/core/masonry/builders/wheel.py
+++ b/src/poetry/core/masonry/builders/wheel.py
@@ -169,7 +169,7 @@ class WheelBuilder(Builder):
 
                     build_dir = self._path / "build"
                     lib = list(build_dir.glob("lib.*"))
-                    if not lib:
+                    if self._editable or not lib:
                         # The result of building the extensions
                         # does not exist, this may due to conditional
                         # builds, so we assume that it's okay

--- a/src/poetry/core/masonry/builders/wheel.py
+++ b/src/poetry/core/masonry/builders/wheel.py
@@ -201,6 +201,15 @@ class WheelBuilder(Builder):
             )
 
     def _run_build_command(self, setup: Path) -> None:
+        if self._editable:
+            subprocess.check_call(
+                [
+                    self.executable.as_posix(),
+                    str(setup),
+                    "build_ext",
+                    "--inplace",
+                ]
+            )
         subprocess.check_call(
             [
                 self.executable.as_posix(),


### PR DESCRIPTION
Hi! I have really come to love poetry, but cannot currently use it as is for my project that uses compiled modules. The issues I've encountered (and fixed in this PR) are detailed below. Hopefully these small patches are helpful to others also.

When you have configured poetry to generate a setup file, for example by using:
```
[tool.poetry.build]
script = "build.py"
generate-setup-file = true
```
and then attempt an editable install, `poetry` will include the module in the generated wheel. This shouldn't happen according to [PEP 660](https://peps.python.org/pep-0660/) (you should only include the files which are necessary for the editable installation to work), and it gets in the way of the editable module being imported from the "editable" path. This is fixed in the commit labelled: "fix: Do not include library in wheel when performing an editable install".

Additionally, when your project uses extension modules, to be usable in an editable installation they need to be built in-place during the editable installation. This is added in the commit labelled: "enh: Build extension modules inplace during editable install." PEP 660 also mentions that this is an optional thing to do, but for modules with compiled dependencies, it is required to achieve an editable installation.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code. (I've tested things locally, but will wait for your blessing before worrying about unit tests).
- [ ] Updated **documentation** for changed code. (Based on comments in https://github.com/python-poetry/poetry/issues/2740, I don't think you are documenting this functionality yet).

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
