### PR TITLE
chore(tests): remove type errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ module = [
   'lark.*',
   'setuptools.*',
   'tomlkit.*',
+  'virtualenv.*',
 ]
 ignore_missing_imports = true
 
@@ -107,20 +108,6 @@ module = [
   'poetry.core.version.pep440.parser',
   'poetry.core.version.pep440.segments',
   'poetry.core.version.pep440.version',
-  # test modules
-  'tests.conftest',
-  'tests.integration.test_pep517',
-  'tests.json.*',
-  'tests.masonry.*',
-  'tests.packages.*',
-  'tests.pyproject.*',
-  'tests.semver.*',
-  'tests.spdx.*',
-  'tests.test_factory',
-  'tests.testutils.*',
-  'tests.utils.*',
-  'tests.vcs.*',
-  'tests.version.*',
 ]
 ignore_errors = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ known_third_party = ["poetry.core._vendor"]
 strict = true
 explicit_package_bases = true
 namespace_packages = true
+show_error_codes = true
 mypy_path = "src"
 files = "src, tests"
 exclude = "(?x)(^tests/.*/fixtures | ^src/poetry/core/_vendor)"
@@ -110,6 +111,11 @@ module = [
   'poetry.core.version.pep440.version',
 ]
 ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = ['tests.*']
+# TODO: remove when mypy runs in environment with dependencies
+disallow_untyped_decorators = false
 
 [tool.vendoring]
 destination = "src/poetry/core/_vendor/"

--- a/src/poetry/core/masonry/builders/sdist.py
+++ b/src/poetry/core/masonry/builders/sdist.py
@@ -15,7 +15,7 @@ from posixpath import join as pjoin
 from pprint import pformat
 from tarfile import TarInfo
 from typing import TYPE_CHECKING
-from typing import ContextManager
+from typing import Iterator
 
 from poetry.core.masonry.builders.builder import Builder
 from poetry.core.masonry.builders.builder import BuildIncludeFile
@@ -213,7 +213,7 @@ class SdistBuilder(Builder):
         ).encode()
 
     @contextmanager
-    def setup_py(self) -> ContextManager[Path]:
+    def setup_py(self) -> Iterator[Path]:
         setup = self._path / "setup.py"
         has_setup = setup.exists()
 

--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -86,10 +86,10 @@ class Package(PackageSpecification):
         self._authors = []
         self._maintainers = []
 
-        self.homepage = None
-        self.repository_url = None
-        self.documentation_url = None
-        self.keywords = []
+        self.homepage: str | None = None
+        self.repository_url: str | None = None
+        self.documentation_url: str | None = None
+        self.keywords: list[str] = []
         self._license = None
         self.readmes: tuple[Path, ...] = ()
 

--- a/src/poetry/core/packages/utils/utils.py
+++ b/src/poetry/core/packages/utils/utils.py
@@ -161,7 +161,7 @@ def group_markers(
     return groups
 
 
-def convert_markers(marker: BaseMarker) -> dict[str, list[tuple[str, str]]]:
+def convert_markers(marker: BaseMarker) -> dict[str, list[list[tuple[str, str]]]]:
     groups = group_markers([marker])
 
     requirements = {}

--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -64,7 +64,7 @@ class BaseMarker:
     def is_empty(self) -> bool:
         return False
 
-    def validate(self, environment: dict[str, Any]) -> bool:
+    def validate(self, environment: dict[str, Any] | None) -> bool:
         raise NotImplementedError()
 
     def without_extras(self) -> BaseMarker:
@@ -96,7 +96,7 @@ class AnyMarker(BaseMarker):
     def is_empty(self) -> bool:
         return False
 
-    def validate(self, environment: dict[str, Any]) -> bool:
+    def validate(self, environment: dict[str, Any] | None) -> bool:
         return True
 
     def without_extras(self) -> BaseMarker:
@@ -140,7 +140,7 @@ class EmptyMarker(BaseMarker):
     def is_empty(self) -> bool:
         return True
 
-    def validate(self, environment: dict[str, Any]) -> bool:
+    def validate(self, environment: dict[str, Any] | None) -> bool:
         return False
 
     def without_extras(self) -> BaseMarker:
@@ -274,7 +274,7 @@ class SingleMarker(BaseMarker):
 
         return other.union(self)
 
-    def validate(self, environment: dict[str, Any]) -> bool:
+    def validate(self, environment: dict[str, Any] | None) -> bool:
         if environment is None:
             return True
 
@@ -505,7 +505,7 @@ class MultiMarker(BaseMarker):
 
         return None
 
-    def validate(self, environment: dict[str, Any]) -> bool:
+    def validate(self, environment: dict[str, Any] | None) -> bool:
         return all(m.validate(environment) for m in self._markers)
 
     def without_extras(self) -> BaseMarker:
@@ -695,7 +695,7 @@ class MarkerUnion(BaseMarker):
 
         return MarkerUnion.of(*new_markers)
 
-    def validate(self, environment: dict[str, Any]) -> bool:
+    def validate(self, environment: dict[str, Any] | None) -> bool:
         return any(m.validate(environment) for m in self._markers)
 
     def without_extras(self) -> BaseMarker:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import tempfile
 
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -11,7 +12,6 @@ import pytest
 import virtualenv
 
 from poetry.core.factory import Factory
-from tests.testutils import tempfile
 
 
 if TYPE_CHECKING:

--- a/tests/integration/test_pep517.py
+++ b/tests/integration/test_pep517.py
@@ -29,16 +29,18 @@ pytestmark = pytest.mark.integration
 )
 def test_pep517_check_poetry_managed(
     request: FixtureRequest, getter: str, project: str
-):
+) -> None:
     with temporary_project_directory(request.getfixturevalue(getter)(project)) as path:
         assert project_wheel_metadata(path)
 
 
-def test_pep517_check(project_source_root: Path):
+def test_pep517_check(project_source_root: Path) -> None:
     assert project_wheel_metadata(str(project_source_root))
 
 
