### PR TITLE
chore(toml): remove type errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,8 +104,6 @@ module = [
   'poetry.core.packages.dependency',
   'poetry.core.packages.package',
   'poetry.core.semver.version_union',
-  'poetry.core.toml.exceptions',
-  'poetry.core.toml.file',
 ]
 ignore_errors = true
 

--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -9,6 +9,7 @@ from typing import Dict
 from typing import List
 from typing import Mapping
 from typing import Union
+from typing import cast
 from warnings import warn
 
 from poetry.core.utils.helpers import combine_unicode
@@ -55,8 +56,8 @@ class Factory:
             raise RuntimeError("The Poetry configuration is invalid:\n" + message)
 
         # Load package
-        name = local_config["name"]
-        version = local_config["version"]
+        name = cast(str, local_config["name"])
+        version = cast(str, local_config["version"])
         package = self.get_package(name, version)
         package = self.configure_package(
             package, local_config, poetry_file.parent, with_groups=with_groups

--- a/src/poetry/core/pyproject/toml.py
+++ b/src/poetry/core/pyproject/toml.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import cast
+
+from tomlkit.container import Container
 
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from tomlkit.container import Container
     from tomlkit.toml_document import TOMLDocument
 
     from poetry.core.pyproject.tables import BuildSystem
@@ -63,7 +65,7 @@ class PyProjectTOML:
         from tomlkit.exceptions import NonExistentKey
 
         try:
-            return self.data["tool"]["poetry"]
+            return cast(Container, self.data["tool"]["poetry"])
         except NonExistentKey as e:
             from poetry.core.pyproject.exceptions import PyProjectException
 
@@ -95,8 +97,9 @@ class PyProjectTOML:
             if "build-system" not in data:
                 data["build-system"] = Container()
 
-            data["build-system"]["requires"] = self._build_system.requires
-            data["build-system"]["build-backend"] = self._build_system.build_backend
+            build_system = cast(Container, data["build-system"])
+            build_system["requires"] = self._build_system.requires
+            build_system["build-backend"] = self._build_system.build_backend
 
         self.file.write(data=data)
 

--- a/src/poetry/core/toml/exceptions.py
+++ b/src/poetry/core/toml/exceptions.py
@@ -5,5 +5,5 @@ from tomlkit.exceptions import TOMLKitError
 from poetry.core.exceptions import PoetryCoreException
 
 
-class TOMLError(TOMLKitError, PoetryCoreException):
+class TOMLError(TOMLKitError, PoetryCoreException):  # type: ignore[misc]
     pass

--- a/src/poetry/core/toml/file.py
+++ b/src/poetry/core/toml/file.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from tomlkit.toml_document import TOMLDocument
 
 
-class TOMLFile(BaseTOMLFile):
+class TOMLFile(BaseTOMLFile):  # type: ignore[misc]
     def __init__(self, path: str | Path) -> None:
         if isinstance(path, str):
             path = Path(path)

--- a/tests/pyproject/test_pyproject_toml.py
+++ b/tests/pyproject/test_pyproject_toml.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import uuid
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -37,7 +38,8 @@ def test_pyproject_toml_poetry_config(
     pyproject_toml: Path, poetry_section: str
 ) -> None:
     pyproject = PyProjectTOML(pyproject_toml)
-    config = TOMLFile(pyproject_toml.as_posix()).read()["tool"]["poetry"]
+    doc: dict[str, Any] = TOMLFile(pyproject_toml.as_posix()).read()
+    config = doc["tool"]["poetry"]
 
     assert pyproject.is_poetry_project()
     assert pyproject.poetry_config == config

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -174,14 +174,16 @@ def test_create_poetry_with_multi_constraints_dependency() -> None:
 
 def test_validate() -> None:
     complete = TOMLFile(fixtures_dir / "complete.toml")
-    content = complete.read()["tool"]["poetry"]
+    doc: dict[str, Any] = complete.read()
+    content = doc["tool"]["poetry"]
 
     assert Factory.validate(content) == {"errors": [], "warnings": []}
 
 
 def test_validate_fails() -> None:
     complete = TOMLFile(fixtures_dir / "complete.toml")
-    content = complete.read()["tool"]["poetry"]
+    doc: dict[str, Any] = complete.read()
+    content = doc["tool"]["poetry"]
     content["this key is not in the schema"] = ""
 
     expected = (
@@ -194,14 +196,16 @@ def test_validate_fails() -> None:
 
 def test_strict_validation_success_on_multiple_readme_files() -> None:
     with_readme_files = TOMLFile(fixtures_dir / "with_readme_files" / "pyproject.toml")
-    content = with_readme_files.read()["tool"]["poetry"]
+    doc: dict[str, Any] = with_readme_files.read()
+    content = doc["tool"]["poetry"]
 
     assert Factory.validate(content, strict=True) == {"errors": [], "warnings": []}
 
 
 def test_strict_validation_fails_on_readme_files_with_unmatching_types() -> None:
     with_readme_files = TOMLFile(fixtures_dir / "with_readme_files" / "pyproject.toml")
-    content = with_readme_files.read()["tool"]["poetry"]
+    doc: dict[str, Any] = with_readme_files.read()
+    content = doc["tool"]["poetry"]
     content["readme"][0] = "README.md"
 
     assert Factory.validate(content, strict=True) == {


### PR DESCRIPTION
Removes `poetry.core.toml.*` from the ignored list

Relates-to: https://github.com/python-poetry/poetry/issues/5017
