### PR TITLE
typechecking semver.version_union

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,6 @@ module = [
   'poetry.core.packages.utils.utils',
   'poetry.core.packages.dependency',
   'poetry.core.packages.package',
-  'poetry.core.semver.version_union',
 ]
 ignore_errors = true
 


### PR DESCRIPTION
I believe that if we can get the MRs merged, this will complete the typechecking campaign in poetry-core 🎉 .

Specifically:
- #274
- #339
- #340
- this

(though it does look as though #339 may have some non-trivial conflicts at the moment).

It would be a stretch to call this a blocker for the next release; but it would be awfully nice to get this mini-project completed.