-def test_pep517_build_sdist(temporary_directory: Path, project_source_root: Path):
+def test_pep517_build_sdist(
+    temporary_directory: Path, project_source_root: Path
+) -> None:
     build_package(
         srcdir=str(project_source_root),
         outdir=str(temporary_directory),
@@ -48,7 +50,9 @@ def test_pep517_build_sdist(temporary_directory: Path, project_source_root: Path
     assert len(distributions) == 1
 
 
-def test_pep517_build_wheel(temporary_directory: Path, project_source_root: Path):
+def test_pep517_build_wheel(
+    temporary_directory: Path, project_source_root: Path
+) -> None:
     build_package(
         srcdir=str(project_source_root),
         outdir=str(temporary_directory),
@@ -58,7 +62,7 @@ def test_pep517_build_wheel(temporary_directory: Path, project_source_root: Path
     assert len(distributions) == 1
 
 
-def test_pip_wheel_build(temporary_directory: Path, project_source_root: Path):
+def test_pip_wheel_build(temporary_directory: Path, project_source_root: Path) -> None:
     tmp = str(temporary_directory)
     pip = subprocess_run(
         "pip", "wheel", "--use-pep517", "-w", tmp, str(project_source_root)
@@ -71,7 +75,7 @@ def test_pip_wheel_build(temporary_directory: Path, project_source_root: Path):
     assert len(wheels) == 1
 
 
-def test_pip_install_no_binary(python: str, project_source_root: Path):
+def test_pip_install_no_binary(python: str, project_source_root: Path) -> None:
     subprocess_run(
         python,
         "-m",

--- a/tests/json/test_poetry_schema.py
+++ b/tests/json/test_poetry_schema.py
@@ -37,18 +37,18 @@ def multi_url_object() -> dict[str, Any]:
     }
 
 
-def test_path_dependencies(base_object: dict[str, Any]):
+def test_path_dependencies(base_object: dict[str, Any]) -> None:
     base_object["dependencies"].update({"foo": {"path": "../foo"}})
     base_object["dev-dependencies"].update({"foo": {"path": "../foo"}})
 
     assert len(validate_object(base_object, "poetry-schema")) == 0
 
 
-def test_multi_url_dependencies(multi_url_object: dict[str, Any]):
+def test_multi_url_dependencies(multi_url_object: dict[str, Any]) -> None:
     assert len(validate_object(multi_url_object, "poetry-schema")) == 0
 
 
-def test_multiline_description(base_object: dict[str, Any]):
+def test_multiline_description(base_object: dict[str, Any]) -> None:
     bad_description = "Some multi-\nline string"
     base_object["description"] = bad_description
 

--- a/tests/json/test_poetry_schema.py
+++ b/tests/json/test_poetry_schema.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from poetry.core.json import validate_object
 
 
 @pytest.fixture
-def base_object() -> dict:
+def base_object() -> dict[str, Any]:
     return {
         "name": "myapp",
         "version": "1.0.0",
@@ -17,7 +19,7 @@ def base_object() -> dict:
 
 
 @pytest.fixture
-def multi_url_object() -> dict:
+def multi_url_object() -> dict[str, Any]:
     return {
         "name": "myapp",
         "version": "1.0.0",
@@ -35,18 +37,18 @@ def multi_url_object() -> dict:
     }
 
 
-def test_path_dependencies(base_object: dict):
+def test_path_dependencies(base_object: dict[str, Any]):
     base_object["dependencies"].update({"foo": {"path": "../foo"}})
     base_object["dev-dependencies"].update({"foo": {"path": "../foo"}})
 
     assert len(validate_object(base_object, "poetry-schema")) == 0
 
 
-def test_multi_url_dependencies(multi_url_object: dict):
+def test_multi_url_dependencies(multi_url_object: dict[str, Any]):
     assert len(validate_object(multi_url_object, "poetry-schema")) == 0
 
 
-def test_multiline_description(base_object: dict):
+def test_multiline_description(base_object: dict[str, Any]):
     bad_description = "Some multi-\nline string"
     base_object["description"] = bad_description
 

--- a/tests/masonry/builders/fixtures/excluded_subpackage/example/test/excluded.py
+++ b/tests/masonry/builders/fixtures/excluded_subpackage/example/test/excluded.py
@@ -1,5 +1,5 @@
 from tests.masonry.builders.fixtures.excluded_subpackage.example import __version__
 
 
-def test_version():
+def test_version() -> None:
     assert __version__ == "0.1.0"

--- a/tests/masonry/builders/fixtures/extended_with_no_setup/build.py
+++ b/tests/masonry/builders/fixtures/extended_with_no_setup/build.py
@@ -9,7 +9,7 @@ from distutils.core import Extension
 extensions = [Extension("extended.extended", ["extended/extended.c"])]
 
 
-def build():
+def build() -> None:
     distribution = Distribution({"name": "extended", "ext_modules": extensions})
     distribution.package_dir = "extended"
 

--- a/tests/masonry/builders/test_builder.py
+++ b/tests/masonry/builders/test_builder.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
-def test_builder_find_excluded_files(mocker: MockerFixture):
+def test_builder_find_excluded_files(mocker: MockerFixture) -> None:
     p = mocker.patch("poetry.core.vcs.git.Git.get_ignored_files")
     p.return_value = []
 
@@ -31,7 +31,7 @@ def test_builder_find_excluded_files(mocker: MockerFixture):
     sys.platform == "win32",
     reason="Windows is case insensitive for the most part",
 )
-def test_builder_find_case_sensitive_excluded_files(mocker: MockerFixture):
+def test_builder_find_case_sensitive_excluded_files(mocker: MockerFixture) -> None:
     p = mocker.patch("poetry.core.vcs.git.Git.get_ignored_files")
     p.return_value = []
 
@@ -56,7 +56,9 @@ def test_builder_find_case_sensitive_excluded_files(mocker: MockerFixture):
     sys.platform == "win32",
     reason="Windows is case insensitive for the most part",
 )
-def test_builder_find_invalid_case_sensitive_excluded_files(mocker: MockerFixture):
+def test_builder_find_invalid_case_sensitive_excluded_files(
+    mocker: MockerFixture,
+) -> None:
     p = mocker.patch("poetry.core.vcs.git.Git.get_ignored_files")
     p.return_value = []
 
@@ -69,7 +71,7 @@ def test_builder_find_invalid_case_sensitive_excluded_files(mocker: MockerFixtur
     assert {"my_package/Bar/foo/bar/Foo.py"} == builder.find_excluded_files()
 
 
-def test_get_metadata_content():
+def test_get_metadata_content() -> None:
     builder = Builder(
         Factory().create_poetry(Path(__file__).parent / "fixtures" / "complete")
     )
@@ -122,7 +124,7 @@ def test_get_metadata_content():
     ]
 
 
-def test_metadata_homepage_default():
+def test_metadata_homepage_default() -> None:
     builder = Builder(
         Factory().create_poetry(Path(__file__).parent / "fixtures" / "simple_version")
     )
@@ -132,7 +134,7 @@ def test_metadata_homepage_default():
     assert metadata["Home-page"] is None
 
 
-def test_metadata_with_vcs_dependencies():
+def test_metadata_with_vcs_dependencies() -> None:
     builder = Builder(
         Factory().create_poetry(
             Path(__file__).parent / "fixtures" / "with_vcs_dependency"
@@ -146,7 +148,7 @@ def test_metadata_with_vcs_dependencies():
     assert requires_dist == "cleo @ git+https://github.com/sdispater/cleo.git@master"
 
 
-def test_metadata_with_url_dependencies():
+def test_metadata_with_url_dependencies() -> None:
     builder = Builder(
         Factory().create_poetry(
             Path(__file__).parent / "fixtures" / "with_url_dependency"
@@ -164,7 +166,7 @@ def test_metadata_with_url_dependencies():
     )
 
 
-def test_missing_script_files_throws_error():
+def test_missing_script_files_throws_error() -> None:
     builder = Builder(
         Factory().create_poetry(
             Path(__file__).parent / "fixtures" / "script_reference_file_missing"
@@ -177,7 +179,7 @@ def test_missing_script_files_throws_error():
     assert "is not found." in err.value.args[0]
 
 
-def test_invalid_script_files_definition():
+def test_invalid_script_files_definition() -> None:
     with pytest.raises(RuntimeError) as err:
         Builder(
             Factory().create_poetry(
@@ -197,7 +199,7 @@ def test_invalid_script_files_definition():
         "script_callable_legacy_table",
     ],
 )
-def test_entrypoint_scripts_legacy_warns(fixture: str):
+def test_entrypoint_scripts_legacy_warns(fixture: str) -> None:
     with pytest.warns(DeprecationWarning):
         Builder(
             Factory().create_poetry(Path(__file__).parent / "fixtures" / fixture)
@@ -236,7 +238,9 @@ def test_entrypoint_scripts_legacy_warns(fixture: str):
     ],
 )
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
-def test_builder_convert_entry_points(fixture: str, result: dict[str, list[str]]):
+def test_builder_convert_entry_points(
+    fixture: str, result: dict[str, list[str]]
+) -> None:
     entry_points = Builder(
         Factory().create_poetry(Path(__file__).parent / "fixtures" / fixture)
     ).convert_entry_points()
@@ -264,13 +268,13 @@ def test_builder_convert_entry_points(fixture: str, result: dict[str, list[str]]
         ),
     ],
 )
-def test_builder_convert_script_files(fixture: str, result: list[Path]):
+def test_builder_convert_script_files(fixture: str, result: list[Path]) -> None:
     project_root = Path(__file__).parent / "fixtures" / fixture
     script_files = Builder(Factory().create_poetry(project_root)).convert_script_files()
     assert [p.relative_to(project_root) for p in script_files] == result
 
 
-def test_metadata_with_readme_files():
+def test_metadata_with_readme_files() -> None:
     test_path = Path(__file__).parent.parent.parent / "fixtures" / "with_readme_files"
     builder = Builder(Factory().create_poetry(test_path))
 

--- a/tests/masonry/builders/test_complete.py
+++ b/tests/masonry/builders/test_complete.py
@@ -49,7 +49,7 @@ def clear_samples_dist() -> None:
     or platform.python_implementation().lower() == "pypy",
     reason="Disable test on Windows for Python <=3.6 and for PyPy",
 )
-def test_wheel_c_extension():
+def test_wheel_c_extension() -> None:
     module_path = fixtures_dir / "extended"
     builder = Builder(Factory().create_poetry(module_path))
     builder.build(fmt="all")
@@ -104,7 +104,7 @@ $""",
     or platform.python_implementation().lower() == "pypy",
     reason="Disable test on Windows for Python <=3.6 and for PyPy",
 )
-def test_wheel_c_extension_with_no_setup():
+def test_wheel_c_extension_with_no_setup() -> None:
     module_path = fixtures_dir / "extended_with_no_setup"
     builder = Builder(Factory().create_poetry(module_path))
     builder.build(fmt="all")
@@ -159,7 +159,7 @@ $""",
     or platform.python_implementation().lower() == "pypy",
     reason="Disable test on Windows for Python <=3.6 and for PyPy",
 )
-def test_wheel_c_extension_src_layout():
+def test_wheel_c_extension_src_layout() -> None:
     module_path = fixtures_dir / "src_extended"
     builder = Builder(Factory().create_poetry(module_path))
     builder.build(fmt="all")
@@ -208,7 +208,7 @@ $""",
         zip.close()
 
 
-def test_complete():
+def test_complete() -> None:
     module_path = fixtures_dir / "complete"
     builder = Builder(Factory().create_poetry(module_path))
     builder.build(fmt="all")
@@ -317,7 +317,7 @@ My Package
         zip.close()
 
 
-def test_complete_no_vcs():
+def test_complete_no_vcs() -> None:
     # Copy the complete fixtures dir to a temporary directory
     module_path = fixtures_dir / "complete"
     temporary_dir = Path(tempfile.mkdtemp()) / "complete"
@@ -420,7 +420,7 @@ My Package
         zip.close()
 
 
-def test_module_src():
+def test_module_src() -> None:
     module_path = fixtures_dir / "source_file"
     builder = Builder(Factory().create_poetry(module_path))
     builder.build(fmt="all")
@@ -444,7 +444,7 @@ def test_module_src():
         zip.close()
 
 
-def test_package_src():
+def test_package_src() -> None:
     module_path = fixtures_dir / "source_package"
     builder = Builder(Factory().create_poetry(module_path))
     builder.build(fmt="all")
@@ -469,7 +469,7 @@ def test_package_src():
         zip.close()
 
 
-def test_split_source():
+def test_split_source() -> None:
     module_path = fixtures_dir / "split_source"
     builder = Builder(Factory().create_poetry(module_path))
     builder.build(fmt="all")
@@ -495,7 +495,7 @@ def test_split_source():
         zip.close()
 
 
-def test_package_with_include(mocker: MockerFixture):
+def test_package_with_include(mocker: MockerFixture) -> None:
     module_path = fixtures_dir / "with-include"
 
     # Patch git module to return specific excluded files
@@ -582,7 +582,7 @@ def test_package_with_include(mocker: MockerFixture):
         assert "src_package/__init__.py" in names
 
 
-def test_respect_format_for_explicit_included_files():
+def test_respect_format_for_explicit_included_files() -> None:
     module_path = fixtures_dir / "exclude-whl-include-sdist"
     builder = Builder(Factory().create_poetry(module_path))
     builder.build(fmt="all")

--- a/tests/masonry/builders/test_sdist.py
+++ b/tests/masonry/builders/test_sdist.py
@@ -47,7 +47,7 @@ def project(name: str) -> Path:
     return Path(__file__).parent / "fixtures" / name
 
 
-def test_convert_dependencies():
+def test_convert_dependencies() -> None:
     package = ProjectPackage("foo", "1.2.3")
     result = SdistBuilder.convert_dependencies(
         package,
@@ -114,7 +114,7 @@ def test_convert_dependencies():
     assert result == (main, extras)
 
 
-def test_make_setup():
+def test_make_setup() -> None:
     poetry = Factory().create_poetry(project("complete"))
 
     builder = SdistBuilder(poetry)
@@ -146,7 +146,7 @@ def test_make_setup():
     }
 
 
-def test_make_pkg_info(mocker: MockerFixture):
+def test_make_pkg_info(mocker: MockerFixture) -> None:
     get_metadata_content = mocker.patch(
         "poetry.core.masonry.builders.builder.Builder.get_metadata_content"
     )
@@ -158,7 +158,7 @@ def test_make_pkg_info(mocker: MockerFixture):
     assert get_metadata_content.called
 
 
-def test_make_pkg_info_any_python():
+def test_make_pkg_info_any_python() -> None:
     poetry = Factory().create_poetry(project("module1"))
 
     builder = SdistBuilder(poetry)
@@ -169,7 +169,7 @@ def test_make_pkg_info_any_python():
     assert "Requires-Python" not in parsed
 
 
-def test_find_files_to_add():
+def test_find_files_to_add() -> None:
     poetry = Factory().create_poetry(project("complete"))
 
     builder = SdistBuilder(poetry)
@@ -191,7 +191,7 @@ def test_find_files_to_add():
     )
 
 
-def test_make_pkg_info_multi_constraints_dependency():
+def test_make_pkg_info_multi_constraints_dependency() -> None:
     poetry = Factory().create_poetry(
         Path(__file__).parent.parent.parent
         / "fixtures"
@@ -210,7 +210,7 @@ def test_make_pkg_info_multi_constraints_dependency():
     ]
 
 
-def test_find_packages():
+def test_find_packages() -> None:
     poetry = Factory().create_poetry(project("complete"))
 
     builder = SdistBuilder(poetry)
@@ -247,7 +247,7 @@ def test_find_packages():
     assert pkg_data == {"": ["*"]}
 
 
-def test_package():
+def test_package() -> None:
     poetry = Factory().create_poetry(project("complete"))
 
     builder = SdistBuilder(poetry)
@@ -261,7 +261,7 @@ def test_package():
         assert "my-package-1.2.3/LICENSE" in tar.getnames()
 
 
-def test_sdist_reproducibility():
+def test_sdist_reproducibility() -> None:
     poetry = Factory().create_poetry(project("complete"))
 
     hashes = set()
@@ -279,7 +279,7 @@ def test_sdist_reproducibility():
     assert len(hashes) == 1
 
 
-def test_setup_py_context():
+def test_setup_py_context() -> None:
     poetry = Factory().create_poetry(project("complete"))
 
     builder = SdistBuilder(poetry)
@@ -304,7 +304,7 @@ def test_setup_py_context():
             project_setup_py.unlink()
 
 
-def test_module():
+def test_module() -> None:
     poetry = Factory().create_poetry(project("module1"))
 
     builder = SdistBuilder(poetry)
@@ -318,7 +318,7 @@ def test_module():
         assert "module1-0.1/module1.py" in tar.getnames()
 
 
-def test_prelease():
+def test_prelease() -> None:
     poetry = Factory().create_poetry(project("prerelease"))
 
     builder = SdistBuilder(poetry)
@@ -330,7 +330,7 @@ def test_prelease():
 
 
 @pytest.mark.parametrize("directory", ["extended", "extended_legacy_config"])
-def test_with_c_extensions(directory: str):
+def test_with_c_extensions(directory: str) -> None:
     poetry = Factory().create_poetry(project("extended"))
 
     builder = SdistBuilder(poetry)
@@ -345,7 +345,7 @@ def test_with_c_extensions(directory: str):
         assert "extended-0.1/extended/extended.c" in tar.getnames()
 
 
-def test_with_c_extensions_src_layout():
+def test_with_c_extensions_src_layout() -> None:
     poetry = Factory().create_poetry(project("src_extended"))
 
     builder = SdistBuilder(poetry)
@@ -360,7 +360,7 @@ def test_with_c_extensions_src_layout():
         assert "extended-0.1/src/extended/extended.c" in tar.getnames()
 
 
-def test_with_src_module_file():
+def test_with_src_module_file() -> None:
     poetry = Factory().create_poetry(project("source_file"))
 
     builder = SdistBuilder(poetry)
@@ -385,7 +385,7 @@ def test_with_src_module_file():
         assert "module-src-0.1/src/module_src.py" in tar.getnames()
 
 
-def test_with_src_module_dir():
+def test_with_src_module_dir() -> None:
     poetry = Factory().create_poetry(project("source_package"))
 
     builder = SdistBuilder(poetry)
@@ -411,7 +411,7 @@ def test_with_src_module_dir():
         assert "package-src-0.1/src/package_src/module.py" in tar.getnames()
 
 
-def test_default_with_excluded_data(mocker: MockerFixture):
+def test_default_with_excluded_data(mocker: MockerFixture) -> None:
     # Patch git module to return specific excluded files
     p = mocker.patch("poetry.core.vcs.git.Git.get_ignored_files")
     p.return_value = [
@@ -477,7 +477,7 @@ def test_default_with_excluded_data(mocker: MockerFixture):
             assert tarinfo.mtime > 0
 
 
-def test_src_excluded_nested_data():
+def test_src_excluded_nested_data() -> None:
     module_path = fixtures_dir / "exclude_nested_data_toml"
     poetry = Factory().create_poetry(module_path)
 
@@ -510,7 +510,7 @@ def test_src_excluded_nested_data():
         assert "my-package-1.2.3/my_package/public/item2/itemdata2.txt" not in names
 
 
-def test_proper_python_requires_if_two_digits_precision_version_specified():
+def test_proper_python_requires_if_two_digits_precision_version_specified() -> None:
     poetry = Factory().create_poetry(project("simple_version"))
 
     builder = SdistBuilder(poetry)
@@ -521,7 +521,7 @@ def test_proper_python_requires_if_two_digits_precision_version_specified():
     assert parsed["Requires-Python"] == ">=3.6,<3.7"
 
 
-def test_proper_python_requires_if_three_digits_precision_version_specified():
+def test_proper_python_requires_if_three_digits_precision_version_specified() -> None:
     poetry = Factory().create_poetry(project("single_python"))
 
     builder = SdistBuilder(poetry)
@@ -532,7 +532,7 @@ def test_proper_python_requires_if_three_digits_precision_version_specified():
     assert parsed["Requires-Python"] == "==2.7.15"
 
 
-def test_includes():
+def test_includes() -> None:
     poetry = Factory().create_poetry(project("with-include"))
 
     builder = SdistBuilder(poetry)
@@ -548,7 +548,7 @@ def test_includes():
         assert "with-include-1.2.3/notes.txt" in tar.getnames()
 
 
-def test_includes_with_inline_table():
+def test_includes_with_inline_table() -> None:
     poetry = Factory().create_poetry(project("with_include_inline_table"))
 
     builder = SdistBuilder(poetry)
@@ -571,7 +571,7 @@ def test_includes_with_inline_table():
         assert "with-include-1.2.3/tests/test_foo/test.py" in tar.getnames()
 
 
-def test_excluded_subpackage():
+def test_excluded_subpackage() -> None:
     poetry = Factory().create_poetry(project("excluded_subpackage"))
 
     builder = SdistBuilder(poetry)
@@ -586,7 +586,7 @@ def test_excluded_subpackage():
     assert ns["packages"] == ["example"]
 
 
-def test_sdist_package_pep_561_stub_only():
+def test_sdist_package_pep_561_stub_only() -> None:
     root = fixtures_dir / "pep_561_stub_only"
     poetry = Factory().create_poetry(root)
 
@@ -604,7 +604,7 @@ def test_sdist_package_pep_561_stub_only():
         assert "pep-561-stubs-0.1/pkg-stubs/subpkg/__init__.pyi" in names
 
 
-def test_sdist_disable_setup_py():
+def test_sdist_disable_setup_py() -> None:
     module_path = fixtures_dir / "disable_setup_py"
     poetry = Factory().create_poetry(module_path)
 
@@ -624,7 +624,7 @@ def test_sdist_disable_setup_py():
         }
 
 
-def test_sdist_mtime_zero():
+def test_sdist_mtime_zero() -> None:
     poetry = Factory().create_poetry(project("module1"))
 
     builder = SdistBuilder(poetry)
@@ -639,7 +639,7 @@ def test_sdist_mtime_zero():
         assert gz.mtime == 0
 
 
-def test_split_source():
+def test_split_source() -> None:
     root = fixtures_dir / "split_source"
     poetry = Factory().create_poetry(root)
 

--- a/tests/masonry/builders/test_sdist.py
+++ b/tests/masonry/builders/test_sdist.py
@@ -9,6 +9,8 @@ import tarfile
 from email.parser import Parser
 from pathlib import Path
 from typing import TYPE_CHECKING
+from typing import Any
+from typing import Iterator
 
 import pytest
 
@@ -16,7 +18,7 @@ from poetry.core.factory import Factory
 from poetry.core.masonry.builders.sdist import SdistBuilder
 from poetry.core.masonry.utils.package_include import PackageInclude
 from poetry.core.packages.dependency import Dependency
-from poetry.core.packages.package import Package
+from poetry.core.packages.project_package import ProjectPackage
 from poetry.core.packages.vcs_dependency import VCSDependency
 
 
@@ -27,7 +29,7 @@ fixtures_dir = Path(__file__).parent / "fixtures"
 
 
 @pytest.fixture(autouse=True)
-def setup() -> None:
+def setup() -> Iterator[None]:
     clear_samples_dist()
 
     yield
@@ -46,7 +48,7 @@ def project(name: str) -> Path:
 
 
 def test_convert_dependencies():
-    package = Package("foo", "1.2.3")
+    package = ProjectPackage("foo", "1.2.3")
     result = SdistBuilder.convert_dependencies(
         package,
         [
@@ -66,11 +68,11 @@ def test_convert_dependencies():
         "E>=1.0,<2.0",
         "F>=1.0,<2.0,!=1.3",
     ]
-    extras = {}
+    extras: dict[str, Any] = {}
 
     assert result == (main, extras)
 
-    package = Package("foo", "1.2.3")
+    package = ProjectPackage("foo", "1.2.3")
     package.extras = {"bar": [Dependency("A", "*")]}
 
     result = SdistBuilder.convert_dependencies(
@@ -120,7 +122,7 @@ def test_make_setup():
     setup_ast = ast.parse(setup)
 
     setup_ast.body = [n for n in setup_ast.body if isinstance(n, ast.Assign)]
-    ns = {}
+    ns: dict[str, Any] = {}
     exec(compile(setup_ast, filename="setup.py", mode="exec"), ns)
     assert ns["packages"] == [
         "my_package",
@@ -368,7 +370,7 @@ def test_with_src_module_file():
     setup_ast = ast.parse(setup)
 
     setup_ast.body = [n for n in setup_ast.body if isinstance(n, ast.Assign)]
-    ns = {}
+    ns: dict[str, Any] = {}
     exec(compile(setup_ast, filename="setup.py", mode="exec"), ns)
     assert ns["package_dir"] == {"": "src"}
     assert ns["modules"] == ["module_src"]
@@ -393,7 +395,7 @@ def test_with_src_module_dir():
     setup_ast = ast.parse(setup)
 
     setup_ast.body = [n for n in setup_ast.body if isinstance(n, ast.Assign)]
-    ns = {}
+    ns: dict[str, Any] = {}
     exec(compile(setup_ast, filename="setup.py", mode="exec"), ns)
     assert ns["package_dir"] == {"": "src"}
     assert ns["packages"] == ["package_src"]
@@ -436,7 +438,7 @@ def test_default_with_excluded_data(mocker: MockerFixture):
     setup_ast = ast.parse(setup)
 
     setup_ast.body = [n for n in setup_ast.body if isinstance(n, ast.Assign)]
-    ns = {}
+    ns: dict[str, Any] = {}
     exec(compile(setup_ast, filename="setup.py", mode="exec"), ns)
     assert "package_dir" not in ns
     assert ns["packages"] == ["my_package"]
@@ -578,7 +580,7 @@ def test_excluded_subpackage():
     setup_ast = ast.parse(setup)
 
     setup_ast.body = [n for n in setup_ast.body if isinstance(n, ast.Assign)]
-    ns = {}
+    ns: dict[str, Any] = {}
     exec(compile(setup_ast, filename="setup.py", mode="exec"), ns)
 
     assert ns["packages"] == ["example"]
@@ -648,6 +650,6 @@ def test_split_source():
     setup_ast = ast.parse(setup)
 
     setup_ast.body = [n for n in setup_ast.body if isinstance(n, ast.Assign)]
-    ns = {}
+    ns: dict[str, Any] = {}
     exec(compile(setup_ast, filename="setup.py", mode="exec"), ns)
     assert "" in ns["package_dir"] and "module_b" in ns["package_dir"]

--- a/tests/masonry/builders/test_wheel.py
+++ b/tests/masonry/builders/test_wheel.py
@@ -7,6 +7,8 @@ import zipfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Iterator
+from typing import TextIO
 
 import pytest
 
@@ -23,7 +25,7 @@ fixtures_dir = Path(__file__).parent / "fixtures"
 
 
 @pytest.fixture(autouse=True)
-def setup() -> None:
+def setup() -> Iterator[None]:
     clear_samples_dist()
 
     yield
@@ -300,11 +302,11 @@ def test_wheel_file_is_closed(monkeypatch: MonkeyPatch):
     """Confirm that wheel zip files are explicitly closed."""
 
     # Using a list is a hack for Python 2.7 compatibility.
-    fd_file = [None]
+    fd_file: list[TextIO | None] = [None]
 
     real_fdopen = os.fdopen
 
-    def capturing_fdopen(*args: Any, **kwargs: Any):
+    def capturing_fdopen(*args: Any, **kwargs: Any) -> TextIO | None:
         fd_file[0] = real_fdopen(*args, **kwargs)
         return fd_file[0]
 

--- a/tests/masonry/builders/test_wheel.py
+++ b/tests/masonry/builders/test_wheel.py
@@ -39,7 +39,7 @@ def clear_samples_dist() -> None:
             shutil.rmtree(str(dist))
 
 
-def test_wheel_module():
+def test_wheel_module() -> None:
     module_path = fixtures_dir / "module1"
     WheelBuilder.make(Factory().create_poetry(module_path))
 
@@ -51,7 +51,7 @@ def test_wheel_module():
         assert "module1.py" in z.namelist()
 
 
-def test_wheel_package():
+def test_wheel_package() -> None:
     module_path = fixtures_dir / "complete"
     WheelBuilder.make(Factory().create_poetry(module_path))
 
@@ -63,7 +63,7 @@ def test_wheel_package():
         assert "my_package/sub_pkg1/__init__.py" in z.namelist()
 
 
-def test_wheel_prerelease():
+def test_wheel_prerelease() -> None:
     module_path = fixtures_dir / "prerelease"
     WheelBuilder.make(Factory().create_poetry(module_path))
 
@@ -72,7 +72,7 @@ def test_wheel_prerelease():
     assert whl.exists()
 
 
-def test_wheel_excluded_data():
+def test_wheel_excluded_data() -> None:
     module_path = fixtures_dir / "default_with_excluded_data_toml"
     WheelBuilder.make(Factory().create_poetry(module_path))
 
@@ -87,7 +87,7 @@ def test_wheel_excluded_data():
         assert "my_package/data/data1.txt" not in z.namelist()
 
 
-def test_wheel_excluded_nested_data():
+def test_wheel_excluded_nested_data() -> None:
     module_path = fixtures_dir / "exclude_nested_data_toml"
     poetry = Factory().create_poetry(module_path)
     WheelBuilder.make(poetry)
@@ -108,7 +108,7 @@ def test_wheel_excluded_nested_data():
         assert "my_package/public/item2/itemdata2.txt" not in z.namelist()
 
 
-def test_include_excluded_code():
+def test_include_excluded_code() -> None:
     module_path = fixtures_dir / "include_excluded_code"
     poetry = Factory().create_poetry(module_path)
     wb = WheelBuilder(poetry)
@@ -122,7 +122,7 @@ def test_include_excluded_code():
         assert "lib/my_package/generated.py" not in z.namelist()
 
 
-def test_wheel_localversionlabel():
+def test_wheel_localversionlabel() -> None:
     module_path = fixtures_dir / "localversionlabel"
     project = Factory().create_poetry(module_path)
     WheelBuilder.make(project)
@@ -135,7 +135,7 @@ def test_wheel_localversionlabel():
         assert local_version_string + ".dist-info/METADATA" in z.namelist()
 
 
-def test_wheel_package_src():
+def test_wheel_package_src() -> None:
     module_path = fixtures_dir / "source_package"
     WheelBuilder.make(Factory().create_poetry(module_path))
 
@@ -148,7 +148,7 @@ def test_wheel_package_src():
         assert "package_src/module.py" in z.namelist()
 
 
-def test_wheel_module_src():
+def test_wheel_module_src() -> None:
     module_path = fixtures_dir / "source_file"
     WheelBuilder.make(Factory().create_poetry(module_path))
 
@@ -160,7 +160,7 @@ def test_wheel_module_src():
         assert "module_src.py" in z.namelist()
 
 
-def test_dist_info_file_permissions():
+def test_dist_info_file_permissions() -> None:
     module_path = fixtures_dir / "complete"
     WheelBuilder.make(Factory().create_poetry(module_path))
 
@@ -183,7 +183,7 @@ def test_dist_info_file_permissions():
         )
 
 
-def test_wheel_includes_inline_table():
+def test_wheel_includes_inline_table() -> None:
     module_path = fixtures_dir / "with_include_inline_table"
     WheelBuilder.make(Factory().create_poetry(module_path))
 
@@ -201,7 +201,7 @@ def test_wheel_includes_inline_table():
     "package",
     ["pep_561_stub_only", "pep_561_stub_only_partial", "pep_561_stub_only_src"],
 )
-def test_wheel_package_pep_561_stub_only(package: str):
+def test_wheel_package_pep_561_stub_only(package: str) -> None:
     root = fixtures_dir / package
     WheelBuilder.make(Factory().create_poetry(root))
 
@@ -215,7 +215,7 @@ def test_wheel_package_pep_561_stub_only(package: str):
         assert "pkg-stubs/subpkg/__init__.pyi" in z.namelist()
 
 
-def test_wheel_package_pep_561_stub_only_includes_typed_marker():
+def test_wheel_package_pep_561_stub_only_includes_typed_marker() -> None:
     root = fixtures_dir / "pep_561_stub_only_partial"
     WheelBuilder.make(Factory().create_poetry(root))
 
@@ -227,7 +227,7 @@ def test_wheel_package_pep_561_stub_only_includes_typed_marker():
         assert "pkg-stubs/py.typed" in z.namelist()
 
 
-def test_wheel_includes_licenses_in_correct_paths():
+def test_wheel_includes_licenses_in_correct_paths() -> None:
     root = fixtures_dir / "licenses_and_copying"
     WheelBuilder.make(Factory().create_poetry(root))
 
@@ -244,7 +244,7 @@ def test_wheel_includes_licenses_in_correct_paths():
         assert "my_package-1.2.3.dist-info/LICENSES/MIT.txt" in z.namelist()
 
 
-def test_wheel_with_file_with_comma():
+def test_wheel_with_file_with_comma() -> None:
     root = fixtures_dir / "comma_file"
     WheelBuilder.make(Factory().create_poetry(root))
 
@@ -257,7 +257,7 @@ def test_wheel_with_file_with_comma():
         assert '\n"comma_file/a,b.py"' in records.decode()
 
 
-def test_default_src_with_excluded_data(mocker: MockerFixture):
+def test_default_src_with_excluded_data(mocker: MockerFixture) -> None:
     # Patch git module to return specific excluded files
     p = mocker.patch("poetry.core.vcs.git.Git.get_ignored_files")
     p.return_value = [
@@ -298,7 +298,7 @@ def test_default_src_with_excluded_data(mocker: MockerFixture):
         assert "my_package/data/sub_data/data3.txt" in names
 
 
-def test_wheel_file_is_closed(monkeypatch: MonkeyPatch):
+def test_wheel_file_is_closed(monkeypatch: MonkeyPatch) -> None:
     """Confirm that wheel zip files are explicitly closed."""
 
     # Using a list is a hack for Python 2.7 compatibility.

--- a/tests/masonry/test_api.py
+++ b/tests/masonry/test_api.py
@@ -32,13 +32,13 @@ fixtures = os.path.join(os.path.dirname(__file__), "builders", "fixtures")
 
 
 def test_get_requires_for_build_wheel():
-    expected = []
+    expected: list[str] = []
     with cwd(os.path.join(fixtures, "complete")):
         assert api.get_requires_for_build_wheel() == expected
 
 
 def test_get_requires_for_build_sdist():
-    expected = []
+    expected: list[str] = []
     with cwd(os.path.join(fixtures, "complete")):
         assert api.get_requires_for_build_sdist() == expected
 

--- a/tests/masonry/test_api.py
+++ b/tests/masonry/test_api.py
@@ -31,19 +31,19 @@ def cwd(directory: str | Path) -> Iterator[None]:
 fixtures = os.path.join(os.path.dirname(__file__), "builders", "fixtures")
 
 
-def test_get_requires_for_build_wheel():
+def test_get_requires_for_build_wheel() -> None:
     expected: list[str] = []
     with cwd(os.path.join(fixtures, "complete")):
         assert api.get_requires_for_build_wheel() == expected
 
 
-def test_get_requires_for_build_sdist():
+def test_get_requires_for_build_sdist() -> None:
     expected: list[str] = []
     with cwd(os.path.join(fixtures, "complete")):
         assert api.get_requires_for_build_sdist() == expected
 
 
-def test_build_wheel():
+def test_build_wheel() -> None:
     with temporary_directory() as tmp_dir, cwd(os.path.join(fixtures, "complete")):
         filename = api.build_wheel(tmp_dir)
         validate_wheel_contents(
@@ -54,7 +54,7 @@ def test_build_wheel():
         )
 
 
-def test_build_wheel_with_include():
+def test_build_wheel_with_include() -> None:
     with temporary_directory() as tmp_dir, cwd(os.path.join(fixtures, "with-include")):
         filename = api.build_wheel(tmp_dir)
         validate_wheel_contents(
@@ -65,14 +65,14 @@ def test_build_wheel_with_include():
         )
 
 
-def test_build_wheel_with_bad_path_dev_dep_succeeds():
+def test_build_wheel_with_bad_path_dev_dep_succeeds() -> None:
     with temporary_directory() as tmp_dir, cwd(
         os.path.join(fixtures, "with_bad_path_dev_dep")
     ):
         api.build_wheel(tmp_dir)
 
 
-def test_build_wheel_with_bad_path_dep_fails():
+def test_build_wheel_with_bad_path_dep_fails() -> None:
     with pytest.raises(ValueError) as err, temporary_directory() as tmp_dir, cwd(
         os.path.join(fixtures, "with_bad_path_dep")
     ):
@@ -86,7 +86,7 @@ def test_build_wheel_with_bad_path_dep_fails():
     or platform.python_implementation().lower() == "pypy",
     reason="Disable test on Windows for Python <=3.6 and for PyPy",
 )
-def test_build_wheel_extended():
+def test_build_wheel_extended() -> None:
     with temporary_directory() as tmp_dir, cwd(os.path.join(fixtures, "extended")):
         filename = api.build_wheel(tmp_dir)
         whl = Path(tmp_dir) / filename
@@ -94,7 +94,7 @@ def test_build_wheel_extended():
         validate_wheel_contents(name="extended", version="0.1", path=whl.as_posix())
 
 
-def test_build_sdist():
+def test_build_sdist() -> None:
     with temporary_directory() as tmp_dir, cwd(os.path.join(fixtures, "complete")):
         filename = api.build_sdist(tmp_dir)
         validate_sdist_contents(
@@ -105,7 +105,7 @@ def test_build_sdist():
         )
 
 
-def test_build_sdist_with_include():
+def test_build_sdist_with_include() -> None:
     with temporary_directory() as tmp_dir, cwd(os.path.join(fixtures, "with-include")):
         filename = api.build_sdist(tmp_dir)
         validate_sdist_contents(
@@ -116,14 +116,14 @@ def test_build_sdist_with_include():
         )
 
 
-def test_build_sdist_with_bad_path_dev_dep_succeeds():
+def test_build_sdist_with_bad_path_dev_dep_succeeds() -> None:
     with temporary_directory() as tmp_dir, cwd(
         os.path.join(fixtures, "with_bad_path_dev_dep")
     ):
         api.build_sdist(tmp_dir)
 
 
-def test_build_sdist_with_bad_path_dep_fails():
+def test_build_sdist_with_bad_path_dep_fails() -> None:
     with pytest.raises(ValueError) as err, temporary_directory() as tmp_dir, cwd(
         os.path.join(fixtures, "with_bad_path_dep")
     ):
@@ -131,7 +131,7 @@ def test_build_sdist_with_bad_path_dep_fails():
     assert "does not exist" in str(err.value)
 
 
-def test_prepare_metadata_for_build_wheel():
+def test_prepare_metadata_for_build_wheel() -> None:
     entry_points = """\
 [console_scripts]
 extra-script=my_package.extra:main[time]
@@ -201,14 +201,14 @@ My Package
             assert metadata == f.read()
 
 
-def test_prepare_metadata_for_build_wheel_with_bad_path_dev_dep_succeeds():
+def test_prepare_metadata_for_build_wheel_with_bad_path_dev_dep_succeeds() -> None:
     with temporary_directory() as tmp_dir, cwd(
         os.path.join(fixtures, "with_bad_path_dev_dep")
     ):
         api.prepare_metadata_for_build_wheel(tmp_dir)
 
 
-def test_prepare_metadata_for_build_wheel_with_bad_path_dep_succeeds():
+def test_prepare_metadata_for_build_wheel_with_bad_path_dep_succeeds() -> None:
     with pytest.raises(ValueError) as err, temporary_directory() as tmp_dir, cwd(
         os.path.join(fixtures, "with_bad_path_dep")
     ):
@@ -216,7 +216,7 @@ def test_prepare_metadata_for_build_wheel_with_bad_path_dep_succeeds():
     assert "does not exist" in str(err.value)
 
 
-def test_build_editable_wheel():
+def test_build_editable_wheel() -> None:
     pkg_dir = Path(fixtures) / "complete"
 
     with temporary_directory() as tmp_dir, cwd(pkg_dir):

--- a/tests/masonry/utils/test_package_include.py
+++ b/tests/masonry/utils/test_package_include.py
@@ -11,7 +11,7 @@ fixtures_dir = Path(__file__).parent / "fixtures"
 with_includes = fixtures_dir / "with_includes"
 
 
-def test_package_include_with_multiple_dirs():
+def test_package_include_with_multiple_dirs() -> None:
     pkg_include = PackageInclude(base=fixtures_dir, include="with_includes")
     assert pkg_include.elements == [
         with_includes / "__init__.py",
@@ -26,12 +26,12 @@ def test_package_include_with_multiple_dirs():
     ]
 
 
-def test_package_include_with_simple_dir():
+def test_package_include_with_simple_dir() -> None:
     pkg_include = PackageInclude(base=with_includes, include="bar")
     assert pkg_include.elements == [with_includes / "bar/baz.py"]
 
 
-def test_package_include_with_nested_dir():
+def test_package_include_with_nested_dir() -> None:
     pkg_include = PackageInclude(base=with_includes, include="extra_package/**/*.py")
     assert pkg_include.elements == [
         with_includes / "extra_package/some_dir/foo.py",
@@ -39,14 +39,14 @@ def test_package_include_with_nested_dir():
     ]
 
 
-def test_package_include_with_no_python_files_in_dir():
+def test_package_include_with_no_python_files_in_dir() -> None:
     with pytest.raises(ValueError) as e:
         PackageInclude(base=with_includes, include="not_a_python_pkg")
 
     assert str(e.value) == "not_a_python_pkg is not a package."
 
 
-def test_package_include_with_non_existent_directory():
+def test_package_include_with_non_existent_directory() -> None:
     with pytest.raises(ValueError) as e:
         PackageInclude(base=with_includes, include="not_a_dir")
 
@@ -55,7 +55,7 @@ def test_package_include_with_non_existent_directory():
     assert str(e.value) == err_str
 
 
-def test_pep_561_stub_only_package_good_name_suffix():
+def test_pep_561_stub_only_package_good_name_suffix() -> None:
     pkg_include = PackageInclude(
         base=fixtures_dir / "pep_561_stub_only", include="good-stubs"
     )
@@ -65,7 +65,7 @@ def test_pep_561_stub_only_package_good_name_suffix():
     ]
 
 
-def test_pep_561_stub_only_package_bad_name_suffix():
+def test_pep_561_stub_only_package_bad_name_suffix() -> None:
     with pytest.raises(ValueError) as e:
         PackageInclude(base=fixtures_dir / "pep_561_stub_only", include="bad")
 

--- a/tests/packages/constraints/test_constraint.py
+++ b/tests/packages/constraints/test_constraint.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from poetry.core.packages.constraints import BaseConstraint
 
 
-def test_allows():
+def test_allows() -> None:
     c = Constraint("win32")
 
     assert c.allows(Constraint("win32"))
@@ -27,7 +27,7 @@ def test_allows():
     assert c.allows(Constraint("linux"))
 
 
-def test_allows_any():
+def test_allows_any() -> None:
     c = Constraint("win32")
 
     assert c.allows_any(Constraint("win32"))
@@ -43,7 +43,7 @@ def test_allows_any():
     assert c.allows_any(Constraint("linux", "!="))
 
 
-def test_allows_all():
+def test_allows_all() -> None:
     c = Constraint("win32")
 
     assert c.allows_all(Constraint("win32"))
@@ -106,7 +106,7 @@ def test_intersect(
     constraint1: BaseConstraint,
     constraint2: BaseConstraint,
     expected: BaseConstraint,
-):
+) -> None:
     intersection = constraint1.intersect(constraint2)
     assert intersection == expected
 
@@ -157,12 +157,12 @@ def test_union(
     constraint1: BaseConstraint,
     constraint2: BaseConstraint,
     expected: BaseConstraint,
-):
+) -> None:
     union = constraint1.union(constraint2)
     assert union == expected
 
 
-def test_difference():
+def test_difference() -> None:
     c = Constraint("win32")
 
     assert c.difference(Constraint("win32")).is_empty()

--- a/tests/packages/constraints/test_main.py
+++ b/tests/packages/constraints/test_main.py
@@ -20,7 +20,7 @@ from poetry.core.packages.constraints.union_constraint import UnionConstraint
         ("!= win32", Constraint("win32", "!=")),
     ],
 )
