### PR TITLE
fix parsing PEP 508 url requirements with extras

### DIFF
--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -576,7 +576,7 @@ class Dependency(PackageSpecification):
                     name, "git", link.url_without_fragment, extras=req.extras
                 )
             elif link.scheme in ["http", "https"]:
-                dep = URLDependency(name, link.url)
+                dep = URLDependency(name, link.url, extras=req.extras)
             elif is_file_uri:
                 # handle RFC 8089 references
                 path = url_to_path(req.url)

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -347,3 +347,8 @@ def test_marker_properly_unsets_python_constraint() -> None:
 
     dependency.marker = "*"  # type: ignore[assignment]
     assert str(dependency.python_constraint) == "*"
+
+
+def test_create_from_pep_508_url_with_activated_extras() -> None:
+    dependency = Dependency.create_from_pep_508("name [fred,bar] @ http://foo.com")
+    assert dependency.extras == {"fred", "bar"}


### PR DESCRIPTION
Discovered this issue while implementing https://github.com/python-poetry/poetry/pull/5554.