### PR TITLE
markers: fix union of multi markers if one marker is a subset of the other marker

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -513,7 +513,11 @@ class MultiMarker(BaseMarker):
             other_markers = set(other.markers)
             common_markers = markers & other_markers
             unique_markers = markers - common_markers
+            if not unique_markers:
+                return self
             other_unique_markers = other_markers - common_markers
+            if not other_unique_markers:
+                return other
             if common_markers:
                 unique_union = self.of(*unique_markers).union(
                     self.of(*other_unique_markers)

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -445,13 +445,30 @@ def test_multi_marker_union_multi_is_single_marker() -> None:
     assert str(m2.union(m)) == 'python_version >= "3"'
 
 
-def test_multi_marker_union_multi_is_multi() -> None:
-    m = parse_marker('python_version >= "3" and sys_platform == "win32"')
-    m2 = parse_marker(
-        'python_version >= "3" and sys_platform != "win32" and sys_platform != "linux"'
-    )
-    assert str(m.union(m2)) == 'python_version >= "3" and sys_platform != "linux"'
-    assert str(m2.union(m)) == 'python_version >= "3" and sys_platform != "linux"'
+@pytest.mark.parametrize(
+    "marker1, marker2, expected",
+    [
+        (
+            'python_version >= "3" and sys_platform == "win32"',
+            'python_version >= "3" and sys_platform != "win32" and sys_platform !='
+            ' "linux"',
+            'python_version >= "3" and sys_platform != "linux"',
+        ),
+        (
+            'python_version >= "3.8" and python_version < "4.0" and sys_platform =='
+            ' "win32"',
+            'python_version >= "3.8" and python_version < "4.0"',
+            'python_version >= "3.8" and python_version < "4.0"',
+        ),
+    ],
+)
+def test_multi_marker_union_multi_is_multi(
+    marker1: str, marker2: str, expected: str
+) -> None:
+    m1 = parse_marker(marker1)
+    m2 = parse_marker(marker2)
+    assert str(m1.union(m2)) == expected
+    assert str(m2.union(m1)) == expected
 
 
 def test_multi_marker_union_with_union() -> None:


### PR DESCRIPTION
Resolves: python-poetry/poetry#5593

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