-def test_parse_constraint(input: str, constraint: AnyConstraint | Constraint):
+def test_parse_constraint(input: str, constraint: AnyConstraint | Constraint) -> None:
     assert parse_constraint(input) == constraint
 
 
@@ -41,7 +41,7 @@ def test_parse_constraint(input: str, constraint: AnyConstraint | Constraint):
         ),
     ],
 )
-def test_parse_constraint_multi(input: str, constraint: MultiConstraint):
+def test_parse_constraint_multi(input: str, constraint: MultiConstraint) -> None:
     assert parse_constraint(input) == constraint
 
 
@@ -55,5 +55,5 @@ def test_parse_constraint_multi(input: str, constraint: MultiConstraint):
         ),
     ],
 )
-def test_parse_constraint_union(input: str, constraint: UnionConstraint):
+def test_parse_constraint_union(input: str, constraint: UnionConstraint) -> None:
     assert parse_constraint(input) == constraint

--- a/tests/packages/constraints/test_multi_constraint.py
+++ b/tests/packages/constraints/test_multi_constraint.py
@@ -4,7 +4,7 @@ from poetry.core.packages.constraints.constraint import Constraint
 from poetry.core.packages.constraints.multi_constraint import MultiConstraint
 
 
-def test_allows():
+def test_allows() -> None:
     c = MultiConstraint(Constraint("win32", "!="), Constraint("linux", "!="))
 
     assert not c.allows(Constraint("win32"))
@@ -12,7 +12,7 @@ def test_allows():
     assert c.allows(Constraint("darwin"))
 
 
-def test_allows_any():
+def test_allows_any() -> None:
     c = MultiConstraint(Constraint("win32", "!="), Constraint("linux", "!="))
 
     assert c.allows_any(Constraint("darwin"))
@@ -24,7 +24,7 @@ def test_allows_any():
     )
 
 
-def test_allows_all():
+def test_allows_all() -> None:
     c = MultiConstraint(Constraint("win32", "!="), Constraint("linux", "!="))
 
     assert c.allows_all(Constraint("darwin"))
@@ -36,7 +36,7 @@ def test_allows_all():
     )
 
 
-def test_intersect():
+def test_intersect() -> None:
     c = MultiConstraint(Constraint("win32", "!="), Constraint("linux", "!="))
 
     intersection = c.intersect(Constraint("win32", "!="))

--- a/tests/packages/constraints/test_union_constraint.py
+++ b/tests/packages/constraints/test_union_constraint.py
@@ -4,7 +4,7 @@ from poetry.core.packages.constraints.constraint import Constraint
 from poetry.core.packages.constraints.union_constraint import UnionConstraint
 
 
-def test_allows():
+def test_allows() -> None:
     c = UnionConstraint(Constraint("win32"), Constraint("linux"))
 
     assert c.allows(Constraint("win32"))
@@ -12,7 +12,7 @@ def test_allows():
     assert not c.allows(Constraint("darwin"))
 
 
-def test_allows_any():
+def test_allows_any() -> None:
     c = UnionConstraint(Constraint("win32"), Constraint("linux"))
 
     assert c.allows_any(c)
@@ -22,7 +22,7 @@ def test_allows_any():
     assert not c.allows_any(Constraint("darwin"))
 
 
-def test_allows_all():
+def test_allows_all() -> None:
     c = UnionConstraint(Constraint("win32"), Constraint("linux"))
 
     assert c.allows_all(c)

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -7,7 +7,7 @@ from poetry.core.packages.package import Package
 from poetry.core.version.markers import parse_marker
 
 
-def test_accepts():
+def test_accepts() -> None:
     dependency = Dependency("A", "^1.0")
     package = Package("A", "1.4")
 
@@ -27,18 +27,18 @@ def test_accepts():
         ("^1.0.0-1", False),
     ],
 )
-def test_allows_prerelease(constraint: str, result: bool):
+def test_allows_prerelease(constraint: str, result: bool) -> None:
     assert Dependency("A", constraint).allows_prereleases() == result
 
 
-def test_accepts_prerelease():
+def test_accepts_prerelease() -> None:
     dependency = Dependency("A", "^1.0", allows_prereleases=True)
     package = Package("A", "1.4-beta.1")
 
     assert dependency.accepts(package)
 
 
-def test_accepts_python_versions():
+def test_accepts_python_versions() -> None:
     dependency = Dependency("A", "^1.0")
     dependency.python_versions = "^3.6"
     package = Package("A", "1.4")
@@ -47,28 +47,28 @@ def test_accepts_python_versions():
     assert dependency.accepts(package)
 
 
-def test_accepts_fails_with_different_names():
+def test_accepts_fails_with_different_names() -> None:
     dependency = Dependency("A", "^1.0")
     package = Package("B", "1.4")
 
     assert not dependency.accepts(package)
 
 
-def test_accepts_fails_with_version_mismatch():
+def test_accepts_fails_with_version_mismatch() -> None:
     dependency = Dependency("A", "~1.0")
     package = Package("B", "1.4")
 
     assert not dependency.accepts(package)
 
 
-def test_accepts_fails_with_prerelease_mismatch():
+def test_accepts_fails_with_prerelease_mismatch() -> None:
     dependency = Dependency("A", "^1.0")
     package = Package("B", "1.4-beta.1")
 
     assert not dependency.accepts(package)
 
 
-def test_accepts_fails_with_python_versions_mismatch():
+def test_accepts_fails_with_python_versions_mismatch() -> None:
     dependency = Dependency("A", "^1.0")
     dependency.python_versions = "^3.6"
     package = Package("B", "1.4")
@@ -77,7 +77,7 @@ def test_accepts_fails_with_python_versions_mismatch():
     assert not dependency.accepts(package)
 
 
-def test_to_pep_508():
+def test_to_pep_508() -> None:
     dependency = Dependency("Django", "^1.23")
 
     result = dependency.to_pep_508()
@@ -95,14 +95,14 @@ def test_to_pep_508():
     )
 
 
-def test_to_pep_508_wilcard():
+def test_to_pep_508_wilcard() -> None:
     dependency = Dependency("Django", "*")
 
     result = dependency.to_pep_508()
     assert result == "Django"
 
 
-def test_to_pep_508_in_extras():
+def test_to_pep_508_in_extras() -> None:
     dependency = Dependency("Django", "^1.23")
     dependency.in_extras.append("foo")
 
@@ -139,7 +139,7 @@ def test_to_pep_508_in_extras():
     )
 
 
-def test_to_pep_508_in_extras_parsed():
+def test_to_pep_508_in_extras_parsed() -> None:
     dependency = Dependency.create_from_pep_508(
         'foo[baz,bar] (>=1.23,<2.0) ; extra == "baz"'
     )
@@ -151,7 +151,7 @@ def test_to_pep_508_in_extras_parsed():
     assert result == "foo[bar,baz] (>=1.23,<2.0)"
 
 
-def test_to_pep_508_with_single_version_excluded():
+def test_to_pep_508_with_single_version_excluded() -> None:
     dependency = Dependency("foo", "!=1.2.3")
 
     assert dependency.to_pep_508() == "foo (!=1.2.3)"
@@ -167,7 +167,9 @@ def test_to_pep_508_with_single_version_excluded():
         ("== 3.5.4", 'python_full_version == "3.5.4"'),
     ],
 )
-def test_to_pep_508_with_patch_python_version(python_versions: str, marker: str):
+def test_to_pep_508_with_patch_python_version(
+    python_versions: str, marker: str
+) -> None:
     dependency = Dependency("Django", "^1.23")
     dependency.python_versions = python_versions
 
@@ -177,7 +179,7 @@ def test_to_pep_508_with_patch_python_version(python_versions: str, marker: str)
     assert str(dependency.marker) == marker
 
 
-def test_to_pep_508_tilde():
+def test_to_pep_508_tilde() -> None:
     dependency = Dependency("foo", "~1.2.3")
 
     assert dependency.to_pep_508() == "foo (>=1.2.3,<1.3.0)"
@@ -195,7 +197,7 @@ def test_to_pep_508_tilde():
     assert dependency.to_pep_508() == "foo (>=0.2,<0.3)"
 
 
-def test_to_pep_508_caret():
+def test_to_pep_508_caret() -> None:
     dependency = Dependency("foo", "^1.2.3")
 
     assert dependency.to_pep_508() == "foo (>=1.2.3,<2.0.0)"
@@ -213,7 +215,7 @@ def test_to_pep_508_caret():
     assert dependency.to_pep_508() == "foo (>=0.2,<0.3)"
 
 
-def test_to_pep_508_combination():
+def test_to_pep_508_combination() -> None:
     dependency = Dependency("foo", "^1.2,!=1.3.5")
 
     assert dependency.to_pep_508() == "foo (>=1.2,<2.0,!=1.3.5)"
@@ -223,7 +225,7 @@ def test_to_pep_508_combination():
     assert dependency.to_pep_508() == "foo (>=1.2,<1.3,!=1.2.5)"
 
 
-def test_complete_name():
+def test_complete_name() -> None:
     assert Dependency("foo", ">=1.2.3").complete_name == "foo"
     assert (
         Dependency("foo", ">=1.2.3", extras=["baz", "bar"]).complete_name
@@ -247,19 +249,19 @@ def test_complete_name():
 )
 def test_dependency_string_representation(
     name: str, constraint: str, extras: list[str] | None, expected: str
-):
+) -> None:
     dependency = Dependency(name=name, constraint=constraint, extras=extras)
     assert str(dependency) == expected
 
 
-def test_set_constraint_sets_pretty_constraint():
+def test_set_constraint_sets_pretty_constraint() -> None:
     dependency = Dependency("A", "^1.0")
     assert dependency.pretty_constraint == "^1.0"
     dependency.set_constraint("^2.0")
     assert dependency.pretty_constraint == "^2.0"
 
 
