### PR TITLE
semver/pep508: handle wildcard exclusions

### DIFF
--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -260,7 +260,13 @@ class Dependency(PackageSpecification):
 
         constraint = self.constraint
         if isinstance(constraint, VersionUnion):
-            if constraint.excludes_single_version():
+            if (
+                constraint.excludes_single_version()
+                or constraint.excludes_single_wildcard_range()
+            ):
+                # This branch is a short-circuit logic for special cases and
+                # avoids having to split and parse constraint again. This has
+                # no functional difference with the logic in the else branch.
                 requirement += f" ({str(constraint)})"
             else:
                 constraints = self.pretty_constraint.split(",")

--- a/tests/masonry/builders/fixtures/with_wildcard_dependency_constraint/pyproject.toml
+++ b/tests/masonry/builders/fixtures/with_wildcard_dependency_constraint/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.poetry]
+name = "my-package"
+version = "1.2.3"
+description = "Some description."
+authors = [
+    "People Everywhere <people@everywhere.com>"
+]
+
+[tool.poetry.dependencies]
+python = "^3.10"
+google-api-python-client = ">=1.8,!=2.0.*"

--- a/tests/masonry/builders/test_builder.py
+++ b/tests/masonry/builders/test_builder.py
@@ -285,3 +285,15 @@ def test_metadata_with_readme_files() -> None:
     description = "\n".join([readme1.read_text(), readme2.read_text(), ""])
 
     assert metadata.get_payload() == description
+
+
+def test_metadata_with_wildcard_dependency_constraint() -> None:
+    test_path = (
+        Path(__file__).parent / "fixtures" / "with_wildcard_dependency_constraint"
+    )
+    builder = Builder(Factory().create_poetry(test_path))
+
+    metadata = Parser().parsestr(builder.get_metadata_content())
+
+    requires = metadata.get_all("Requires-Dist")
+    assert requires == ["google-api-python-client (>=1.8,!=2.0.*)"]


### PR DESCRIPTION
Prior to this change, when exporting PEP 508 strings for dependencies, wildcard exclusion constraints like `!=2.0.*` were incorrectly serialised as invalid PEP 508 due to how version unions were serialsed.

This change allows for determining if a version union is a single wildcard range exclusion, and if so serialise it appropriately.

Resolves: python-poetry/poetry#5470

PS: Not entirely sure if this is the best fix, but it does the trick for now. Not entirely happy with the determination logic, if anyone has a better approach please do share.

Additionally, during testing it was identified that the `X_CONSTRAINT` pattern mattaching when parsing constraints ignores any non semver versions (eg: calver). While the parser is in the "semver" package, since Poetry needs to support PEP440 based constraints, this should be improved. Will propose a fix in another PR.