### PR TITLE
version: fix normalize_version() according to PEP440

### DIFF
--- a/src/poetry/core/utils/helpers.py
+++ b/src/poetry/core/utils/helpers.py
@@ -33,7 +33,7 @@ def module_name(name: str) -> str:
 
 
 def normalize_version(version: str) -> str:
-    return PEP440Version.parse(version).to_string(short=True)
+    return PEP440Version.parse(version).normalize()
 
 
 @contextmanager

--- a/src/poetry/core/utils/helpers.py
+++ b/src/poetry/core/utils/helpers.py
@@ -33,7 +33,7 @@ def module_name(name: str) -> str:
 
 
 def normalize_version(version: str) -> str:
-    return PEP440Version.parse(version).normalize()
+    return PEP440Version.parse(version).to_string()
 
 
 @contextmanager

--- a/src/poetry/core/version/pep440/segments.py
+++ b/src/poetry/core/version/pep440/segments.py
@@ -7,32 +7,23 @@ from typing import Tuple
 from typing import Union
 
 
-RELEASE_PHASE_ALPHA = "alpha"
-RELEASE_PHASE_BETA = "beta"
-RELEASE_PHASE_RC = "rc"
-RELEASE_PHASE_PREVIEW = "preview"
-RELEASE_PHASE_POST = "post"
-RELEASE_PHASE_REV = "rev"
-RELEASE_PHASE_DEV = "dev"
-RELEASE_PHASES = {
-    RELEASE_PHASE_ALPHA: "a",
-    RELEASE_PHASE_BETA: "b",
-    RELEASE_PHASE_RC: "c",
-    RELEASE_PHASE_PREVIEW: "pre",
-    RELEASE_PHASE_POST: "-",  # shorthand of 1.2.3-post1 is 1.2.3-1
-    RELEASE_PHASE_REV: "r",
-    RELEASE_PHASE_DEV: "dev",
+# Release phase IDs according to PEP440
+RELEASE_PHASE_ID_ALPHA = "a"
+RELEASE_PHASE_ID_BETA = "b"
+RELEASE_PHASE_ID_RC = "rc"
+RELEASE_PHASE_ID_POST = "post"
+RELEASE_PHASE_ID_DEV = "dev"
+
+RELEASE_PHASE_SPELLINGS = {
+    RELEASE_PHASE_ID_ALPHA: {RELEASE_PHASE_ID_ALPHA, "alpha"},
+    RELEASE_PHASE_ID_BETA: {RELEASE_PHASE_ID_BETA, "beta"},
+    RELEASE_PHASE_ID_RC: {RELEASE_PHASE_ID_RC, "c", "pre", "preview"},
+    RELEASE_PHASE_ID_POST: {RELEASE_PHASE_ID_POST, "r", "rev", "-"},
+    RELEASE_PHASE_ID_DEV: {RELEASE_PHASE_ID_DEV},
 }
-RELEASE_PHASES_NORMALIZED = {
-    RELEASE_PHASE_ALPHA: "a",
-    RELEASE_PHASE_BETA: "b",
-    RELEASE_PHASE_RC: "rc",
-    RELEASE_PHASE_PREVIEW: "rc",
-    RELEASE_PHASE_POST: "post",
-    RELEASE_PHASE_REV: "post",
-    RELEASE_PHASE_DEV: "dev",
+RELEASE_PHASE_NORMALIZATIONS = {
+    s: id_ for id_, spellings in RELEASE_PHASE_SPELLINGS.items() for s in spellings
 }
-RELEASE_PHASES_SHORT = {v: k for k, v in RELEASE_PHASES.items() if k != "post"}
 
 
 @dataclasses.dataclass(frozen=True, eq=True, order=True)
@@ -118,41 +109,38 @@ class ReleaseTag:
     number: int = dataclasses.field(default=0)
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "phase", self.expand(self.phase))
-
-    def normalize(self) -> str:
-        normalized_phase = RELEASE_PHASES_NORMALIZED.get(self.phase, self.phase)
-        return f"{normalized_phase}{self.number}"
-
-    @classmethod
-    def shorten(cls, phase: str) -> str:
-        return RELEASE_PHASES.get(phase, phase)
-
-    @classmethod
-    def expand(cls, phase: str) -> str:
-        return RELEASE_PHASES_SHORT.get(phase, phase)
+        object.__setattr__(
+            self, "phase", RELEASE_PHASE_NORMALIZATIONS.get(self.phase, self.phase)
+        )
 
     def to_string(self, short: bool = False) -> str:
         if short:
-            return f"{self.shorten(self.phase)}{self.number}"
-        return f"{self.phase}.{self.number}"
+            import warnings
+
+            warnings.warn(
+                "Parameter 'short' has no effect and will be removed. "
+                "(Release tags are always normalized according to PEP 440 now.)",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        return f"{self.phase}{self.number}"
 
     def next(self) -> ReleaseTag:
         return dataclasses.replace(self, phase=self.phase, number=self.number + 1)
 
     def next_phase(self) -> ReleaseTag | None:
         if self.phase in [
-            RELEASE_PHASE_POST,
-            RELEASE_PHASE_RC,
-            RELEASE_PHASE_REV,
-            RELEASE_PHASE_DEV,
+            RELEASE_PHASE_ID_POST,
+            RELEASE_PHASE_ID_RC,
+            RELEASE_PHASE_ID_DEV,
         ]:
             return None
 
-        if self.phase == RELEASE_PHASE_ALPHA:
-            _phase = RELEASE_PHASE_BETA
-        elif self.phase == RELEASE_PHASE_BETA:
-            _phase = RELEASE_PHASE_RC
+        if self.phase == RELEASE_PHASE_ID_ALPHA:
+            _phase = RELEASE_PHASE_ID_BETA
+        elif self.phase == RELEASE_PHASE_ID_BETA:
+            _phase = RELEASE_PHASE_ID_RC
         else:
             return None
 

--- a/src/poetry/core/version/pep440/segments.py
+++ b/src/poetry/core/version/pep440/segments.py
@@ -23,6 +23,15 @@ RELEASE_PHASES = {
     RELEASE_PHASE_REV: "r",
     RELEASE_PHASE_DEV: "dev",
 }
+RELEASE_PHASES_NORMALIZED = {
+    RELEASE_PHASE_ALPHA: "a",
+    RELEASE_PHASE_BETA: "b",
+    RELEASE_PHASE_RC: "rc",
+    RELEASE_PHASE_PREVIEW: "rc",
+    RELEASE_PHASE_POST: "post",
+    RELEASE_PHASE_REV: "post",
+    RELEASE_PHASE_DEV: "dev",
+}
 RELEASE_PHASES_SHORT = {v: k for k, v in RELEASE_PHASES.items() if k != "post"}
 
 
@@ -110,6 +119,10 @@ class ReleaseTag:
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "phase", self.expand(self.phase))
+
+    def normalize(self) -> str:
+        normalized_phase = RELEASE_PHASES_NORMALIZED.get(self.phase, self.phase)
+        return f"{normalized_phase}{self.number}"
 
     @classmethod
     def shorten(cls, phase: str) -> str:

--- a/src/poetry/core/version/pep440/version.py
+++ b/src/poetry/core/version/pep440/version.py
@@ -142,6 +142,28 @@ class PEP440Version:
         assert isinstance(self.release.extra, tuple)
         return self.release.extra
 
+    def normalize(self) -> str:
+        version_string = self.release.to_string()
+
+        if self.epoch:
+            # if epoch is non-zero we should include it
+            version_string = f"{self.epoch}!{version_string}"
+
+        if self.pre:
+            version_string += self.pre.normalize()
+
+        if self.post:
+            version_string = f"{version_string}.{self.post.normalize()}"
+
+        if self.dev:
+            version_string = f"{version_string}.{self.dev.normalize()}"
+
+        if self.local:
+            assert isinstance(self.local, tuple)
+            version_string += "+" + ".".join(map(str, self.local))
+
+        return version_string.lower()
+
     def to_string(self, short: bool = False) -> str:
         dash = "-" if not short else ""
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -9,9 +9,80 @@ import pytest
 
 from poetry.core.utils.helpers import canonicalize_name
 from poetry.core.utils.helpers import combine_unicode
+from poetry.core.utils.helpers import normalize_version
 from poetry.core.utils.helpers import parse_requires
 from poetry.core.utils.helpers import readme_content_type
 from poetry.core.utils.helpers import temporary_directory
+
+
+@pytest.mark.parametrize(
+    "version,normalized_version",
+    [
+        (  # already normalized version
+            "1!2.3.4.5.6a7.post8.dev9+local1.123.abc",
+            "1!2.3.4.5.6a7.post8.dev9+local1.123.abc",
+        ),
+        # PEP 440 Normalization
+        # Case sensitivity
+        ("1.1RC1", "1.1rc1"),
+        # Integer Normalization
+        ("00", "0"),
+        ("09000", "9000"),
+        ("1.0+foo0100", "1.0+foo0100"),
+        # Pre-release separators
+        ("1.1.a1", "1.1a1"),
+        ("1.1-a1", "1.1a1"),
+        ("1.1_a1", "1.1a1"),
+        ("1.1a.1", "1.1a1"),
+        ("1.1a-1", "1.1a1"),
+        ("1.1a_1", "1.1a1"),
+        # Pre-release spelling
+        ("1.1alpha1", "1.1a1"),
+        ("1.1beta2", "1.1b2"),
+        ("1.1c3", "1.1rc3"),
+        ("1.1pre4", "1.1rc4"),
+        ("1.1preview5", "1.1rc5"),
+        # Implicit pre-release number
+        ("1.2a", "1.2a0"),
+        # Post release separators
+        ("1.2.post2", "1.2.post2"),
+        ("1.2-post2", "1.2.post2"),
+        ("1.2_post2", "1.2.post2"),
+        ("1.2post.2", "1.2.post2"),
+        ("1.2post-2", "1.2.post2"),
+        ("1.2post_2", "1.2.post2"),
+        # Post release spelling
+        ("1.0-r4", "1.0.post4"),
+        ("1.0-rev4", "1.0.post4"),
+        # Implicit post release number
+        ("1.2.post", "1.2.post0"),
+        # Implicit post releases
+        ("1.0-1", "1.0.post1"),
+        # Development release separators
+        ("1.2.dev2", "1.2.dev2"),
+        ("1.2-dev2", "1.2.dev2"),
+        ("1.2_dev2", "1.2.dev2"),
+        ("1.2dev.2", "1.2.dev2"),
+        ("1.2dev-2", "1.2.dev2"),
+        ("1.2dev_2", "1.2.dev2"),
+        # Implicit development release number
+        ("1.2.dev", "1.2.dev0"),
+        # Local version segments
+        ("1.0+ubuntu-1", "1.0+ubuntu.1"),
+        ("1.0+ubuntu_1", "1.0+ubuntu.1"),
+        # Preceding v character
+        ("v1.0", "1.0"),
+        # Leading and Trailing Whitespace
+        (" 1.0 ", "1.0"),
+        ("\t1.0\t", "1.0"),
+        ("\n1.0\n", "1.0"),
+        ("\r\n1.0\r\n", "1.0"),
+        ("\f1.0\f", "1.0"),
+        ("\v1.0\v", "1.0"),
+    ],
+)
+def test_normalize_version(version: str, normalized_version: str) -> None:
+    assert normalize_version(version) == normalized_version
 
 
 def test_parse_requires() -> None:

--- a/tests/version/test_version_pep440.py
+++ b/tests/version/test_version_pep440.py
@@ -6,8 +6,7 @@ from poetry.core.version.exceptions import InvalidVersion
 from poetry.core.version.pep440 import PEP440Version
 from poetry.core.version.pep440 import Release
 from poetry.core.version.pep440 import ReleaseTag
-from poetry.core.version.pep440.segments import RELEASE_PHASES
-from poetry.core.version.pep440.segments import RELEASE_PHASES_SHORT
+from poetry.core.version.pep440.segments import RELEASE_PHASE_NORMALIZATIONS
 
 
 @pytest.mark.parametrize(
@@ -67,12 +66,10 @@ def test_pep440_release_tag_next_phase(
     assert ReleaseTag(*parts).next_phase() == result
 
 
-@pytest.mark.parametrize(
-    "phase", list({*RELEASE_PHASES.keys(), *RELEASE_PHASES_SHORT.keys()})
-)
+@pytest.mark.parametrize("phase", list({*RELEASE_PHASE_NORMALIZATIONS.keys()}))
 def test_pep440_release_tag_next(phase: str) -> None:
     tag = ReleaseTag(phase=phase).next()
-    assert tag.phase == ReleaseTag.expand(phase)
+    assert tag.phase == RELEASE_PHASE_NORMALIZATIONS[phase]
     assert tag.number == 1
 
 


### PR DESCRIPTION
Resolves: python-poetry/poetry#5534

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

`normalize_version()` seems quite buggy supposing that it should do normalizations according to PEP 440. This PR fixes this method and adds tests derived from PEP 440 examples.

Since I wasn't sure if the `to_string(short=False)` method has some other usage (seems to be more semver than PEP440), I introduced a new property `norm_string`.