-def test_with_constraint():
+def test_with_constraint() -> None:
     dependency = Dependency(
         "foo",
         "^1.2.3",
@@ -291,7 +293,7 @@ def test_with_constraint():
     assert new.transitive_python_constraint == dependency.transitive_python_constraint
 
 
-def test_marker_properly_sets_python_constraint():
+def test_marker_properly_sets_python_constraint() -> None:
     dependency = Dependency("foo", "^1.2.3")
 
     dependency.marker = 'python_version >= "3.6" and python_version < "4.0"'  # type: ignore[assignment]
@@ -299,14 +301,14 @@ def test_marker_properly_sets_python_constraint():
     assert str(dependency.python_constraint) == ">=3.6,<4.0"
 
 
-def test_dependency_markers_are_the_same_as_markers():
+def test_dependency_markers_are_the_same_as_markers() -> None:
     dependency = Dependency.create_from_pep_508('foo ; extra=="bar"')
     marker = parse_marker('extra=="bar"')
 
     assert dependency.marker == marker
 
 
-def test_marker_properly_unsets_python_constraint():
+def test_marker_properly_unsets_python_constraint() -> None:
     dependency = Dependency("foo", "^1.2.3")
 
     dependency.marker = 'python_version >= "3.6"'  # type: ignore[assignment]

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -294,7 +294,7 @@ def test_with_constraint():
 def test_marker_properly_sets_python_constraint():
     dependency = Dependency("foo", "^1.2.3")
 
-    dependency.marker = 'python_version >= "3.6" and python_version < "4.0"'
+    dependency.marker = 'python_version >= "3.6" and python_version < "4.0"'  # type: ignore[assignment]
 
     assert str(dependency.python_constraint) == ">=3.6,<4.0"
 
@@ -309,8 +309,8 @@ def test_dependency_markers_are_the_same_as_markers():
 def test_marker_properly_unsets_python_constraint():
     dependency = Dependency("foo", "^1.2.3")
 
-    dependency.marker = 'python_version >= "3.6"'
+    dependency.marker = 'python_version >= "3.6"'  # type: ignore[assignment]
     assert str(dependency.python_constraint) == ">=3.6"
 
-    dependency.marker = "*"
+    dependency.marker = "*"  # type: ignore[assignment]
     assert str(dependency.python_constraint) == "*"

--- a/tests/packages/test_dependency_group.py
+++ b/tests/packages/test_dependency_group.py
@@ -4,7 +4,7 @@ from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.dependency_group import DependencyGroup
 
 
-def test_dependency_group_remove_dependency():
+def test_dependency_group_remove_dependency() -> None:
     group = DependencyGroup(name="linter")
     group.add_dependency(Dependency(name="black", constraint="*"))
     group.add_dependency(Dependency(name="isort", constraint="*"))

--- a/tests/packages/test_directory_dependency.py
+++ b/tests/packages/test_directory_dependency.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -24,6 +25,7 @@ def _test_directory_dependency_pep_508(
     )
 
     assert dep.is_directory()
+    dep = cast(DirectoryDependency, dep)
     assert dep.name == name
     assert dep.path == path
     assert dep.to_pep_508() == pep_508_output or pep_508_input

--- a/tests/packages/test_directory_dependency.py
+++ b/tests/packages/test_directory_dependency.py
@@ -12,7 +12,7 @@ from poetry.core.packages.directory_dependency import DirectoryDependency
 DIST_PATH = Path(__file__).parent.parent / "fixtures" / "git" / "github.com" / "demo"
 
 
-def test_directory_dependency_must_exist():
+def test_directory_dependency_must_exist() -> None:
     with pytest.raises(ValueError):
         DirectoryDependency("demo", DIST_PATH / "invalid")
 
@@ -31,7 +31,7 @@ def _test_directory_dependency_pep_508(
     assert dep.to_pep_508() == pep_508_output or pep_508_input
 
 
-def test_directory_dependency_pep_508_local_absolute():
+def test_directory_dependency_pep_508_local_absolute() -> None:
     path = (
         Path(__file__).parent.parent
         / "fixtures"
@@ -44,7 +44,7 @@ def test_directory_dependency_pep_508_local_absolute():
     _test_directory_dependency_pep_508("demo", path, requirement)
 
 
-def test_directory_dependency_pep_508_localhost():
+def test_directory_dependency_pep_508_localhost() -> None:
     path = (
         Path(__file__).parent.parent
         / "fixtures"
@@ -55,7 +55,7 @@ def test_directory_dependency_pep_508_localhost():
     _test_directory_dependency_pep_508("demo", path, requirement, requirement_expected)
 
 
-def test_directory_dependency_pep_508_local_relative():
+def test_directory_dependency_pep_508_local_relative() -> None:
     path = Path("..") / "fixtures" / "project_with_multi_constraints_dependency"
 
     with pytest.raises(ValueError):
@@ -66,7 +66,7 @@ def test_directory_dependency_pep_508_local_relative():
     _test_directory_dependency_pep_508("demo", path, requirement)
 
 
-def test_directory_dependency_pep_508_extras():
+def test_directory_dependency_pep_508_extras() -> None:
     path = (
         Path(__file__).parent.parent
         / "fixtures"

--- a/tests/packages/test_file_dependency.py
+++ b/tests/packages/test_file_dependency.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING
+from typing import cast
 
 import pytest
 
@@ -39,7 +40,7 @@ def test_default_hash():
 try:
     from hashlib import algorithms_guaranteed as ALGORITHMS_GUARANTEED
 except ImportError:
-    ALGORITHMS_GUARANTEED = "md5,sha1,sha224,sha256,sha384,sha512".split(",")
+    ALGORITHMS_GUARANTEED = set("md5,sha1,sha224,sha256,sha384,sha512".split(","))
 
 
 @pytest.mark.parametrize(
@@ -110,6 +111,7 @@ def _test_file_dependency_pep_508(
         dep.marker = marker
 
     assert dep.is_file()
+    dep = cast(FileDependency, dep)
     assert dep.name == name
     assert dep.path == path
     assert dep.to_pep_508() == pep_508_output or pep_508_input

--- a/tests/packages/test_file_dependency.py
+++ b/tests/packages/test_file_dependency.py
@@ -20,17 +20,17 @@ DIST_PATH = Path(__file__).parent.parent / "fixtures" / "distributions"
 TEST_FILE = "demo-0.1.0.tar.gz"
 
 
-def test_file_dependency_wrong_path():
+def test_file_dependency_wrong_path() -> None:
     with pytest.raises(ValueError):
         FileDependency("demo", DIST_PATH / "demo-0.2.0.tar.gz")
 
 
-def test_file_dependency_dir():
+def test_file_dependency_dir() -> None:
     with pytest.raises(ValueError):
         FileDependency("demo", DIST_PATH)
 
 
-def test_default_hash():
+def test_default_hash() -> None:
     path = DIST_PATH / TEST_FILE
     dep = FileDependency("demo", path)
     SHA_256 = "72e8531e49038c5f9c4a837b088bfcb8011f4a9f76335c8f0654df6ac539b3d6"
@@ -87,7 +87,7 @@ except ImportError:
         if hash_name in ALGORITHMS_GUARANTEED
     ],
 )
-def test_guaranteed_hash(hash_name: str, expected: str):
+def test_guaranteed_hash(hash_name: str, expected: str) -> None:
     path = DIST_PATH / TEST_FILE
     dep = FileDependency("demo", path)
     assert dep.hash(hash_name) == expected
@@ -117,7 +117,7 @@ def _test_file_dependency_pep_508(
     assert dep.to_pep_508() == pep_508_output or pep_508_input
 
 
-def test_file_dependency_pep_508_local_file_absolute(mocker: MockerFixture):
+def test_file_dependency_pep_508_local_file_absolute(mocker: MockerFixture) -> None:
     path = DIST_PATH / "demo-0.2.0.tar.gz"
     requirement = f"demo @ file://{path.as_posix()}"
     _test_file_dependency_pep_508(mocker, "demo", path, requirement)
@@ -126,7 +126,7 @@ def test_file_dependency_pep_508_local_file_absolute(mocker: MockerFixture):
     _test_file_dependency_pep_508(mocker, "demo", path, requirement)
 
 
-def test_file_dependency_pep_508_local_file_localhost(mocker: MockerFixture):
+def test_file_dependency_pep_508_local_file_localhost(mocker: MockerFixture) -> None:
     path = DIST_PATH / "demo-0.2.0.tar.gz"
     requirement = f"demo @ file://localhost{path.as_posix()}"
     requirement_expected = f"demo @ file://{path.as_posix()}"
@@ -135,7 +135,9 @@ def test_file_dependency_pep_508_local_file_localhost(mocker: MockerFixture):
     )
 
 
-def test_file_dependency_pep_508_local_file_relative_path(mocker: MockerFixture):
+def test_file_dependency_pep_508_local_file_relative_path(
+    mocker: MockerFixture,
+) -> None:
     path = Path("..") / "fixtures" / "distributions" / "demo-0.2.0.tar.gz"
 
     with pytest.raises(ValueError):
@@ -146,7 +148,7 @@ def test_file_dependency_pep_508_local_file_relative_path(mocker: MockerFixture)
     _test_file_dependency_pep_508(mocker, "demo", path, requirement)
 
 
-def test_absolute_file_dependency_to_pep_508_with_marker(mocker: MockerFixture):
+def test_absolute_file_dependency_to_pep_508_with_marker(mocker: MockerFixture) -> None:
     wheel = "demo-0.1.0-py2.py3-none-any.whl"
 
     abs_path = DIST_PATH / wheel
@@ -160,7 +162,7 @@ def test_absolute_file_dependency_to_pep_508_with_marker(mocker: MockerFixture):
     )
 
 
-def test_relative_file_dependency_to_pep_508_with_marker(mocker: MockerFixture):
+def test_relative_file_dependency_to_pep_508_with_marker(mocker: MockerFixture) -> None:
     wheel = "demo-0.1.0-py2.py3-none-any.whl"
 
     rel_path = Path("..") / "fixtures" / "distributions" / wheel
@@ -174,7 +176,7 @@ def test_relative_file_dependency_to_pep_508_with_marker(mocker: MockerFixture):
     )
 
 
-def test_file_dependency_pep_508_extras(mocker: MockerFixture):
+def test_file_dependency_pep_508_extras(mocker: MockerFixture) -> None:
     wheel = "demo-0.1.0-py2.py3-none-any.whl"
 
     rel_path = Path("..") / "fixtures" / "distributions" / wheel

--- a/tests/packages/test_main.py
+++ b/tests/packages/test_main.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+from typing import cast
+
 from poetry.core.packages.dependency import Dependency
+from poetry.core.packages.url_dependency import URLDependency
+from poetry.core.packages.vcs_dependency import VCSDependency
 from poetry.core.semver.version import Version
 
 
@@ -182,6 +186,7 @@ def test_dependency_from_pep_508_with_git_url():
 
     assert dep.name == "django-utils"
     assert dep.is_vcs()
+    dep = cast(VCSDependency, dep)
     assert dep.vcs == "git"
     assert dep.source == "ssh://git@corp-gitlab.com/corp-utils.git"
     assert dep.reference == "1.2"
@@ -197,6 +202,7 @@ def test_dependency_from_pep_508_with_git_url_and_subdirectory():
 
     assert dep.name == "django-utils"
     assert dep.is_vcs()
+    dep = cast(VCSDependency, dep)
     assert dep.vcs == "git"
     assert dep.source == "ssh://git@corp-gitlab.com/corp-utils.git"
     assert dep.reference == "1.2"
@@ -213,6 +219,7 @@ def test_dependency_from_pep_508_with_git_url_and_comment_and_extra():
 
     assert dep.name == "poetry"
     assert dep.is_vcs()
+    dep = cast(VCSDependency, dep)
     assert dep.vcs == "git"
     assert dep.source == "https://github.com/python-poetry/poetry.git"
     assert dep.reference == "b;ar;"
@@ -226,6 +233,7 @@ def test_dependency_from_pep_508_with_url():
 
     assert dep.name == "django-utils"
     assert dep.is_url()
+    dep = cast(URLDependency, dep)
     assert dep.url == "https://example.com/django-utils-1.0.0.tar.gz"
 
 

--- a/tests/packages/test_main.py
+++ b/tests/packages/test_main.py
@@ -8,7 +8,7 @@ from poetry.core.packages.vcs_dependency import VCSDependency
 from poetry.core.semver.version import Version
 
 
-def test_dependency_from_pep_508():
+def test_dependency_from_pep_508() -> None:
     name = "requests"
     dep = Dependency.create_from_pep_508(name)
 
@@ -16,7 +16,7 @@ def test_dependency_from_pep_508():
     assert str(dep.constraint) == "*"
 
 
-def test_dependency_from_pep_508_with_version():
+def test_dependency_from_pep_508_with_version() -> None:
     name = "requests==2.18.0"
     dep = Dependency.create_from_pep_508(name)
 
@@ -24,7 +24,7 @@ def test_dependency_from_pep_508_with_version():
     assert str(dep.constraint) == "2.18.0"
 
 
-def test_dependency_from_pep_508_with_parens():
+def test_dependency_from_pep_508_with_parens() -> None:
     name = "requests (==2.18.0)"
     dep = Dependency.create_from_pep_508(name)
 
@@ -32,7 +32,7 @@ def test_dependency_from_pep_508_with_parens():
     assert str(dep.constraint) == "2.18.0"
 
 
-def test_dependency_from_pep_508_with_constraint():
+def test_dependency_from_pep_508_with_constraint() -> None:
     name = "requests>=2.12.0,!=2.17.*,<3.0"
     dep = Dependency.create_from_pep_508(name)
 
@@ -40,7 +40,7 @@ def test_dependency_from_pep_508_with_constraint():
     assert str(dep.constraint) == ">=2.12.0,<2.17.0 || >=2.18.0,<3.0"
 
 
-def test_dependency_from_pep_508_with_extras():
+def test_dependency_from_pep_508_with_extras() -> None:
     name = 'requests==2.18.0; extra == "foo" or extra == "bar"'
     dep = Dependency.create_from_pep_508(name)
 
@@ -50,7 +50,7 @@ def test_dependency_from_pep_508_with_extras():
     assert str(dep.marker) == 'extra == "foo" or extra == "bar"'
 
 
-def test_dependency_from_pep_508_with_python_version():
+def test_dependency_from_pep_508_with_python_version() -> None:
     name = 'requests (==2.18.0); python_version == "2.7" or python_version == "2.6"'
     dep = Dependency.create_from_pep_508(name)
 
@@ -61,7 +61,7 @@ def test_dependency_from_pep_508_with_python_version():
     assert str(dep.marker) == 'python_version == "2.7" or python_version == "2.6"'
 
 
-def test_dependency_from_pep_508_with_single_python_version():
+def test_dependency_from_pep_508_with_single_python_version() -> None:
     name = 'requests (==2.18.0); python_version == "2.7"'
     dep = Dependency.create_from_pep_508(name)
 
@@ -72,7 +72,7 @@ def test_dependency_from_pep_508_with_single_python_version():
     assert str(dep.marker) == 'python_version == "2.7"'
 
 
-def test_dependency_from_pep_508_with_platform():
+def test_dependency_from_pep_508_with_platform() -> None:
     name = 'requests (==2.18.0); sys_platform == "win32" or sys_platform == "darwin"'
     dep = Dependency.create_from_pep_508(name)
 
@@ -83,7 +83,7 @@ def test_dependency_from_pep_508_with_platform():
     assert str(dep.marker) == 'sys_platform == "win32" or sys_platform == "darwin"'
 
 
-def test_dependency_from_pep_508_complex():
+def test_dependency_from_pep_508_complex() -> None:
     name = (
         "requests (==2.18.0); "
         'python_version >= "2.7" and python_version != "3.2" '
@@ -104,7 +104,7 @@ def test_dependency_from_pep_508_complex():
     )
 
 
-def test_dependency_python_version_in():
+def test_dependency_python_version_in() -> None:
     name = "requests (==2.18.0); python_version in '3.3 3.4 3.5'"
     dep = Dependency.create_from_pep_508(name)
 
@@ -114,7 +114,7 @@ def test_dependency_python_version_in():
     assert str(dep.marker) == 'python_version in "3.3 3.4 3.5"'
 
 
-def test_dependency_python_version_in_comma():
+def test_dependency_python_version_in_comma() -> None:
     name = "requests (==2.18.0); python_version in '3.3, 3.4, 3.5'"
     dep = Dependency.create_from_pep_508(name)
 
@@ -124,7 +124,7 @@ def test_dependency_python_version_in_comma():
     assert str(dep.marker) == 'python_version in "3.3, 3.4, 3.5"'
 
 
-def test_dependency_platform_in():
+def test_dependency_platform_in() -> None:
     name = "requests (==2.18.0); sys_platform in 'win32 darwin'"
     dep = Dependency.create_from_pep_508(name)
 
@@ -133,7 +133,7 @@ def test_dependency_platform_in():
     assert str(dep.marker) == 'sys_platform in "win32 darwin"'
 
 
-def test_dependency_with_extra():
+def test_dependency_with_extra() -> None:
     name = "requests[security] (==2.18.0)"
     dep = Dependency.create_from_pep_508(name)
 
@@ -144,7 +144,7 @@ def test_dependency_with_extra():
     assert "security" in dep.extras
 
 
-def test_dependency_from_pep_508_with_python_version_union_of_multi():
+def test_dependency_from_pep_508_with_python_version_union_of_multi() -> None:
     name = (
         "requests (==2.18.0); "
         '(python_version >= "2.7" and python_version < "2.8") '
@@ -163,7 +163,7 @@ def test_dependency_from_pep_508_with_python_version_union_of_multi():
     )
 
 
-def test_dependency_from_pep_508_with_not_in_op_marker():
+def test_dependency_from_pep_508_with_not_in_op_marker() -> None:
     name = (
         'jinja2 (>=2.7,<2.8); python_version not in "3.0,3.1,3.2" and extra == "export"'
     )
@@ -179,7 +179,7 @@ def test_dependency_from_pep_508_with_not_in_op_marker():
     )
 
 
-def test_dependency_from_pep_508_with_git_url():
+def test_dependency_from_pep_508_with_git_url() -> None:
     name = "django-utils @ git+ssh://git@corp-gitlab.com/corp-utils.git@1.2"
 
     dep = Dependency.create_from_pep_508(name)
@@ -192,7 +192,7 @@ def test_dependency_from_pep_508_with_git_url():
     assert dep.reference == "1.2"
 
 
-def test_dependency_from_pep_508_with_git_url_and_subdirectory():
+def test_dependency_from_pep_508_with_git_url_and_subdirectory() -> None:
     name = (
         "django-utils @"
         " git+ssh://git@corp-gitlab.com/corp-utils.git@1.2#subdirectory=package-dir"
@@ -209,7 +209,7 @@ def test_dependency_from_pep_508_with_git_url_and_subdirectory():
     assert dep.directory == "package-dir"
 
 
-def test_dependency_from_pep_508_with_git_url_and_comment_and_extra():
+def test_dependency_from_pep_508_with_git_url_and_comment_and_extra() -> None:
     name = (
         "poetry @ git+https://github.com/python-poetry/poetry.git@b;ar;#egg=poetry"
         ' ; extra == "foo;"'
@@ -226,7 +226,7 @@ def test_dependency_from_pep_508_with_git_url_and_comment_and_extra():
     assert dep.in_extras == ["foo;"]
 
 
-def test_dependency_from_pep_508_with_url():
+def test_dependency_from_pep_508_with_url() -> None:
     name = "django-utils @ https://example.com/django-utils-1.0.0.tar.gz"
 
     dep = Dependency.create_from_pep_508(name)
@@ -237,7 +237,7 @@ def test_dependency_from_pep_508_with_url():
     assert dep.url == "https://example.com/django-utils-1.0.0.tar.gz"
 
 
-def test_dependency_from_pep_508_with_wheel_url():
+def test_dependency_from_pep_508_with_wheel_url() -> None:
     name = (
         "example_wheel @ https://example.com/example_wheel-14.0.2-py2.py3-none-any.whl"
     )
@@ -248,7 +248,7 @@ def test_dependency_from_pep_508_with_wheel_url():
     assert str(dep.constraint) == "14.0.2"
 
 
-def test_dependency_from_pep_508_with_python_full_version():
+def test_dependency_from_pep_508_with_python_full_version() -> None:
     name = (
         "requests (==2.18.0); "
         '(python_version >= "2.7" and python_version < "2.8") '
@@ -267,7 +267,7 @@ def test_dependency_from_pep_508_with_python_full_version():
     )
 
 
-def test_dependency_from_pep_508_with_python_full_version_pep440_compatible_release_astrix():
+def test_dependency_from_pep_508_with_python_full_version_pep440_compatible_release_astrix() -> None:
     name = 'pathlib2 ; python_version == "3.4.*" or python_version < "3"'
     dep = Dependency.create_from_pep_508(name)
 
@@ -276,7 +276,7 @@ def test_dependency_from_pep_508_with_python_full_version_pep440_compatible_rele
     assert dep.python_versions == "==3.4.* || <3"
 
 
-def test_dependency_from_pep_508_with_python_full_version_pep440_compatible_release_tilde():
+def test_dependency_from_pep_508_with_python_full_version_pep440_compatible_release_tilde() -> None:
     name = 'pathlib2 ; python_version ~= "3.4" or python_version < "3"'
     dep = Dependency.create_from_pep_508(name)
 
@@ -285,7 +285,7 @@ def test_dependency_from_pep_508_with_python_full_version_pep440_compatible_rele
     assert dep.python_versions == "~=3.4 || <3"
 
 
-def test_dependency_from_pep_508_should_not_produce_empty_constraints_for_correct_markers():
+def test_dependency_from_pep_508_should_not_produce_empty_constraints_for_correct_markers() -> None:
     name = (
         'pytest-mypy; python_implementation != "PyPy" and python_version <= "3.10" and'
         ' python_version > "3"'

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -31,7 +31,7 @@ def package_with_groups() -> Package:
     return package
 
 
-def test_package_authors():
+def test_package_authors() -> None:
     package = Package("foo", "0.1.0")
 
     package.authors.append("Sébastien Eustace <sebastien@eustace.io>")
@@ -43,7 +43,7 @@ def test_package_authors():
     assert package.author_email is None
 
 
-def test_package_authors_invalid():
+def test_package_authors_invalid() -> None:
     package = Package("foo", "0.1.0")
 
     package.authors.insert(0, "<John Doe")
@@ -57,7 +57,7 @@ def test_package_authors_invalid():
 
 
 @pytest.mark.parametrize("groups", [["main"], ["dev"]])
-def test_package_add_dependency_vcs_groups(groups: list[str], f: Factory):
+def test_package_add_dependency_vcs_groups(groups: list[str], f: Factory) -> None:
     package = Package("foo", "0.1.0")
 
     dependency = package.add_dependency(
@@ -70,7 +70,7 @@ def test_package_add_dependency_vcs_groups(groups: list[str], f: Factory):
     assert dependency.groups == frozenset(groups)
 
 
-def test_package_add_dependency_vcs_groups_default_main(f: Factory):
+def test_package_add_dependency_vcs_groups_default_main(f: Factory) -> None:
     package = Package("foo", "0.1.0")
 
     dependency = package.add_dependency(
@@ -83,7 +83,9 @@ def test_package_add_dependency_vcs_groups_default_main(f: Factory):
 
 @pytest.mark.parametrize("groups", [["main"], ["dev"]])
 @pytest.mark.parametrize("optional", [True, False])
-def test_package_url_groups_optional(groups: list[str], optional: bool, f: Factory):
+def test_package_url_groups_optional(
+    groups: list[str], optional: bool, f: Factory
+) -> None:
     package = Package("foo", "0.1.0")
 
     dependency = package.add_dependency(
@@ -100,13 +102,13 @@ def test_package_url_groups_optional(groups: list[str], optional: bool, f: Facto
     assert dependency.is_optional() == optional
 
 
-def test_package_equality_simple():
+def test_package_equality_simple() -> None:
     assert Package("foo", "0.1.0") == Package("foo", "0.1.0")
     assert Package("foo", "0.1.0") != Package("foo", "0.1.1")
     assert Package("bar", "0.1.0") != Package("foo", "0.1.0")
 
 
-def test_package_equality_source_type():
+def test_package_equality_source_type() -> None:
     a1 = Package("a", "0.1.0", source_type="file")
     a2 = Package(a1.name, a1.version, source_type="directory")
     a3 = Package(a1.name, a1.version, source_type=a1.source_type)
@@ -120,7 +122,7 @@ def test_package_equality_source_type():
     assert a2 != a4
 
 
-def test_package_equality_source_url():
+def test_package_equality_source_url() -> None:
     a1 = Package("a", "0.1.0", source_type="file", source_url="/some/path")
     a2 = Package(
         a1.name, a1.version, source_type=a1.source_type, source_url="/some/other/path"
@@ -138,7 +140,7 @@ def test_package_equality_source_url():
     assert a2 != a4
 
 
-def test_package_equality_source_reference():
+def test_package_equality_source_reference() -> None:
     a1 = Package(
         "a",
         "0.1.0",
@@ -170,7 +172,7 @@ def test_package_equality_source_reference():
     assert a2 != a4
 
 
-def test_package_resolved_reference_is_relevant_for_equality_only_if_present_for_both_packages():
+def test_package_resolved_reference_is_relevant_for_equality_only_if_present_for_both_packages() -> None:
     a1 = Package(
         "a",
         "0.1.0",
@@ -211,14 +213,14 @@ def test_package_resolved_reference_is_relevant_for_equality_only_if_present_for
     assert a2 == a4
 
 
-def test_complete_name():
+def test_complete_name() -> None:
     assert Package("foo", "1.2.3").complete_name == "foo"
     assert (
         Package("foo", "1.2.3", features=["baz", "bar"]).complete_name == "foo[bar,baz]"
     )
 
 
-def test_to_dependency():
+def test_to_dependency() -> None:
     package = Package("foo", "1.2.3")
     dep = package.to_dependency()
 
@@ -226,7 +228,7 @@ def test_to_dependency():
     assert dep.constraint == package.version
 
 
-def test_to_dependency_with_python_constraint():
+def test_to_dependency_with_python_constraint() -> None:
     package = Package("foo", "1.2.3")
     package.python_versions = ">=3.6"
     dep = package.to_dependency()
@@ -236,7 +238,7 @@ def test_to_dependency_with_python_constraint():
     assert dep.python_versions == ">=3.6"
 
 
-def test_to_dependency_with_features():
+def test_to_dependency_with_features() -> None:
     package = Package("foo", "1.2.3", features=["baz", "bar"])
     dep = package.to_dependency()
 
@@ -245,7 +247,7 @@ def test_to_dependency_with_features():
     assert dep.features == frozenset({"bar", "baz"})
 
 
-def test_to_dependency_for_directory():
+def test_to_dependency_for_directory() -> None:
     path = Path(__file__).parent.parent.joinpath("fixtures/simple_project")
     package = Package(
         "foo",
@@ -266,7 +268,7 @@ def test_to_dependency_for_directory():
     assert dep.source_url == path.as_posix()
 
 
-def test_to_dependency_for_file():
+def test_to_dependency_for_file() -> None:
     path = Path(__file__).parent.parent.joinpath(
         "fixtures/distributions/demo-0.1.0.tar.gz"
     )
@@ -289,7 +291,7 @@ def test_to_dependency_for_file():
     assert dep.source_url == path.as_posix()
 
 
-def test_to_dependency_for_url():
+def test_to_dependency_for_url() -> None:
     package = Package(
         "foo",
         "1.2.3",
@@ -309,7 +311,7 @@ def test_to_dependency_for_url():
     assert dep.source_url == "https://example.com/path.tar.gz"
 
 
-def test_to_dependency_for_vcs():
+def test_to_dependency_for_vcs() -> None:
     package = Package(
         "foo",
         "1.2.3",
@@ -336,7 +338,7 @@ def test_to_dependency_for_vcs():
     assert dep.source_subdirectory == "baz"
 
 
-def test_package_clone(f: Factory):
+def test_package_clone(f: Factory) -> None:
     # TODO(nic): this test is not future-proof, in that any attributes added
     #  to the Package object and not filled out in this test setup might
     #  cause comparisons to match that otherwise should not.  A factory method
@@ -367,12 +369,12 @@ def test_package_clone(f: Factory):
     assert len(p2.all_requires) == 2
 
 
-def test_dependency_groups(package_with_groups: Package):
+def test_dependency_groups(package_with_groups: Package) -> None:
     assert len(package_with_groups.requires) == 2
     assert len(package_with_groups.all_requires) == 4
 
 
-def test_without_dependency_groups(package_with_groups: Package):
+def test_without_dependency_groups(package_with_groups: Package) -> None:
     package = package_with_groups.without_dependency_groups(["dev"])
 
     assert len(package.requires) == 2
@@ -384,7 +386,7 @@ def test_without_dependency_groups(package_with_groups: Package):
     assert len(package.all_requires) == 2
 
 
-def test_with_dependency_groups(package_with_groups: Package):
+def test_with_dependency_groups(package_with_groups: Package) -> None:
     package = package_with_groups.with_dependency_groups([])
 
     assert len(package.requires) == 2
@@ -396,14 +398,14 @@ def test_with_dependency_groups(package_with_groups: Package):
     assert len(package.all_requires) == 4
 
 
-def test_without_optional_dependency_groups(package_with_groups: Package):
+def test_without_optional_dependency_groups(package_with_groups: Package) -> None:
     package = package_with_groups.without_optional_dependency_groups()
 
     assert len(package.requires) == 2
     assert len(package.all_requires) == 3
 
 
-def test_only_with_dependency_groups(package_with_groups: Package):
+def test_only_with_dependency_groups(package_with_groups: Package) -> None:
     package = package_with_groups.with_dependency_groups(["dev"], only=True)
 
     assert len(package.requires) == 0
@@ -420,7 +422,7 @@ def test_only_with_dependency_groups(package_with_groups: Package):
     assert len(package.all_requires) == 2
 
 
-def test_get_readme_property_with_multiple_readme_files():
+def test_get_readme_property_with_multiple_readme_files() -> None:
     package = Package("foo", "0.1.0")
 
     package.readmes = (Path("README.md"), Path("HISTORY.md"))
@@ -428,7 +430,7 @@ def test_get_readme_property_with_multiple_readme_files():
         assert package.readme == Path("README.md")
 
 
-def test_set_readme_property():
+def test_set_readme_property() -> None:
     package = Package("foo", "0.1.0")
 
     with pytest.deprecated_call():

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -3,12 +3,17 @@ from __future__ import annotations
 import random
 
 from pathlib import Path
+from typing import cast
 
 import pytest
 
 from poetry.core.factory import Factory
 from poetry.core.packages.dependency_group import DependencyGroup
+from poetry.core.packages.directory_dependency import DirectoryDependency
+from poetry.core.packages.file_dependency import FileDependency
 from poetry.core.packages.package import Package
+from poetry.core.packages.url_dependency import URLDependency
+from poetry.core.packages.vcs_dependency import VCSDependency
 
 
 @pytest.fixture()
@@ -255,6 +260,7 @@ def test_to_dependency_for_directory():
     assert dep.constraint == package.version
     assert dep.features == frozenset({"bar", "baz"})
     assert dep.is_directory()
+    dep = cast(DirectoryDependency, dep)
     assert dep.path == path
     assert dep.source_type == "directory"
     assert dep.source_url == path.as_posix()
@@ -277,6 +283,7 @@ def test_to_dependency_for_file():
     assert dep.constraint == package.version
     assert dep.features == frozenset({"bar", "baz"})
     assert dep.is_file()
+    dep = cast(FileDependency, dep)
     assert dep.path == path
     assert dep.source_type == "file"
     assert dep.source_url == path.as_posix()
@@ -296,6 +303,7 @@ def test_to_dependency_for_url():
     assert dep.constraint == package.version
     assert dep.features == frozenset({"bar", "baz"})
     assert dep.is_url()
+    dep = cast(URLDependency, dep)
     assert dep.url == "https://example.com/path.tar.gz"
     assert dep.source_type == "url"
     assert dep.source_url == "https://example.com/path.tar.gz"
@@ -318,6 +326,7 @@ def test_to_dependency_for_vcs():
     assert dep.constraint == package.version
     assert dep.features == frozenset({"bar", "baz"})
     assert dep.is_vcs()
+    dep = cast(VCSDependency, dep)
     assert dep.source_type == "git"
     assert dep.source == "https://github.com/foo/foo.git"
     assert dep.reference == "master"
@@ -346,7 +355,7 @@ def test_package_clone(f: Factory):
     )
     p.add_dependency(Factory.create_dependency("foo", "^1.2.3"))
     p.add_dependency(Factory.create_dependency("foo", "^1.2.3", groups=["dev"]))
-    p.files = (["file1", "file2", "file3"],)
+    p.files = (["file1", "file2", "file3"],)  # type: ignore[assignment]
     p.homepage = "https://some.other.url"
     p.repository_url = "http://bug.farm"
     p.documentation_url = "http://lorem.ipsum/dolor/sit.amet"
@@ -414,17 +423,17 @@ def test_only_with_dependency_groups(package_with_groups: Package):
 def test_get_readme_property_with_multiple_readme_files():
     package = Package("foo", "0.1.0")
 
-    package.readmes = ("README.md", "HISTORY.md")
+    package.readmes = (Path("README.md"), Path("HISTORY.md"))
     with pytest.deprecated_call():
-        assert package.readme == "README.md"
+        assert package.readme == Path("README.md")
 
 
 def test_set_readme_property():
     package = Package("foo", "0.1.0")
 
     with pytest.deprecated_call():
-        package.readme = "README.md"
+        package.readme = Path("README.md")
 
-    assert package.readmes == ("README.md",)
+    assert package.readmes == (Path("README.md"),)
     with pytest.deprecated_call():
-        assert package.readme == "README.md"
+        assert package.readme == Path("README.md")

--- a/tests/packages/test_url_dependency.py
+++ b/tests/packages/test_url_dependency.py
@@ -4,7 +4,7 @@ from poetry.core.packages.url_dependency import URLDependency
 from poetry.core.version.markers import SingleMarker
 
 
-def test_to_pep_508():
+def test_to_pep_508() -> None:
     dependency = URLDependency(
         "pytorch",
         "https://download.pytorch.org/whl/cpu/torch-1.5.1%2Bcpu-cp38-cp38-linux_x86_64.whl",
@@ -17,7 +17,7 @@ def test_to_pep_508():
     assert dependency.to_pep_508() == expected
 
 
-def test_to_pep_508_with_extras():
+def test_to_pep_508_with_extras() -> None:
     dependency = URLDependency(
         "pytorch",
         "https://download.pytorch.org/whl/cpu/torch-1.5.1%2Bcpu-cp38-cp38-linux_x86_64.whl",
@@ -31,7 +31,7 @@ def test_to_pep_508_with_extras():
     assert expected == dependency.to_pep_508()
 
 
-def test_to_pep_508_with_marker():
+def test_to_pep_508_with_marker() -> None:
     dependency = URLDependency(
         "pytorch",
         "https://download.pytorch.org/whl/cpu/torch-1.5.1%2Bcpu-cp38-cp38-linux_x86_64.whl",

--- a/tests/packages/test_vcs_dependency.py
+++ b/tests/packages/test_vcs_dependency.py
@@ -5,7 +5,7 @@ import pytest
 from poetry.core.packages.vcs_dependency import VCSDependency
 
 
-def test_to_pep_508():
+def test_to_pep_508() -> None:
     dependency = VCSDependency(
         "poetry", "git", "https://github.com/python-poetry/poetry.git"
     )
@@ -15,7 +15,7 @@ def test_to_pep_508():
     assert dependency.to_pep_508() == expected
 
 
-def test_to_pep_508_ssh():
+def test_to_pep_508_ssh() -> None:
     dependency = VCSDependency("poetry", "git", "git@github.com:sdispater/poetry.git")
 
     expected = "poetry @ git+ssh://git@github.com/sdispater/poetry.git"
@@ -23,7 +23,7 @@ def test_to_pep_508_ssh():
     assert dependency.to_pep_508() == expected
 
 
-def test_to_pep_508_with_extras():
+def test_to_pep_508_with_extras() -> None:
     dependency = VCSDependency(
         "poetry",
         "git",
@@ -36,7 +36,7 @@ def test_to_pep_508_with_extras():
     assert dependency.to_pep_508() == expected
 
 
-def test_to_pep_508_in_extras():
+def test_to_pep_508_in_extras() -> None:
     dependency = VCSDependency(
         "poetry", "git", "https://github.com/python-poetry/poetry.git"
     )
@@ -72,7 +72,7 @@ def test_to_pep_508_in_extras():
 
 
 @pytest.mark.parametrize("groups", [["main"], ["dev"]])
-def test_category(groups: list[str]):
+def test_category(groups: list[str]) -> None:
     dependency = VCSDependency(
         "poetry",
         "git",
@@ -82,7 +82,7 @@ def test_category(groups: list[str]):
     assert dependency.groups == frozenset(groups)
 
 
-def test_vcs_dependency_can_have_resolved_reference_specified():
+def test_vcs_dependency_can_have_resolved_reference_specified() -> None:
     dependency = VCSDependency(
         "poetry",
         "git",
@@ -96,7 +96,7 @@ def test_vcs_dependency_can_have_resolved_reference_specified():
     assert dependency.source_resolved_reference == "123456"
 
 
-def test_vcs_dependencies_are_equal_if_resolved_references_match():
+def test_vcs_dependencies_are_equal_if_resolved_references_match() -> None:
     dependency1 = VCSDependency(
         "poetry",
         "git",

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -46,6 +46,6 @@ def test_convert_markers():
     ],
 )
 def test_get_python_constraint_from_marker(marker: str, constraint: str):
-    marker = parse_marker(marker)
-    constraint = parse_constraint(constraint)
-    assert constraint == get_python_constraint_from_marker(marker)
+    marker_parsed = parse_marker(marker)
+    constraint_parsed = parse_constraint(constraint)
+    assert constraint_parsed == get_python_constraint_from_marker(marker_parsed)

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -8,7 +8,7 @@ from poetry.core.semver.helpers import parse_constraint
 from poetry.core.version.markers import parse_marker
 
 
-def test_convert_markers():
+def test_convert_markers() -> None:
     marker = parse_marker(
         'sys_platform == "win32" and python_version < "3.6" or sys_platform == "linux"'
         ' and python_version < "3.6" and python_version >= "3.3" or sys_platform =='
@@ -45,7 +45,7 @@ def test_convert_markers():
         ('sys_platform == "linux"', "*"),
     ],
 )
-def test_get_python_constraint_from_marker(marker: str, constraint: str):
+def test_get_python_constraint_from_marker(marker: str, constraint: str) -> None:
     marker_parsed = parse_marker(marker)
     constraint_parsed = parse_constraint(constraint)
     assert constraint_parsed == get_python_constraint_from_marker(marker_parsed)

--- a/tests/packages/utils/test_utils_link.py
+++ b/tests/packages/utils/test_utils_link.py
@@ -15,7 +15,7 @@ def make_url(ext: str) -> Link:
     )
 
 
-def test_package_link_is_checks():
+def test_package_link_is_checks() -> None:
     assert make_url("egg").is_egg
     assert make_url("tar.gz").is_sdist
     assert make_url("zip").is_sdist

--- a/tests/packages/utils/test_utils_urls.py
+++ b/tests/packages/utils/test_utils_urls.py
@@ -14,14 +14,14 @@ from poetry.core.packages.utils.utils import url_to_path
 
 
 @pytest.mark.skipif("sys.platform == 'win32'")
-def test_path_to_url_unix():
+def test_path_to_url_unix() -> None:
     assert path_to_url("/tmp/file") == "file:///tmp/file"
     path = Path(".") / "file"
     assert path_to_url("file") == "file://" + path.absolute().as_posix()
 
 
 @pytest.mark.skipif("sys.platform != 'win32'")
-def test_path_to_url_win():
+def test_path_to_url_win() -> None:
     assert path_to_url("c:/tmp/file") == "file:///c:/tmp/file"
     assert path_to_url("c:\\tmp\\file") == "file:///c:/tmp/file"
     assert path_to_url(r"\\unc\as\path") == "file://unc/as/path"
@@ -42,7 +42,7 @@ def test_path_to_url_win():
         ("file:///c:/tmp/file", r"C:\tmp\file", "/c:/tmp/file"),
     ],
 )
-def test_url_to_path(url: str, win_expected: str, non_win_expected: str | None):
+def test_url_to_path(url: str, win_expected: str, non_win_expected: str | None) -> None:
     if sys.platform == "win32":
         expected_path = win_expected
     else:
@@ -56,7 +56,7 @@ def test_url_to_path(url: str, win_expected: str, non_win_expected: str | None):
 
 
 @pytest.mark.skipif("sys.platform != 'win32'")
-def test_url_to_path_path_to_url_symmetry_win():
+def test_url_to_path_path_to_url_symmetry_win() -> None:
     path = r"C:\tmp\file"
     assert url_to_path(path_to_url(path)) == Path(path)
 

--- a/tests/pyproject/test_pyproject_toml.py
+++ b/tests/pyproject/test_pyproject_toml.py
@@ -15,12 +15,12 @@ from poetry.core.pyproject.toml import PyProjectTOML
 
 def test_pyproject_toml_simple(
     pyproject_toml: Path, build_system_section: str, poetry_section: str
-):
+) -> None:
     data = TOMLFile(pyproject_toml.as_posix()).read()
     assert PyProjectTOML(pyproject_toml).data == data
 
 
-def test_pyproject_toml_no_poetry_config(pyproject_toml: Path):
+def test_pyproject_toml_no_poetry_config(pyproject_toml: Path) -> None:
     pyproject = PyProjectTOML(pyproject_toml)
 
     assert not pyproject.is_poetry_project()
@@ -33,7 +33,9 @@ def test_pyproject_toml_no_poetry_config(pyproject_toml: Path):
     )
 
 
-def test_pyproject_toml_poetry_config(pyproject_toml: Path, poetry_section: str):
+def test_pyproject_toml_poetry_config(
+    pyproject_toml: Path, poetry_section: str
+) -> None:
     pyproject = PyProjectTOML(pyproject_toml)
     config = TOMLFile(pyproject_toml.as_posix()).read()["tool"]["poetry"]
 
@@ -41,7 +43,7 @@ def test_pyproject_toml_poetry_config(pyproject_toml: Path, poetry_section: str)
     assert pyproject.poetry_config == config
 
 
-def test_pyproject_toml_no_build_system_defaults():
+def test_pyproject_toml_no_build_system_defaults() -> None:
     pyproject_toml = (
         Path(__file__).parent.parent
         / "fixtures"
@@ -57,13 +59,13 @@ def test_pyproject_toml_no_build_system_defaults():
     assert build_system.dependencies[1].to_pep_508() == "Cython (>=0.29.6,<0.30.0)"
 
 
-def test_pyproject_toml_build_requires_as_dependencies(pyproject_toml: Path):
+def test_pyproject_toml_build_requires_as_dependencies(pyproject_toml: Path) -> None:
     build_system = PyProjectTOML(pyproject_toml).build_system
     assert build_system.requires == ["setuptools", "wheel"]
     assert build_system.build_backend == "setuptools.build_meta:__legacy__"
 
 
-def test_pyproject_toml_non_existent(pyproject_toml: Path):
+def test_pyproject_toml_non_existent(pyproject_toml: Path) -> None:
     pyproject_toml.unlink()
     pyproject = PyProjectTOML(pyproject_toml)
     build_system = pyproject.build_system
@@ -73,7 +75,7 @@ def test_pyproject_toml_non_existent(pyproject_toml: Path):
     assert build_system.build_backend == "poetry.core.masonry.api"
 
 
-def test_pyproject_toml_reload(pyproject_toml: Path, poetry_section: str):
+def test_pyproject_toml_reload(pyproject_toml: Path, poetry_section: str) -> None:
     pyproject = PyProjectTOML(pyproject_toml)
     name_original = pyproject.poetry_config["name"]
     name_new = str(uuid.uuid4())
@@ -87,7 +89,7 @@ def test_pyproject_toml_reload(pyproject_toml: Path, poetry_section: str):
 
 def test_pyproject_toml_save(
     pyproject_toml: Path, poetry_section: str, build_system_section: str
-):
+) -> None:
     pyproject = PyProjectTOML(pyproject_toml)
 
     name = str(uuid.uuid4())

--- a/tests/pyproject/test_pyproject_toml_file.py
+++ b/tests/pyproject/test_pyproject_toml_file.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 def test_old_pyproject_toml_file_deprecation(
     pyproject_toml: Path, build_system_section: str, poetry_section: str
-):
+) -> None:
     from poetry.core.utils.toml_file import TomlFile
 
     with pytest.warns(DeprecationWarning):
@@ -24,7 +24,7 @@ def test_old_pyproject_toml_file_deprecation(
     assert data == TOMLFile(pyproject_toml).read()
 
 
-def test_pyproject_toml_file_invalid(pyproject_toml: Path):
+def test_pyproject_toml_file_invalid(pyproject_toml: Path) -> None:
     with pyproject_toml.open(mode="a") as f:
         f.write("<<<<<<<<<<<")
 
@@ -34,6 +34,6 @@ def test_pyproject_toml_file_invalid(pyproject_toml: Path):
     assert f"Invalid TOML file {pyproject_toml.as_posix()}" in str(excval.value)
 
 
-def test_pyproject_toml_file_getattr(tmp_path: Path, pyproject_toml: Path):
+def test_pyproject_toml_file_getattr(tmp_path: Path, pyproject_toml: Path) -> None:
     file = TOMLFile(pyproject_toml)
     assert file.parent == tmp_path

--- a/tests/semver/test_helpers.py
+++ b/tests/semver/test_helpers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 
 from poetry.core.semver.helpers import parse_constraint
@@ -376,7 +378,7 @@ def test_constraints_keep_version_precision(input: str, expected: str):
     ],
 )
 def test_versions_are_sortable(unsorted: list[str], sorted_: list[str]):
-    unsorted = [parse_constraint(u) for u in unsorted]
-    sorted_ = [parse_constraint(s) for s in sorted_]
+    unsorted_parsed = [cast(Version, parse_constraint(u)) for u in unsorted]
+    sorted_parsed = [cast(Version, parse_constraint(s)) for s in sorted_]
 
-    assert sorted(unsorted) == sorted_
+    assert sorted(unsorted_parsed) == sorted_parsed

--- a/tests/semver/test_helpers.py
+++ b/tests/semver/test_helpers.py
@@ -35,7 +35,7 @@ from poetry.core.version.pep440 import ReleaseTag
         ),  # Issue 206
     ],
 )
-def test_parse_constraint(input: str, constraint: Version | VersionRange):
+def test_parse_constraint(input: str, constraint: Version | VersionRange) -> None:
     assert parse_constraint(input) == constraint
 
 
@@ -95,7 +95,7 @@ def test_parse_constraint(input: str, constraint: Version | VersionRange):
         ("0.x", VersionRange(max=Version.from_parts(1, 0, 0))),
     ],
 )
-def test_parse_constraint_wildcard(input: str, constraint: VersionRange):
+def test_parse_constraint_wildcard(input: str, constraint: VersionRange) -> None:
     assert parse_constraint(input) == constraint
 
 
@@ -182,7 +182,7 @@ def test_parse_constraint_wildcard(input: str, constraint: VersionRange):
         ),  # PEP 440
     ],
 )
-def test_parse_constraint_tilde(input: str, constraint: VersionRange):
+def test_parse_constraint_tilde(input: str, constraint: VersionRange) -> None:
     assert parse_constraint(input) == constraint
 
 
@@ -248,7 +248,7 @@ def test_parse_constraint_tilde(input: str, constraint: VersionRange):
         ),
     ],
 )
