### PR TITLE
Fix get_python_constraint_from_marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-core"
-version = "1.1.0-alpha.7"
+version = "1.1.0-alpha.8"
 description = "Poetry PEP 517 Build Backend"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 

--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -14,6 +14,7 @@ from poetry.core.packages.constraints import (
 )
 from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.core.packages.specification import PackageSpecification
+from poetry.core.packages.utils.utils import contains_group_without_marker
 from poetry.core.semver.helpers import parse_constraint
 from poetry.core.semver.version_range_constraint import VersionRangeConstraint
 from poetry.core.version.markers import parse_marker
@@ -180,7 +181,7 @@ class Dependency(PackageSpecification):
 
         # Recalculate python versions.
         self._python_versions = "*"
-        if "python_version" in markers:
+        if not contains_group_without_marker(markers, "python_version"):
             ors = []
             for or_ in markers["python_version"]:
                 ands = []

--- a/src/poetry/core/packages/utils/utils.py
+++ b/src/poetry/core/packages/utils/utils.py
@@ -322,10 +322,12 @@ def get_python_constraint_from_marker(
         for op, version in or_:
             # Expand python version
             if op == "==":
-                version = "~" + version
-                op = ""
+                if "*" not in version:
+                    version = "~" + version
+                    op = ""
             elif op == "!=":
-                version += ".*"
+                if "*" not in version:
+                    version += ".*"
             elif op in ("<=", ">"):
                 parsed_version = Version.parse(version)
                 if parsed_version.precision == 1:

--- a/src/poetry/core/packages/utils/utils.py
+++ b/src/poetry/core/packages/utils/utils.py
@@ -11,6 +11,8 @@ from urllib.parse import unquote
 from urllib.parse import urlsplit
 from urllib.request import url2pathname
 
+from poetry.core.version.markers import dnf
+
 
 if TYPE_CHECKING:
     from poetry.core.packages.constraints import BaseConstraint
@@ -162,7 +164,7 @@ def group_markers(
 
 
 def convert_markers(marker: BaseMarker) -> dict[str, list[list[tuple[str, str]]]]:
-    groups = group_markers([marker])
+    groups = group_markers([dnf(marker)])
 
     requirements = {}
 
@@ -197,6 +199,13 @@ def convert_markers(marker: BaseMarker) -> dict[str, list[list[tuple[str, str]]]
                 ors[group_name] = False
 
     _group(groups, or_=True)
+
+    for group_name in requirements:
+        # remove duplicates
+        seen = []
+        requirements[group_name] = [
+            r for r in requirements[group_name] if not (r in seen or seen.append(r))
+        ]
 
     return requirements
 

--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import itertools
 import re
 
 from typing import TYPE_CHECKING
@@ -841,3 +842,18 @@ def _compact_markers(tree_elements: Tree, tree_prefix: str = "") -> BaseMarker:
         return groups[0]
 
     return MarkerUnion.of(*groups)
+
+
+def dnf(marker: BaseMarker) -> BaseMarker:
+    """Transforms the marker into DNF (disjunctive normal form)."""
+    if isinstance(marker, MultiMarker):
+        dnf_markers = [dnf(m) for m in marker.markers]
+        sub_marker_lists = [
+            m.markers if isinstance(m, MarkerUnion) else [m] for m in dnf_markers
+        ]
+        return MarkerUnion.of(
+            *[MultiMarker.of(*c) for c in itertools.product(*sub_marker_lists)]
+        )
+    if isinstance(marker, MarkerUnion):
+        return MarkerUnion.of(*[dnf(m) for m in marker.markers])
+    return marker

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -324,12 +324,19 @@ def test_with_constraint() -> None:
     assert new.transitive_python_constraint == dependency.transitive_python_constraint
 
 
-def test_marker_properly_sets_python_constraint() -> None:
+@pytest.mark.parametrize(
+    "marker, expected",
+    [
+        ('python_version >= "3.6" and python_version < "4.0"', ">=3.6,<4.0"),
+        ('sys_platform == "linux"', "*"),
+        ('python_version >= "3.9" or sys_platform == "linux"', "*"),
+        ('python_version >= "3.9" and sys_platform == "linux"', ">=3.9"),
+    ],
+)
+def test_marker_properly_sets_python_constraint(marker: str, expected: str) -> None:
     dependency = Dependency("foo", "^1.2.3")
-
-    dependency.marker = 'python_version >= "3.6" and python_version < "4.0"'  # type: ignore[assignment]
-
-    assert str(dependency.python_constraint) == ">=3.6,<4.0"
+    dependency.marker = marker  # type: ignore[assignment]
+    assert str(dependency.python_constraint) == expected
 
 
 def test_dependency_markers_are_the_same_as_markers() -> None:

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -38,6 +38,19 @@ from poetry.core.version.markers import parse_marker
             'python_version == "2.7" or python_version == "2.6"',
             {"python_version": [[("==", "2.7")], [("==", "2.6")]]},
         ),
+        (
+            '(python_version < "2.7" or python_full_version >= "3.0.0") and'
+            ' python_full_version < "3.6.0"',
+            {"python_version": [[("<", "2.7")], [(">=", "3.0.0"), ("<", "3.6.0")]]},
+        ),
+        (
+            '(python_version < "2.7" or python_full_version >= "3.0.0") and'
+            ' extra == "foo"',
+            {
+                "extra": [[("==", "foo")]],
+                "python_version": [[("<", "2.7")], [(">=", "3.0.0")]],
+            },
+        ),
     ],
 )
 def test_convert_markers(
@@ -55,6 +68,11 @@ def test_convert_markers(
         (
             'python_full_version >= "3.6.1" and python_full_version < "4.0.0"',
             ">=3.6.1, <4.0.0",
+        ),
+        (
+            '(python_version < "2.7" or python_full_version >= "3.0.0") and'
+            ' python_full_version < "3.6.0"',
+            "<2.7 || >=3.0,<3.6",
         ),
         ('sys_platform == "linux"', "*"),
     ],

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -8,30 +8,35 @@ from poetry.core.semver.helpers import parse_constraint
 from poetry.core.version.markers import parse_marker
 
 
-def test_convert_markers() -> None:
-    marker = parse_marker(
-        'sys_platform == "win32" and python_version < "3.6" or sys_platform == "linux"'
-        ' and python_version < "3.6" and python_version >= "3.3" or sys_platform =='
-        ' "darwin" and python_version < "3.3"'
-    )
-    converted = convert_markers(marker)
-    assert converted["python_version"] == [
-        [("<", "3.6")],
-        [("<", "3.6"), (">=", "3.3")],
-        [("<", "3.3")],
-    ]
-
-    marker = parse_marker(
-        'sys_platform == "win32" and python_version < "3.6" or sys_platform == "win32"'
-        ' and python_version < "3.6" and python_version >= "3.3" or sys_platform =='
-        ' "win32" and python_version < "3.3"'
-    )
-    converted = convert_markers(marker)
-    assert converted["python_version"] == [[("<", "3.6")]]
-
-    marker = parse_marker('python_version == "2.7" or python_version == "2.6"')
-    converted = convert_markers(marker)
-    assert converted["python_version"] == [[("==", "2.7")], [("==", "2.6")]]
+@pytest.mark.parametrize(
+    "marker, expected",
+    [
+        (
+            'sys_platform == "win32" and python_version < "3.6" or sys_platform =='
+            ' "linux" and python_version < "3.6" and python_version >= "3.3" or'
+            ' sys_platform == "darwin" and python_version < "3.3"',
+            [
+                [("<", "3.6")],
+                [("<", "3.6"), (">=", "3.3")],
+                [("<", "3.3")],
+            ],
+        ),
+        (
+            'sys_platform == "win32" and python_version < "3.6" or sys_platform =='
+            ' "win32" and python_version < "3.6" and python_version >= "3.3" or'
+            ' sys_platform == "win32" and python_version < "3.3"',
+            [[("<", "3.6")]],
+        ),
+        (
+            'python_version == "2.7" or python_version == "2.6"',
+            [[("==", "2.7")], [("==", "2.6")]],
+        ),
+    ],
+)
+def test_convert_markers(marker: str, expected: list[list[tuple[str, str]]]) -> None:
+    parsed_marker = parse_marker(marker)
+    converted = convert_markers(parsed_marker)
+    assert converted["python_version"] == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -64,20 +64,53 @@ def test_convert_markers(
 @pytest.mark.parametrize(
     ["marker", "constraint"],
     [
+        # ==
+        ('python_version == "3.6"', "~3.6"),
+        ('python_version == "3.6.*"', "==3.6.*"),
+        ('python_version == "3.6.* "', "==3.6.*"),
+        # !=
+        ('python_version != "3.6"', "!=3.6.*"),
+        ('python_version != "3.6.*"', "!=3.6.*"),
+        ('python_version != "3.6.* "', "!=3.6.*"),
+        # <, <=, >, >= precision 1
+        ('python_version < "3"', "<3"),
+        ('python_version <= "3"', "<4"),
+        ('python_version > "3"', ">=4"),
+        ('python_version >= "3"', ">=3"),
+        # <, <=, >, >= precision 2
+        ('python_version < "3.6"', "<3.6"),
+        ('python_version <= "3.6"', "<3.7"),
+        ('python_version > "3.6"', ">=3.7"),
+        ('python_version >= "3.6"', ">=3.6"),
+        # in, not in
+        ('python_version in "2.7, 3.6"', ">=2.7.0,<2.8.0 || >=3.6.0,<3.7.0"),
+        ('python_version in "2.7, 3.6.2"', ">=2.7.0,<2.8.0 || 3.6.2"),
+        ('python_version not in "2.7, 3.6"', "<2.7.0 || >=2.8.0,<3.6.0 || >=3.7.0"),
+        ('python_version not in "2.7, 3.6.2"', "<2.7.0 || >=2.8.0,<3.6.2 || >3.6.2"),
+        # and
         ('python_version >= "3.6" and python_full_version < "4.0"', ">=3.6, <4.0"),
         (
             'python_full_version >= "3.6.1" and python_full_version < "4.0.0"',
             ">=3.6.1, <4.0.0",
+        ),
+        # or
+        ('python_version < "3.6" or python_version >= "3.9"', "<3.6 || >=3.9"),
+        # and or
+        (
+            'python_version >= "3.7" and python_version < "3.8" or python_version >='
+            ' "3.9" and python_version < "3.10"',
+            ">=3.7,<3.8 || >=3.9,<3.10",
         ),
         (
             '(python_version < "2.7" or python_full_version >= "3.0.0") and'
             ' python_full_version < "3.6.0"',
             "<2.7 || >=3.0,<3.6",
         ),
+        # no python_version
         ('sys_platform == "linux"', "*"),
     ],
 )
 def test_get_python_constraint_from_marker(marker: str, constraint: str) -> None:
     marker_parsed = parse_marker(marker)
     constraint_parsed = parse_constraint(constraint)
-    assert constraint_parsed == get_python_constraint_from_marker(marker_parsed)
+    assert get_python_constraint_from_marker(marker_parsed) == constraint_parsed

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -15,28 +15,37 @@ from poetry.core.version.markers import parse_marker
             'sys_platform == "win32" and python_version < "3.6" or sys_platform =='
             ' "linux" and python_version < "3.6" and python_version >= "3.3" or'
             ' sys_platform == "darwin" and python_version < "3.3"',
-            [
-                [("<", "3.6")],
-                [("<", "3.6"), (">=", "3.3")],
-                [("<", "3.3")],
-            ],
+            {
+                "python_version": [
+                    [("<", "3.6")],
+                    [("<", "3.6"), (">=", "3.3")],
+                    [("<", "3.3")],
+                ],
+                "sys_platform": [
+                    [("==", "win32")],
+                    [("==", "linux")],
+                    [("==", "darwin")],
+                ],
+            },
         ),
         (
             'sys_platform == "win32" and python_version < "3.6" or sys_platform =='
             ' "win32" and python_version < "3.6" and python_version >= "3.3" or'
             ' sys_platform == "win32" and python_version < "3.3"',
-            [[("<", "3.6")]],
+            {"python_version": [[("<", "3.6")]], "sys_platform": [[("==", "win32")]]},
         ),
         (
             'python_version == "2.7" or python_version == "2.6"',
-            [[("==", "2.7")], [("==", "2.6")]],
+            {"python_version": [[("==", "2.7")], [("==", "2.6")]]},
         ),
     ],
 )