-def test_parse_constraint_caret(input: str, constraint: VersionRange):
+def test_parse_constraint_caret(input: str, constraint: VersionRange) -> None:
     assert parse_constraint(input) == constraint
 
 
@@ -267,7 +267,7 @@ def test_parse_constraint_caret(input: str, constraint: VersionRange):
         "  > 2.0  ,  <=  3.0 ",
     ],
 )
-def test_parse_constraint_multi(input: str):
+def test_parse_constraint_multi(input: str) -> None:
     assert parse_constraint(input) == VersionRange(
         Version.from_parts(2, 0, 0),
         Version.from_parts(3, 0, 0),
@@ -299,7 +299,7 @@ def test_parse_constraint_multi(input: str):
         ),
     ],
 )
-def test_parse_constraint_multi_with_epochs(input: str, output: VersionRange):
+def test_parse_constraint_multi_with_epochs(input: str, output: VersionRange) -> None:
     assert parse_constraint(input) == output
 
 
@@ -307,7 +307,7 @@ def test_parse_constraint_multi_with_epochs(input: str, output: VersionRange):
     "input",
     [">=2.7,!=3.0.*,!=3.1.*", ">=2.7, !=3.0.*, !=3.1.*", ">= 2.7, != 3.0.*, != 3.1.*"],
 )
-def test_parse_constraint_multi_wilcard(input: str):
+def test_parse_constraint_multi_wilcard(input: str) -> None:
     assert parse_constraint(input) == VersionUnion(
         VersionRange(
             Version.from_parts(2, 7, 0), Version.from_parts(3, 0, 0), True, False
@@ -341,7 +341,9 @@ def test_parse_constraint_multi_wilcard(input: str):
         ("!=0.*.*", VersionRange(Version.parse("1.0"), include_min=True)),
     ],
 )
-def test_parse_constraints_negative_wildcard(input: str, constraint: VersionRange):
+def test_parse_constraints_negative_wildcard(
+    input: str, constraint: VersionRange
+) -> None:
     assert parse_constraint(input) == constraint
 
 
@@ -362,7 +364,7 @@ def test_parse_constraints_negative_wildcard(input: str, constraint: VersionRang
         ("~1.0.0", ">=1.0.0,<1.1.0"),
     ],
 )
-def test_constraints_keep_version_precision(input: str, expected: str):
+def test_constraints_keep_version_precision(input: str, expected: str) -> None:
     assert str(parse_constraint(input)) == expected
 
 
@@ -377,7 +379,7 @@ def test_constraints_keep_version_precision(input: str, expected: str):
         (["1.0.0rc2", "1.0.0b1"], ["1.0.0b1", "1.0.0rc2"]),
     ],
 )
-def test_versions_are_sortable(unsorted: list[str], sorted_: list[str]):
+def test_versions_are_sortable(unsorted: list[str], sorted_: list[str]) -> None:
     unsorted_parsed = [cast(Version, parse_constraint(u)) for u in unsorted]
     sorted_parsed = [cast(Version, parse_constraint(s)) for s in sorted_]
 

--- a/tests/semver/test_parse_constraint.py
+++ b/tests/semver/test_parse_constraint.py
@@ -208,5 +208,7 @@ from poetry.core.version.pep440 import ReleaseTag
         ),
     ],
 )
-def test_parse_constraint(constraint: str, version: VersionRange | VersionUnion):
+def test_parse_constraint(
+    constraint: str, version: VersionRange | VersionUnion
+) -> None:
     assert parse_constraint(constraint) == version

--- a/tests/semver/test_version.py
+++ b/tests/semver/test_version.py
@@ -40,7 +40,7 @@ def test_parse_valid(text: str, version: Version):
 @pytest.mark.parametrize("value", [None, "example"])
 def test_parse_invalid(value: str | None):
     with pytest.raises(InvalidVersion):
-        Version.parse(value)
+        Version.parse(value)  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize(

--- a/tests/semver/test_version.py
+++ b/tests/semver/test_version.py
@@ -30,7 +30,7 @@ from poetry.core.version.pep440 import ReleaseTag
         ("1!2.3.4", Version.from_parts(2, 3, 4, epoch=1)),
     ],
 )
-def test_parse_valid(text: str, version: Version):
+def test_parse_valid(text: str, version: Version) -> None:
     parsed = Version.parse(text)
 
     assert parsed == version
@@ -38,7 +38,7 @@ def test_parse_valid(text: str, version: Version):
 
 
 @pytest.mark.parametrize("value", [None, "example"])
-def test_parse_invalid(value: str | None):
+def test_parse_invalid(value: str | None) -> None:
     with pytest.raises(InvalidVersion):
         Version.parse(value)  # type: ignore[arg-type]
 
@@ -87,7 +87,7 @@ def test_parse_invalid(value: str | None):
         ],
     ],
 )
-def test_comparison(versions: list[str]):
+def test_comparison(versions: list[str]) -> None:
     for i in range(len(versions)):
         for j in range(len(versions)):
             a = Version.parse(versions[i])
@@ -101,7 +101,7 @@ def test_comparison(versions: list[str]):
             assert (a != b) == (i != j)
 
 
-def test_equality():
+def test_equality() -> None:
     assert Version.parse("1.2.3") == Version.parse("01.2.3")
     assert Version.parse("1.2.3") == Version.parse("1.02.3")
     assert Version.parse("1.2.3") == Version.parse("1.2.03")
@@ -109,7 +109,7 @@ def test_equality():
     assert Version.parse("1.2.3+1") == Version.parse("1.2.3+01")
 
 
-def test_allows():
+def test_allows() -> None:
     v = Version.parse("1.2.3")
     assert v.allows(v)
     assert not v.allows(Version.parse("2.2.3"))
@@ -121,7 +121,7 @@ def test_allows():
     assert v.allows(Version.parse("1.2.3-1+build"))
 
 
-def test_allows_with_local():
+def test_allows_with_local() -> None:
     v = Version.parse("1.2.3+build.1")
     assert v.allows(v)
     assert not v.allows(Version.parse("1.3.3"))
@@ -131,7 +131,7 @@ def test_allows_with_local():
     assert v.allows(Version.parse("1.2.3-1+build.1"))
 
 
-def test_allows_with_post():
+def test_allows_with_post() -> None:
     v = Version.parse("1.2.3-1")
     assert v.allows(v)
     assert not v.allows(Version.parse("1.2.3"))
@@ -141,7 +141,7 @@ def test_allows_with_post():
     assert v.allows(Version.parse("1.2.3-1+build.1"))
 
 
-def test_allows_all():
+def test_allows_all() -> None:
     v = Version.parse("1.2.3")
 
     assert v.allows_all(v)
@@ -153,7 +153,7 @@ def test_allows_all():
     assert v.allows_all(EmptyConstraint())
 
 
-def test_allows_any():
+def test_allows_any() -> None:
     v = Version.parse("1.2.3")
 
     assert v.allows_any(v)
@@ -163,7 +163,7 @@ def test_allows_any():
     assert not v.allows_any(EmptyConstraint())
 
 
-def test_intersect():
+def test_intersect() -> None:
     v = Version.parse("1.2.3")
 
     assert v.intersect(v) == v
@@ -178,7 +178,7 @@ def test_intersect():
     )
 
 
-def test_union():
+def test_union() -> None:
     v = Version.parse("1.2.3")
 
     assert v.union(v) == v
@@ -203,7 +203,7 @@ def test_union():
     assert result.allows(Version.parse("0.1.0"))
 
 
-def test_difference():
+def test_difference() -> None:
     v = Version.parse("1.2.3")
 
     assert v.difference(v).is_empty()
@@ -224,6 +224,6 @@ def test_difference():
         ("1.2.3-dev.0", "1.2.3-dev.1"),
     ],
 )
-def test_next_devrelease(version: str, expected: str):
+def test_next_devrelease(version: str, expected: str) -> None:
     v = Version.parse(version)
     assert v.next_devrelease() == Version.parse(expected)

--- a/tests/semver/test_version_range.py
+++ b/tests/semver/test_version_range.py
@@ -86,7 +86,7 @@ def v300b1() -> Version:
         ),
     ],
 )
-def test_allows_post_releases_with_max(base: Version, other: Version):
+def test_allows_post_releases_with_max(base: Version, other: Version) -> None:
     range = VersionRange(max=base, include_max=True)
     assert range.allows(other)
 
@@ -100,12 +100,12 @@ def test_allows_post_releases_with_max(base: Version, other: Version):
         ),
     ],
 )
-def test_allows_post_releases_with_min(base: Version, other: Version):
+def test_allows_post_releases_with_min(base: Version, other: Version) -> None:
     range = VersionRange(min=base, include_min=True)
     assert range.allows(other)
 
 
-def test_allows_post_releases_with_post_and_local_min():
+def test_allows_post_releases_with_post_and_local_min() -> None:
     one = Version.parse("3.0.0+local.1")
     two = Version.parse("3.0.0-1")
     three = Version.parse("3.0.0-1+local.1")
@@ -128,7 +128,7 @@ def test_allows_post_releases_with_post_and_local_min():
     assert VersionRange(min=four, include_min=True).allows(three)
 
 
-def test_allows_post_releases_with_post_and_local_max():
+def test_allows_post_releases_with_post_and_local_max() -> None:
     one = Version.parse("3.0.0+local.1")
     two = Version.parse("3.0.0-1")
     three = Version.parse("3.0.0-1+local.1")
@@ -170,7 +170,7 @@ def test_allows_post_releases_with_post_and_local_max():
 )
 def test_allows_post_releases_explicit_with_max(
     base: Version, one: Version, two: Version
-):
+) -> None:
     range = VersionRange(max=one, include_max=True)
     assert range.allows(base)
     assert not range.allows(two)
@@ -199,7 +199,7 @@ def test_allows_post_releases_explicit_with_max(
 )
 def test_allows_post_releases_explicit_with_min(
     base: Version, one: Version, two: Version
-):
+) -> None:
     range = VersionRange(min=one, include_min=True)
     assert not range.allows(base)
     assert range.allows(two)
@@ -211,7 +211,7 @@ def test_allows_post_releases_explicit_with_min(
 
 def test_allows_all(
     v123: Version, v124: Version, v140: Version, v250: Version, v300: Version
-):
+) -> None:
     assert VersionRange(v123, v250).allows_all(EmptyConstraint())
 
     range = VersionRange(v123, v250, include_max=True)
@@ -223,7 +223,7 @@ def test_allows_all(
 
 def test_allows_all_with_no_min(
     v080: Version, v140: Version, v250: Version, v300: Version
-):
+) -> None:
     range = VersionRange(max=v250)
     assert range.allows_all(VersionRange(v080, v140))
     assert not range.allows_all(VersionRange(v080, v300))
@@ -235,7 +235,7 @@ def test_allows_all_with_no_min(
 
 def test_allows_all_with_no_max(
     v003: Version, v010: Version, v080: Version, v140: Version
-):
+) -> None:
     range = VersionRange(min=v010)
     assert range.allows_all(VersionRange(v080, v140))
     assert not range.allows_all(VersionRange(v003, v140))
@@ -245,7 +245,9 @@ def test_allows_all_with_no_max(
     assert not range.allows_all(VersionRange())
 
 
-def test_allows_all_bordering_range_not_more_inclusive(v010: Version, v250: Version):
+def test_allows_all_bordering_range_not_more_inclusive(
+    v010: Version, v250: Version
+) -> None:
     # Allows bordering range that is not more inclusive
     exclusive = VersionRange(v010, v250)
     inclusive = VersionRange(v010, v250, True, True)
@@ -263,7 +265,7 @@ def test_allows_all_contained_unions(
     v140: Version,
     v200: Version,
     v234: Version,
-):
+) -> None:
     # Allows unions that are completely contained
     range = VersionRange(v114, v200)
     assert range.allows_all(VersionRange(v123, v124).union(v140))
@@ -284,7 +286,7 @@ def test_allows_any(
     v234: Version,
     v250: Version,
     v300: Version,
-):
+) -> None:
     # disallows an empty constraint
     assert not VersionRange(v123, v250).allows_any(EmptyConstraint())
 
@@ -354,7 +356,7 @@ def test_intersect(
     v200: Version,
     v250: Version,
     v300: Version,
-):
+) -> None:
     # two overlapping ranges
     assert VersionRange(v123, v250).intersect(VersionRange(v200, v300)) == VersionRange(
         v200, v250
@@ -400,7 +402,7 @@ def test_union(
     v234: Version,
     v250: Version,
     v300: Version,
-):
+) -> None:
     # with a version returns the range if it contains the version
     range = VersionRange(v114, v124)
     assert range.union(v123) == range