-def test_convert_markers(marker: str, expected: list[list[tuple[str, str]]]) -> None:
+def test_convert_markers(
+    marker: str, expected: dict[str, list[list[tuple[str, str]]]]
+) -> None:
     parsed_marker = parse_marker(marker)
     converted = convert_markers(parsed_marker)
-    assert converted["python_version"] == expected
+    assert converted == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -51,6 +51,20 @@ from poetry.core.version.markers import parse_marker
                 "python_version": [[("<", "2.7")], [(">=", "3.0.0")]],
             },
         ),
+        (
+            'python_version >= "3.9" or sys_platform == "linux"',
+            {
+                "python_version": [[(">=", "3.9")], []],
+                "sys_platform": [[], [("==", "linux")]],
+            },
+        ),
+        (
+            'python_version >= "3.9" and sys_platform == "linux"',
+            {
+                "python_version": [[(">=", "3.9")]],
+                "sys_platform": [[("==", "linux")]],
+            },
+        ),
     ],
 )
 def test_convert_markers(
@@ -108,6 +122,10 @@ def test_convert_markers(
         ),
         # no python_version
         ('sys_platform == "linux"', "*"),
+        # no relevant python_version
+        ('python_version >= "3.9" or sys_platform == "linux"', "*"),
+        # relevant python_version
+        ('python_version >= "3.9" and sys_platform == "linux"', ">=3.9"),
     ],
 )
 def test_get_python_constraint_from_marker(marker: str, constraint: str) -> None:


### PR DESCRIPTION
<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Fixes `get_python_constraint_from_marker()` for markers which are not in disjunctive normal form (DNF).

E.g. without the fix:

`(python_version < "2.7" or python_full_version >= "3.0.0") and python_full_version < "3.6.0"` results in python_constraint `*`
whereas `<2.7 || >=3.0,<3.6` would be correct.

By the way, increased the test coverage for `convert_markers()` and `get_python_constraint_from_marker()`.

Considering the commits separately may facilitate the review.

**Update:**

There was another bug in `get_python_constraint_from_marker()` that is fixed by the last commit.
E.g. for `python_version >= "3.9" or sys_platform == "linux"` the function returned `>=3.9` whereas `*` would be correct (because for `linux` all python versions are allowed).

Further, relying on the marker being in DNF before conversion, allows to simplify `convert_markers()` significantly.