@@ -444,7 +446,7 @@ def test_union(
     assert result == VersionRange(v003, v200)
 
 
-def test_include_max_prerelease(v200: Version, v300: Version, v300b1: Version):
+def test_include_max_prerelease(v200: Version, v300: Version, v300b1: Version) -> None:
     result = VersionRange(v200, v300)
 
     assert not result.allows(v300b1)

--- a/tests/spdx/test_helpers.py
+++ b/tests/spdx/test_helpers.py
@@ -5,7 +5,7 @@ import pytest
 from poetry.core.spdx.helpers import license_by_id
 
 
-def test_license_by_id():
+def test_license_by_id() -> None:
     license = license_by_id("MIT")
 
     assert license.id == "MIT"
@@ -21,7 +21,7 @@ def test_license_by_id():
     assert not license.is_deprecated
 
 
-def test_license_by_id_is_case_insensitive():
+def test_license_by_id_is_case_insensitive() -> None:
     license = license_by_id("mit")
 
     assert license.id == "MIT"
@@ -31,7 +31,7 @@ def test_license_by_id_is_case_insensitive():
     assert license.id == "MIT"
 
 
-def test_license_by_id_with_full_name():
+def test_license_by_id_with_full_name() -> None:
     license = license_by_id("GNU Lesser General Public License v3.0 or later")
 
     assert license.id == "LGPL-3.0-or-later"
@@ -40,12 +40,12 @@ def test_license_by_id_with_full_name():
     assert not license.is_deprecated
 
 
-def test_license_by_id_invalid():
+def test_license_by_id_invalid() -> None:
     with pytest.raises(ValueError):
         license_by_id("")
 
 
-def test_license_by_id_custom():
+def test_license_by_id_custom() -> None:
     license = license_by_id("Custom")
 
     assert license.id == "Custom"

--- a/tests/spdx/test_license.py
+++ b/tests/spdx/test_license.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from poetry.core.spdx.helpers import license_by_id
 
 
-def test_classifier_name():
+def test_classifier_name() -> None:
     license = license_by_id("lgpl-3.0-or-later")
 
     assert (
@@ -12,19 +12,19 @@ def test_classifier_name():
     )
 
 
-def test_classifier_name_no_classifer_osi_approved():
+def test_classifier_name_no_classifer_osi_approved() -> None:
     license = license_by_id("LiLiQ-R-1.1")
 
     assert license.classifier_name is None
 
 
-def test_classifier_name_no_classifer():
+def test_classifier_name_no_classifer() -> None:
     license = license_by_id("Leptonica")
 
     assert license.classifier_name == "Other/Proprietary License"
 
 
-def test_classifier():
+def test_classifier() -> None:
     license = license_by_id("lgpl-3.0-or-later")
 
     assert (
@@ -35,25 +35,25 @@ def test_classifier():
     )
 
 
-def test_classifier_no_classifer_osi_approved():
+def test_classifier_no_classifer_osi_approved() -> None:
     license = license_by_id("LiLiQ-R-1.1")
 
     assert license.classifier == "License :: OSI Approved"
 
 
-def test_classifier_no_classifer():
+def test_classifier_no_classifer() -> None:
     license = license_by_id("Leptonica")
 
     assert license.classifier == "License :: Other/Proprietary License"
 
 
-def test_proprietary_license():
+def test_proprietary_license() -> None:
     license = license_by_id("Proprietary")
 
     assert license.classifier == "License :: Other/Proprietary License"
 
 
-def test_custom_license():
+def test_custom_license() -> None:
     license = license_by_id("Amazon Software License")
 
     assert license.classifier == "License :: Other/Proprietary License"

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
 
@@ -13,14 +12,10 @@ from poetry.core.semver.helpers import parse_constraint
 from poetry.core.toml import TOMLFile
 
 
-if TYPE_CHECKING:
-    from poetry.core.factory import DependencyConstraint
-    from poetry.core.version.markers import BaseMarker
-
 fixtures_dir = Path(__file__).parent / "fixtures"
 
 
-def test_create_poetry():
+def test_create_poetry() -> None:
     poetry = Factory().create_poetry(fixtures_dir / "sample_project")
 
     package = poetry.package
@@ -144,7 +139,7 @@ def test_create_poetry():
     ]
 
 
-def test_create_poetry_with_packages_and_includes():
+def test_create_poetry_with_packages_and_includes() -> None:
     poetry = Factory().create_poetry(
         fixtures_dir.parent / "masonry" / "builders" / "fixtures" / "with-include"
     )
@@ -167,7 +162,7 @@ def test_create_poetry_with_packages_and_includes():
     ]
 
 
-def test_create_poetry_with_multi_constraints_dependency():
+def test_create_poetry_with_multi_constraints_dependency() -> None:
     poetry = Factory().create_poetry(
         fixtures_dir / "project_with_multi_constraints_dependency"
     )
@@ -177,14 +172,14 @@ def test_create_poetry_with_multi_constraints_dependency():
     assert len(package.requires) == 2
 
 
-def test_validate():
+def test_validate() -> None:
     complete = TOMLFile(fixtures_dir / "complete.toml")
     content = complete.read()["tool"]["poetry"]
 
     assert Factory.validate(content) == {"errors": [], "warnings": []}
 
 
-def test_validate_fails():
+def test_validate_fails() -> None:
     complete = TOMLFile(fixtures_dir / "complete.toml")
     content = complete.read()["tool"]["poetry"]
     content["this key is not in the schema"] = ""
@@ -197,14 +192,14 @@ def test_validate_fails():
     assert Factory.validate(content) == {"errors": [expected], "warnings": []}
 
 
-def test_strict_validation_success_on_multiple_readme_files():
+def test_strict_validation_success_on_multiple_readme_files() -> None:
     with_readme_files = TOMLFile(fixtures_dir / "with_readme_files" / "pyproject.toml")
     content = with_readme_files.read()["tool"]["poetry"]
 
     assert Factory.validate(content, strict=True) == {"errors": [], "warnings": []}
 
 
-def test_strict_validation_fails_on_readme_files_with_unmatching_types():
+def test_strict_validation_fails_on_readme_files_with_unmatching_types() -> None:
     with_readme_files = TOMLFile(fixtures_dir / "with_readme_files" / "pyproject.toml")
     content = with_readme_files.read()["tool"]["poetry"]
     content["readme"][0] = "README.md"
@@ -218,7 +213,7 @@ def test_strict_validation_fails_on_readme_files_with_unmatching_types():
     }
 
 
-def test_create_poetry_fails_on_invalid_configuration():
+def test_create_poetry_fails_on_invalid_configuration() -> None:
     with pytest.raises(RuntimeError) as e:
         Factory().create_poetry(
             Path(__file__).parent / "fixtures" / "invalid_pyproject" / "pyproject.toml"
@@ -231,7 +226,7 @@ The Poetry configuration is invalid:
     assert str(e.value) == expected
 
 
-def test_create_poetry_omits_dev_dependencies_iff_with_dev_is_false():
+def test_create_poetry_omits_dev_dependencies_iff_with_dev_is_false() -> None:
     poetry = Factory().create_poetry(fixtures_dir / "sample_project", with_groups=False)
     assert not any("dev" in r.groups for r in poetry.package.all_requires)
 
@@ -239,7 +234,7 @@ def test_create_poetry_omits_dev_dependencies_iff_with_dev_is_false():
     assert any("dev" in r.groups for r in poetry.package.all_requires)
 
 
-def test_create_poetry_fails_with_invalid_dev_dependencies_iff_with_dev_is_true():
+def test_create_poetry_fails_with_invalid_dev_dependencies_iff_with_dev_is_true() -> None:
     with pytest.raises(ValueError) as err:
         Factory().create_poetry(fixtures_dir / "project_with_invalid_dev_deps")
     assert "does not exist" in str(err.value)
@@ -249,7 +244,7 @@ def test_create_poetry_fails_with_invalid_dev_dependencies_iff_with_dev_is_true(
     )
 
 
-def test_create_poetry_with_groups_and_legacy_dev():
+def test_create_poetry_with_groups_and_legacy_dev() -> None:
     poetry = Factory().create_poetry(
         fixtures_dir / "project_with_groups_and_legacy_dev"
     )
@@ -261,7 +256,7 @@ def test_create_poetry_with_groups_and_legacy_dev():
     assert {dependency.name for dependency in dependencies} == {"pytest", "pre-commit"}
 
 
-def test_create_poetry_with_groups_and_explicit_main():
+def test_create_poetry_with_groups_and_explicit_main() -> None:
     poetry = Factory().create_poetry(
         fixtures_dir / "project_with_groups_and_explicit_main"
     )
@@ -320,7 +315,7 @@ def test_create_poetry_with_groups_and_explicit_main():
 )
 def test_create_dependency_marker_variants(
     constraint: dict[str, Any], exp_python: str, exp_marker: str
-):
+) -> None:
     constraint["version"] = "1.0.0"
     dep = Factory.create_dependency("foo", constraint)
     assert dep.python_versions == exp_python

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING
+from typing import Any
+from typing import cast
 
 import pytest
 
 from poetry.core.factory import Factory
+from poetry.core.packages.vcs_dependency import VCSDependency
 from poetry.core.semver.helpers import parse_constraint
 from poetry.core.toml import TOMLFile
 
@@ -26,6 +29,7 @@ def test_create_poetry():
     assert package.version.text == "1.2.3"
     assert package.description == "Some description."
     assert package.authors == ["Sébastien Eustace <sebastien@eustace.io>"]
+    assert package.license
     assert package.license.id == "MIT"
     assert (
         package.readmes[0].relative_to(fixtures_dir).as_posix()
@@ -49,6 +53,7 @@ def test_create_poetry():
     pendulum = dependencies["pendulum"]
     assert pendulum.pretty_constraint == "branch 2.0"
     assert pendulum.is_vcs()
+    pendulum = cast(VCSDependency, pendulum)
     assert pendulum.vcs == "git"
     assert pendulum.branch == "2.0"
     assert pendulum.source == "https://github.com/sdispater/pendulum.git"
@@ -58,6 +63,7 @@ def test_create_poetry():
     tomlkit = dependencies["tomlkit"]
     assert tomlkit.pretty_constraint == "rev 3bff550"
     assert tomlkit.is_vcs()
+    tomlkit = cast(VCSDependency, tomlkit)
     assert tomlkit.vcs == "git"
     assert tomlkit.rev == "3bff550"
     assert tomlkit.source == "https://github.com/sdispater/tomlkit.git"
@@ -313,7 +319,7 @@ def test_create_poetry_with_groups_and_explicit_main():
     ],
 )
 def test_create_dependency_marker_variants(
-    constraint: DependencyConstraint, exp_python: str, exp_marker: BaseMarker
+    constraint: dict[str, Any], exp_python: str, exp_marker: str
 ):
     constraint["version"] = "1.0.0"
     dep = Factory.create_dependency("foo", constraint)

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -50,7 +50,7 @@ def temporary_project_directory(
         yield str(dst)
 
 
-def subprocess_run(*args: str, **kwargs: Any) -> subprocess.CompletedProcess:
+def subprocess_run(*args: str, **kwargs: Any) -> subprocess.CompletedProcess[str]:
     """
     Helper method to run a subprocess. Asserts for success.
     """

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -14,7 +14,7 @@ from poetry.core.utils.helpers import readme_content_type
 from poetry.core.utils.helpers import temporary_directory
 
 
-def test_parse_requires():
+def test_parse_requires() -> None:
     requires = """\
 jsonschema>=2.6.0.0,<3.0.0.0
 lockfile>=0.12.0.0,<0.13.0.0
@@ -74,11 +74,11 @@ isort@ git+git://github.com/timothycrosley/isort.git@e63ae06ec7d70b06df9e5283576
 
 
 @pytest.mark.parametrize("raw", ["a-b-c", "a_b-c", "a_b_c", "a-b_c"])
-def test_utils_helpers_canonical_names(raw: str):
+def test_utils_helpers_canonical_names(raw: str) -> None:
     assert canonicalize_name(raw) == "a-b-c"
 
 
-def test_utils_helpers_combine_unicode():
+def test_utils_helpers_combine_unicode() -> None:
     combined_expected = "é"
     decomposed = "é"
     assert combined_expected != decomposed
@@ -87,7 +87,7 @@ def test_utils_helpers_combine_unicode():
     assert combined == combined_expected
 
 
-def test_utils_helpers_temporary_directory_readonly_file():
+def test_utils_helpers_temporary_directory_readonly_file() -> None:
     with temporary_directory() as temp_dir:
         readonly_filename = os.path.join(temp_dir, "file.txt")
         with open(readonly_filename, "w+") as readonly_file:
@@ -109,5 +109,7 @@ def test_utils_helpers_temporary_directory_readonly_file():
         (Path("README"), "text/plain"),
     ],
 )
-def test_utils_helpers_readme_content_type(readme: str | Path, content_type: str):
+def test_utils_helpers_readme_content_type(
+    readme: str | Path, content_type: str
+) -> None:
     assert readme_content_type(readme) == content_type

--- a/tests/vcs/test_vcs.py
+++ b/tests/vcs/test_vcs.py
@@ -104,7 +104,7 @@ if TYPE_CHECKING:
         ),
     ],
 )
-def test_normalize_url(url: str, normalized: GitUrl):
+def test_normalize_url(url: str, normalized: GitUrl) -> None:
     assert normalized == Git.normalize_url(url)
 
 
@@ -346,7 +346,7 @@ def test_normalize_url(url: str, normalized: GitUrl):
         ),
     ],
 )
-def test_parse_url(url: str, parsed: ParsedUrl):
+def test_parse_url(url: str, parsed: ParsedUrl) -> None:
     result = ParsedUrl.parse(url)
     assert parsed.name == result.name
     assert parsed.pathname == result.pathname
@@ -358,24 +358,24 @@ def test_parse_url(url: str, parsed: ParsedUrl):
     assert parsed.user == result.user
 
 
-def test_parse_url_should_fail():
+def test_parse_url_should_fail() -> None:
     url = "https://" + "@" * 64 + "!"
 
     with pytest.raises(ValueError):
         ParsedUrl.parse(url)
 
 
-def test_git_clone_raises_error_on_invalid_repository():
+def test_git_clone_raises_error_on_invalid_repository() -> None:
     with pytest.raises(GitError):
         Git().clone("-u./payload", Path("foo"))
 
 
-def test_git_checkout_raises_error_on_invalid_repository():
+def test_git_checkout_raises_error_on_invalid_repository() -> None:
     with pytest.raises(GitError):
         Git().checkout("-u./payload")
 
 
-def test_git_rev_parse_raises_error_on_invalid_repository():
+def test_git_rev_parse_raises_error_on_invalid_repository() -> None:
     with pytest.raises(GitError):
         Git().rev_parse("-u./payload")
 
@@ -387,7 +387,7 @@ def test_git_rev_parse_raises_error_on_invalid_repository():
         " reasons"
     ),
 )
-def test_ensure_absolute_path_to_git(mocker: MockerFixture):
+def test_ensure_absolute_path_to_git(mocker: MockerFixture) -> None:
     _reset_executable()
 
     def checkout_output(cmd: list[str], *args: Any, **kwargs: Any) -> str | bytes:
@@ -418,7 +418,7 @@ def test_ensure_absolute_path_to_git(mocker: MockerFixture):
         " reasons"
     ),
 )
-def test_ensure_existing_git_executable_is_found(mocker: MockerFixture):
+def test_ensure_existing_git_executable_is_found(mocker: MockerFixture) -> None:
     mock = mocker.patch.object(subprocess, "check_output", return_value=b"")
 
     Git().run("config")

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -10,7 +10,7 @@ from poetry.core.version.markers import SingleMarker
 from poetry.core.version.markers import parse_marker
 
 
-def test_single_marker():
+def test_single_marker() -> None:
     m = parse_marker('sys_platform == "darwin"')
 
     assert isinstance(m, SingleMarker)
@@ -74,7 +74,7 @@ def test_single_marker():
     )
 
 
-def test_single_marker_intersect():
+def test_single_marker_intersect() -> None:
     m = parse_marker('sys_platform == "darwin"')
 
     intersection = m.intersect(parse_marker('implementation_name == "cpython"'))
@@ -89,14 +89,14 @@ def test_single_marker_intersect():
     assert str(intersection) == 'python_version >= "3.4" and python_version < "3.6"'
 
 
-def test_single_marker_intersect_compacts_constraints():
+def test_single_marker_intersect_compacts_constraints() -> None:
     m = parse_marker('python_version < "3.6"')
 
     intersection = m.intersect(parse_marker('python_version < "3.4"'))
     assert str(intersection) == 'python_version < "3.4"'
 
 
-def test_single_marker_intersect_with_multi():
+def test_single_marker_intersect_with_multi() -> None:
     m = parse_marker('sys_platform == "darwin"')
 
     intersection = m.intersect(
@@ -109,7 +109,7 @@ def test_single_marker_intersect_with_multi():
     )
 
 
-def test_single_marker_intersect_with_multi_with_duplicate():
+def test_single_marker_intersect_with_multi_with_duplicate() -> None:
     m = parse_marker('python_version < "4.0"')
 
     intersection = m.intersect(
@@ -118,7 +118,7 @@ def test_single_marker_intersect_with_multi_with_duplicate():
     assert str(intersection) == 'sys_platform == "darwin" and python_version < "4.0"'
 
 
-def test_single_marker_intersect_with_multi_compacts_constraint():
+def test_single_marker_intersect_with_multi_compacts_constraint() -> None:
     m = parse_marker('python_version < "3.6"')
 
     intersection = m.intersect(
@@ -130,7 +130,7 @@ def test_single_marker_intersect_with_multi_compacts_constraint():
     )
 
 
-def test_single_marker_intersect_with_union_leads_to_single_marker():
+def test_single_marker_intersect_with_union_leads_to_single_marker() -> None:
     m = parse_marker('python_version >= "3.6"')
 
     intersection = m.intersect(
@@ -139,7 +139,7 @@ def test_single_marker_intersect_with_union_leads_to_single_marker():
     assert str(intersection) == 'python_version >= "3.7"'
 
 
-def test_single_marker_intersect_with_union_leads_to_empty():
+def test_single_marker_intersect_with_union_leads_to_empty() -> None:
     m = parse_marker('python_version == "3.7"')
 
     intersection = m.intersect(
@@ -148,7 +148,7 @@ def test_single_marker_intersect_with_union_leads_to_empty():
     assert intersection.is_empty()
 
 
-def test_single_marker_not_in_python_intersection():
+def test_single_marker_not_in_python_intersection() -> None:
     m = parse_marker('python_version not in "2.7, 3.0, 3.1"')
 
     intersection = m.intersect(
@@ -157,7 +157,7 @@ def test_single_marker_not_in_python_intersection():
     assert str(intersection) == 'python_version not in "2.7, 3.0, 3.1, 3.2"'
 
 
-def test_marker_intersection_of_python_version_and_python_full_version():
+def test_marker_intersection_of_python_version_and_python_full_version() -> None:
     m = parse_marker('python_version >= "3.6"')
     m2 = parse_marker('python_full_version >= "3.0.0"')
     intersection = m.intersect(m2)
@@ -165,14 +165,14 @@ def test_marker_intersection_of_python_version_and_python_full_version():
     assert str(intersection) == 'python_version >= "3.6"'
 
 
-def test_single_marker_union():
+def test_single_marker_union() -> None:
     m = parse_marker('sys_platform == "darwin"')
 
     union = m.union(parse_marker('implementation_name == "cpython"'))
     assert str(union) == 'sys_platform == "darwin" or implementation_name == "cpython"'
 
 
-def test_single_marker_union_is_any():
+def test_single_marker_union_is_any() -> None:
     m = parse_marker('python_version >= "3.4"')
 
     union = m.union(parse_marker('python_version < "3.6"'))
@@ -211,14 +211,14 @@ def test_single_marker_union_is_any():
 )
 def test_single_marker_union_is_single_marker(
     marker1: str, marker2: str, expected: str
-):
+) -> None:
     m = parse_marker(marker1)
 
     union = m.union(parse_marker(marker2))
     assert str(union) == expected
 
 
-def test_single_marker_union_with_multi():
+def test_single_marker_union_with_multi() -> None:
     m = parse_marker('sys_platform == "darwin"')
 
     union = m.union(
@@ -231,7 +231,7 @@ def test_single_marker_union_with_multi():
     )
 
 
-def test_single_marker_union_with_multi_duplicate():
+def test_single_marker_union_with_multi_duplicate() -> None:
     m = parse_marker('sys_platform == "darwin" and python_version >= "3.6"')
 
     union = m.union(
@@ -257,13 +257,13 @@ def test_single_marker_union_with_multi_duplicate():
 )
 def test_single_marker_union_with_multi_is_single_marker(
     single_marker: str, multi_marker: str, expected: str
-):
+) -> None:
     m = parse_marker(single_marker)
     union = m.union(parse_marker(multi_marker))
     assert str(union) == expected
 
 
-def test_single_marker_union_with_multi_cannot_be_simplified():
+def test_single_marker_union_with_multi_cannot_be_simplified() -> None:
     m = parse_marker('python_version >= "3.7"')
     union = m.union(parse_marker('python_version >= "3.6" and sys_platform == "win32"'))
     assert (
@@ -273,13 +273,13 @@ def test_single_marker_union_with_multi_cannot_be_simplified():
     )
 
 
-def test_single_marker_union_with_multi_is_union_of_single_markers():
+def test_single_marker_union_with_multi_is_union_of_single_markers() -> None:
     m = parse_marker('python_version >= "3.6"')
     union = m.union(parse_marker('python_version < "3.6" and sys_platform == "win32"'))
     assert str(union) == 'sys_platform == "win32" or python_version >= "3.6"'
 
 
-def test_single_marker_union_with_multi_union_is_union_of_single_markers():
+def test_single_marker_union_with_multi_union_is_union_of_single_markers() -> None:
     m = parse_marker('python_version >= "3.6"')
     union = m.union(
         parse_marker(
@@ -294,7 +294,7 @@ def test_single_marker_union_with_multi_union_is_union_of_single_markers():
     )
 
 
-def test_single_marker_union_with_union():
+def test_single_marker_union_with_union() -> None:
     m = parse_marker('sys_platform == "darwin"')
 
     union = m.union(
@@ -307,14 +307,14 @@ def test_single_marker_union_with_union():
     )
 
 
-def test_single_marker_not_in_python_union():
+def test_single_marker_not_in_python_union() -> None:
     m = parse_marker('python_version not in "2.7, 3.0, 3.1"')
 
     union = m.union(parse_marker('python_version not in "2.7, 3.0, 3.1, 3.2"'))
     assert str(union) == 'python_version not in "2.7, 3.0, 3.1"'
 
 
-def test_single_marker_union_with_union_duplicate():
+def test_single_marker_union_with_union_duplicate() -> None:
     m = parse_marker('sys_platform == "darwin"')
 
     union = m.union(parse_marker('sys_platform == "darwin" or python_version >= "3.6"'))
@@ -331,13 +331,13 @@ def test_single_marker_union_with_union_duplicate():
     assert str(union) == 'sys_platform == "darwin" or python_version <= "3.6"'
 
 
-def test_single_marker_union_with_inverse():
+def test_single_marker_union_with_inverse() -> None:
     m = parse_marker('sys_platform == "darwin"')
     union = m.union(parse_marker('sys_platform != "darwin"'))
     assert union.is_any()
 
 
-def test_multi_marker():
+def test_multi_marker() -> None:
     m = parse_marker('sys_platform == "darwin" and implementation_name == "cpython"')
 
     assert isinstance(m, MultiMarker)
@@ -347,7 +347,7 @@ def test_multi_marker():
     ]
 
 
-def test_multi_marker_is_empty_is_contradictory():
+def test_multi_marker_is_empty_is_contradictory() -> None:
     m = parse_marker(
         'sys_platform == "linux" and python_version >= "3.5" and python_version < "2.8"'
     )
@@ -359,7 +359,7 @@ def test_multi_marker_is_empty_is_contradictory():
     assert m.is_empty()
 
 
-def test_multi_marker_intersect_multi():
+def test_multi_marker_intersect_multi() -> None:
     m = parse_marker('sys_platform == "darwin" and implementation_name == "cpython"')
 
     intersection = m.intersect(
@@ -372,7 +372,7 @@ def test_multi_marker_intersect_multi():
     )
 
 
-def test_multi_marker_intersect_multi_with_overlapping_constraints():
+def test_multi_marker_intersect_multi_with_overlapping_constraints() -> None:
     m = parse_marker('sys_platform == "darwin" and python_version < "3.6"')
 
     intersection = m.intersect(
@@ -388,14 +388,14 @@ def test_multi_marker_intersect_multi_with_overlapping_constraints():
     )
 
 
-def test_multi_marker_intersect_with_union_drops_union():
+def test_multi_marker_intersect_with_union_drops_union() -> None:
     m = parse_marker('python_version >= "3" and python_version < "4"')
     m2 = parse_marker('python_version < "2" or python_version >= "3"')
     assert str(m.intersect(m2)) == str(m)
     assert str(m2.intersect(m)) == str(m)
 
 
-def test_multi_marker_intersect_with_multi_union_leads_to_empty_in_one_step():
+def test_multi_marker_intersect_with_multi_union_leads_to_empty_in_one_step() -> None:
     # empty marker in one step
     # py == 2 and (py < 2 or py >= 3) -> empty
     m = parse_marker('sys_platform == "darwin" and python_version == "2"')
@@ -406,7 +406,7 @@ def test_multi_marker_intersect_with_multi_union_leads_to_empty_in_one_step():
     assert m2.intersect(m).is_empty()
 
 
-def test_multi_marker_intersect_with_multi_union_leads_to_empty_in_two_steps():
+def test_multi_marker_intersect_with_multi_union_leads_to_empty_in_two_steps() -> None:
     # empty marker in two steps
     # py >= 2 and (py < 2 or py >= 3) -> py >= 3
     # py < 3 and py >= 3 -> empty
@@ -418,7 +418,7 @@ def test_multi_marker_intersect_with_multi_union_leads_to_empty_in_two_steps():
     assert m2.intersect(m).is_empty()
 
 
-def test_multi_marker_union_multi():
+def test_multi_marker_union_multi() -> None:
     m = parse_marker('sys_platform == "darwin" and implementation_name == "cpython"')
 
     union = m.union(parse_marker('python_version >= "3.6" and os_name == "Windows"'))
@@ -429,14 +429,14 @@ def test_multi_marker_union_multi():
     )
 
 
-def test_multi_marker_union_multi_is_single_marker():
+def test_multi_marker_union_multi_is_single_marker() -> None:
     m = parse_marker('python_version >= "3" and sys_platform == "win32"')
     m2 = parse_marker('sys_platform != "win32" and python_version >= "3"')
     assert str(m.union(m2)) == 'python_version >= "3"'
     assert str(m2.union(m)) == 'python_version >= "3"'
 
 
-def test_multi_marker_union_multi_is_multi():
+def test_multi_marker_union_multi_is_multi() -> None:
     m = parse_marker('python_version >= "3" and sys_platform == "win32"')
     m2 = parse_marker(
         'python_version >= "3" and sys_platform != "win32" and sys_platform != "linux"'
@@ -445,7 +445,7 @@ def test_multi_marker_union_multi_is_multi():
     assert str(m2.union(m)) == 'python_version >= "3" and sys_platform != "linux"'
 
 
-def test_multi_marker_union_with_union():
+def test_multi_marker_union_with_union() -> None:
     m = parse_marker('sys_platform == "darwin" and implementation_name == "cpython"')
 
     union = m.union(parse_marker('python_version >= "3.6" or os_name == "Windows"'))
@@ -456,7 +456,7 @@ def test_multi_marker_union_with_union():
     )
 
 
-def test_multi_marker_union_with_multi_union_is_single_marker():
+def test_multi_marker_union_with_multi_union_is_single_marker() -> None:
     m = parse_marker('sys_platform == "darwin" and python_version == "3"')
     m2 = parse_marker(
         'sys_platform == "darwin" and python_version < "3" or sys_platform == "darwin"'
@@ -466,7 +466,7 @@ def test_multi_marker_union_with_multi_union_is_single_marker():
     assert str(m2.union(m)) == 'sys_platform == "darwin"'
 
 
-def test_multi_marker_union_with_union_multi_is_single_marker():
+def test_multi_marker_union_with_union_multi_is_single_marker() -> None:
     m = parse_marker('sys_platform == "darwin" and python_version == "3"')
     m2 = parse_marker(
         'sys_platform == "darwin" and (python_version < "3" or python_version > "3")'
@@ -475,7 +475,7 @@ def test_multi_marker_union_with_union_multi_is_single_marker():
     assert str(m2.union(m)) == 'sys_platform == "darwin"'
 
 
-def test_marker_union():
+def test_marker_union() -> None:
     m = parse_marker('sys_platform == "darwin" or implementation_name == "cpython"')
 
     assert isinstance(m, MarkerUnion)
@@ -485,7 +485,7 @@ def test_marker_union():
     ]
 
 
-def test_marker_union_deduplicate():
+def test_marker_union_deduplicate() -> None:
     m = parse_marker(
         'sys_platform == "darwin" or implementation_name == "cpython" or sys_platform'
         ' == "darwin"'
@@ -494,7 +494,7 @@ def test_marker_union_deduplicate():
     assert str(m) == 'sys_platform == "darwin" or implementation_name == "cpython"'
 
 
-def test_marker_union_of_python_version_and_python_full_version():
+def test_marker_union_of_python_version_and_python_full_version() -> None:
     m = parse_marker('python_version >= "3.6"')
     m2 = parse_marker('python_full_version >= "3.0.0"')
     union = m.union(m2)
@@ -502,7 +502,7 @@ def test_marker_union_of_python_version_and_python_full_version():
     assert str(union) == 'python_full_version >= "3.0.0"'
 
 
-def test_marker_union_intersect_single_marker():
+def test_marker_union_intersect_single_marker() -> None:
     m = parse_marker('sys_platform == "darwin" or python_version < "3.4"')
 
     intersection = m.intersect(parse_marker('implementation_name == "cpython"'))
@@ -513,7 +513,7 @@ def test_marker_union_intersect_single_marker():
     )
 
 
-def test_marker_union_intersect_single_with_overlapping_constraints():
+def test_marker_union_intersect_single_with_overlapping_constraints() -> None:
     m = parse_marker('sys_platform == "darwin" or python_version < "3.4"')
 
     intersection = m.intersect(parse_marker('python_version <= "3.6"'))
@@ -528,7 +528,7 @@ def test_marker_union_intersect_single_with_overlapping_constraints():
     assert str(intersection) == 'sys_platform == "darwin"'
 
 
-def test_marker_union_intersect_marker_union():
+def test_marker_union_intersect_marker_union() -> None:
     m = parse_marker('sys_platform == "darwin" or python_version < "3.4"')
 
     intersection = m.intersect(
@@ -543,7 +543,7 @@ def test_marker_union_intersect_marker_union():
     )
 
 
-def test_marker_union_intersect_marker_union_drops_unnecessary_markers():
+def test_marker_union_intersect_marker_union_drops_unnecessary_markers() -> None:
     m = parse_marker(
         'python_version >= "2.7" and python_version < "2.8" '
         'or python_version >= "3.4" and python_version < "4.0"'
@@ -561,7 +561,7 @@ def test_marker_union_intersect_marker_union_drops_unnecessary_markers():
     assert str(intersection) == expected
 
 
-def test_marker_union_intersect_multi_marker():
+def test_marker_union_intersect_multi_marker() -> None:
     m = parse_marker('sys_platform == "darwin" or python_version < "3.4"')
 
     intersection = m.intersect(
@@ -575,7 +575,7 @@ def test_marker_union_intersect_multi_marker():
     )
 
 
-def test_marker_union_union_with_union():
+def test_marker_union_union_with_union() -> None:
     m = parse_marker('sys_platform == "darwin" or python_version < "3.4"')
 
     union = m.union(
@@ -588,7 +588,7 @@ def test_marker_union_union_with_union():
     )
 
 
-def test_marker_union_union_duplicates():
+def test_marker_union_union_duplicates() -> None:
     m = parse_marker('sys_platform == "darwin" or python_version < "3.4"')
 
     union = m.union(parse_marker('sys_platform == "darwin" or os_name == "Windows"'))
@@ -611,25 +611,25 @@ def test_marker_union_union_duplicates():
     )
 
 
-def test_marker_union_all_any():
+def test_marker_union_all_any() -> None:
     union = MarkerUnion(parse_marker(""), parse_marker(""))
 
     assert union.is_any()
 
 
-def test_marker_union_not_all_any():
+def test_marker_union_not_all_any() -> None:
     union = MarkerUnion(parse_marker(""), parse_marker(""), parse_marker("<empty>"))
 
     assert union.is_any()
 
 
-def test_marker_union_all_empty():
+def test_marker_union_all_empty() -> None:
     union = MarkerUnion(parse_marker("<empty>"), parse_marker("<empty>"))
 
     assert union.is_empty()
 
 
-def test_marker_union_not_all_empty():
+def test_marker_union_not_all_empty() -> None:
     union = MarkerUnion(
         parse_marker("<empty>"), parse_marker("<empty>"), parse_marker("")
     )
@@ -637,7 +637,7 @@ def test_marker_union_not_all_empty():
     assert not union.is_empty()
 
 
-def test_marker_str_conversion_skips_empty_and_any():
+def test_marker_str_conversion_skips_empty_and_any() -> None:
     union = MarkerUnion(
         parse_marker("<empty>"),
         parse_marker(
@@ -653,14 +653,14 @@ def test_marker_str_conversion_skips_empty_and_any():
     )
 
 
-def test_intersect_compacts_constraints():
+def test_intersect_compacts_constraints() -> None:
     m = parse_marker('python_version < "4.0"')
 
     intersection = m.intersect(parse_marker('python_version < "5.0"'))
     assert str(intersection) == 'python_version < "4.0"'
 
 
-def test_multi_marker_removes_duplicates():
+def test_multi_marker_removes_duplicates() -> None:
     m = parse_marker('sys_platform == "win32" and sys_platform == "win32"')
 
     assert str(m) == 'sys_platform == "win32"'
@@ -745,7 +745,7 @@ def test_multi_marker_removes_duplicates():
 )
 def test_validate(
     marker_string: str, environment: dict[str, str] | None, expected: bool
-):
+) -> None:
     m = parse_marker(marker_string)
 
     assert m.validate(environment) is expected
@@ -760,7 +760,7 @@ def test_validate(
         )
     ],
 )
-def test_parse_version_like_markers(marker: str, env: dict[str, str]):
+def test_parse_version_like_markers(marker: str, env: dict[str, str]) -> None:
     m = parse_marker(marker)
 
     assert m.validate(env)
@@ -792,7 +792,7 @@ def test_parse_version_like_markers(marker: str, env: dict[str, str]):
         ),
     ],
 )
-def test_without_extras(marker: str, expected: str):
+def test_without_extras(marker: str, expected: str) -> None:
     m = parse_marker(marker)
 
     assert str(m.without_extras()) == expected
@@ -838,7 +838,7 @@ def test_without_extras(marker: str, expected: str):
         ),
     ],
 )
-def test_exclude(marker: str, excluded: str, expected: str):
+def test_exclude(marker: str, excluded: str, expected: str) -> None:
     m = parse_marker(marker)
 
     if expected == "*":
@@ -888,19 +888,19 @@ def test_exclude(marker: str, excluded: str, expected: str):
         ),
     ],
 )
-def test_only(marker: str, only: list[str], expected: str):
+def test_only(marker: str, only: list[str], expected: str) -> None:
     m = parse_marker(marker)
 
     assert str(m.only(*only)) == expected
 
 
-def test_union_of_a_single_marker_is_the_single_marker():
+def test_union_of_a_single_marker_is_the_single_marker() -> None:
     union = MarkerUnion.of(SingleMarker("python_version", ">= 2.7"))
 
     assert SingleMarker("python_version", ">= 2.7") == union
 
 
-def test_union_of_multi_with_a_containing_single():
+def test_union_of_multi_with_a_containing_single() -> None:
     single = parse_marker('python_version >= "2.7"')
     multi = parse_marker('python_version >= "2.7" and extra == "foo"')
     union = multi.union(single)
@@ -938,7 +938,7 @@ def test_union_of_multi_with_a_containing_single():
         ),
     ],
 )
-def test_invert(marker: str, inverse: str):
+def test_invert(marker: str, inverse: str) -> None:
     m = parse_marker(marker)
 
     assert parse_marker(inverse) == m.invert()
@@ -956,7 +956,7 @@ def test_invert(marker: str, inverse: str):
 )
 def test_union_should_drop_markers_if_their_complement_is_present(
     marker: str, expected: str
-):
+) -> None:
     m = parse_marker(marker)
 
     assert parse_marker(expected) == m

--- a/tests/version/test_requirements.py
+++ b/tests/version/test_requirements.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 
-from typing import TYPE_CHECKING
 from typing import Any
 
 import pytest
@@ -12,10 +11,6 @@ from poetry.core.version.requirements import InvalidRequirement
 from poetry.core.version.requirements import Requirement
 
 
-if TYPE_CHECKING:
-    from poetry.core.version.markers import BaseMarker
-
-
 def assert_requirement(
     req: Requirement,
     name: str,
@@ -23,7 +18,7 @@ def assert_requirement(
     extras: list[str] | None = None,
     constraint: str = "*",
     marker: str | None = None,
-):
+) -> None:
     if extras is None:
         extras = []
 
@@ -111,7 +106,7 @@ def assert_requirement(
         ),
     ],
 )
-def test_requirement(string: str, expected: dict[str, Any]):
+def test_requirement(string: str, expected: dict[str, Any]) -> None:
     req = Requirement(string)
 
     assert_requirement(req, **expected)
@@ -126,7 +121,7 @@ def test_requirement(string: str, expected: dict[str, Any]):
         ("name @ file:/.", "invalid URL"),
     ],
 )
-def test_invalid_requirement(string: str, exception: str):
+def test_invalid_requirement(string: str, exception: str) -> None:
     with pytest.raises(
         InvalidRequirement,
         match=re.escape(f"The requirement is invalid: {exception}"),

--- a/tests/version/test_requirements.py
+++ b/tests/version/test_requirements.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 
 from typing import TYPE_CHECKING
+from typing import Any
 
 import pytest
 
@@ -21,7 +22,7 @@ def assert_requirement(
     url: str | None = None,
     extras: list[str] | None = None,
     constraint: str = "*",
-    marker: BaseMarker | None = None,
+    marker: str | None = None,
 ):
     if extras is None:
         extras = []
@@ -110,7 +111,7 @@ def assert_requirement(
         ),
     ],
 )
-def test_requirement(string: str, expected: dict[str, str]):
+def test_requirement(string: str, expected: dict[str, Any]):
     req = Requirement(string)
 
     assert_requirement(req, **expected)

--- a/tests/version/test_version_pep440.py
+++ b/tests/version/test_version_pep440.py
@@ -40,7 +40,7 @@ def test_pep440_release_segment_from_parts(parts: tuple[int, ...], result: Relea
     ],
 )
 def test_pep440_release_tag_normalisation(
-    parts: tuple[str, int | None], result: ReleaseTag
+    parts: tuple[str] | tuple[str, int], result: ReleaseTag
 ):
     tag = ReleaseTag(*parts)
     assert tag == result

--- a/tests/version/test_version_pep440.py
+++ b/tests/version/test_version_pep440.py
@@ -20,7 +20,9 @@ from poetry.core.version.pep440.segments import RELEASE_PHASES_SHORT
         ((1, 2, 3, 4, 5, 6), Release(1, 2, 3, (4, 5, 6))),
     ],
 )
-def test_pep440_release_segment_from_parts(parts: tuple[int, ...], result: Release):
+def test_pep440_release_segment_from_parts(
+    parts: tuple[int, ...], result: Release
+) -> None:
     assert Release.from_parts(*parts) == result
 
 
@@ -41,7 +43,7 @@ def test_pep440_release_segment_from_parts(parts: tuple[int, ...], result: Relea
 )
 def test_pep440_release_tag_normalisation(
     parts: tuple[str] | tuple[str, int], result: ReleaseTag
-):
+) -> None:
     tag = ReleaseTag(*parts)
     assert tag == result
     assert tag.to_string() == result.to_string()
@@ -59,14 +61,16 @@ def test_pep440_release_tag_normalisation(
         (("dev",), None),
     ],
 )
-def test_pep440_release_tag_next_phase(parts: tuple[str], result: ReleaseTag | None):
+def test_pep440_release_tag_next_phase(
+    parts: tuple[str], result: ReleaseTag | None
+) -> None:
     assert ReleaseTag(*parts).next_phase() == result
 
 
 @pytest.mark.parametrize(
     "phase", list({*RELEASE_PHASES.keys(), *RELEASE_PHASES_SHORT.keys()})
 )
-def test_pep440_release_tag_next(phase: str):
+def test_pep440_release_tag_next(phase: str) -> None:
     tag = ReleaseTag(phase=phase).next()
     assert tag.phase == ReleaseTag.expand(phase)
     assert tag.number == 1
@@ -164,13 +168,13 @@ def test_pep440_release_tag_next(phase: str):
         ),
     ],
 )
-def test_pep440_parse_text(text: str, result: PEP440Version):
+def test_pep440_parse_text(text: str, result: PEP440Version) -> None:
     assert PEP440Version.parse(text) == result
 
 
 @pytest.mark.parametrize(
     "text", ["1.2.3.dev1-1", "example-1", "1.2.3-random1", "1.2.3-1-1"]
 )
-def test_pep440_parse_text_invalid_versions(text: str):
+def test_pep440_parse_text_invalid_versions(text: str) -> None:
     with pytest.raises(InvalidVersion):
         assert PEP440Version.parse(text)


### PR DESCRIPTION
Removes `tests` from mypy's ignored list

The first commit 9f8ffc2 fixes type issues, while the second 81bfebd just adds explicit return types `-> None`
