### PR TITLE
Mypy/packages rebased

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,21 +89,6 @@ module = [
 ]
 ignore_missing_imports = true
 
-# The following whitelist is used to allow for incremental adoption
-# of Mypy. Modules should be removed from this whitelist as and when
-# their respective type errors have been addressed. No new modules
-# should be added to this whitelist.
-# see https://github.com/python-poetry/poetry-core/pull/199.
-
-[[tool.mypy.overrides]]
-module = [
-  # src modules
-  'poetry.core.packages.utils.utils',
-  'poetry.core.packages.dependency',
-  'poetry.core.packages.package',
-]
-ignore_errors = true
-
 [tool.vendoring]
 destination = "src/poetry/core/_vendor/"
 requirements = "src/poetry/core/_vendor/vendor.txt"

--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Iterable
-from typing import cast
 
 from poetry.core.packages.constraints import (
     parse_constraint as parse_generic_constraint,
@@ -408,7 +407,7 @@ class Dependency(PackageSpecification):
                 if not constraint.include_min:
                     op = ">"
 
-                version: Version | str = constraint.min.text
+                version = constraint.min.text
                 if constraint.max is not None:
                     max_name = name
                     if constraint.max.precision >= 3 and name == "python_version":
@@ -420,7 +419,7 @@ class Dependency(PackageSpecification):
                     if not constraint.include_max:
                         op = "<"
 
-                    version = constraint.max
+                    version = constraint.max.text
 
                     text += f' and {max_name} {op} "{version}"'
 
@@ -433,7 +432,7 @@ class Dependency(PackageSpecification):
                 if not constraint.include_max:
                     op = "<"
 
-                version = constraint.max
+                version = constraint.max.text
             else:
                 return ""
 
@@ -534,7 +533,6 @@ class Dependency(PackageSpecification):
                 link = Link(path_to_url(p))
 
         # it's a local file, dir, or url
-        dep: Dependency | None
         if link:
             is_file_uri = link.scheme == "file"
             is_relative_uri = is_file_uri and re.search(r"\.\./", link.url)
@@ -555,8 +553,7 @@ class Dependency(PackageSpecification):
                 name = m.group("name")
                 version = m.group("ver")
 
-            name = cast(str, req.name or link.egg_fragment)
-            dep = None
+            dep: Dependency | None = None
 
             if link.scheme.startswith("git+"):
                 url = ParsedUrl.parse(link.url)

--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Iterable
+from typing import cast
 
 from poetry.core.packages.constraints import (
     parse_constraint as parse_generic_constraint,
@@ -56,8 +57,8 @@ class Dependency(PackageSpecification):
             features=extras,
         )
 
-        self._constraint: str | VersionConstraint | None = None
-        self._pretty_constraint: str | None = None
+        self._constraint: VersionConstraint
+        self._pretty_constraint: str
         self.set_constraint(constraint=constraint)
 
         self._optional = optional
@@ -79,17 +80,17 @@ class Dependency(PackageSpecification):
 
         self._python_versions = "*"
         self._python_constraint = parse_constraint("*")
-        self._transitive_python_versions = None
+        self._transitive_python_versions: str | None = None
         self._transitive_python_constraint: VersionConstraint | None = None
-        self._transitive_marker = None
+        self._transitive_marker: BaseMarker | None = None
         self._extras = frozenset(extras or [])
 
-        self._in_extras = []
+        self._in_extras: list[str] = []
 
         self._activated = not self._optional
 
         self.is_root = False
-        self._marker = AnyMarker()
+        self._marker: BaseMarker = AnyMarker()
         self.source_name = None
 
     @property
@@ -270,9 +271,9 @@ class Dependency(PackageSpecification):
                 # no functional difference with the logic in the else branch.
                 requirement += f" ({str(constraint)})"
             else:
-                constraints = self.pretty_constraint.split(",")
-                constraints = [parse_constraint(c) for c in constraints]
-                constraints = ",".join(str(c) for c in constraints)
+                constraints = ",".join(
+                    str(parse_constraint(c)) for c in self.pretty_constraint.split(",")
+                )
                 requirement += f" ({constraints})"
         elif isinstance(constraint, Version):
             requirement += f" (=={constraint.text})"
@@ -350,8 +351,8 @@ class Dependency(PackageSpecification):
                 requirement += " "
 
             if len(markers) > 1:
-                markers = " and ".join(f"({m})" for m in markers)
-                requirement += f"; {markers}"
+                marker_str = " and ".join(f"({m})" for m in markers)
+                requirement += f"; {marker_str}"
             else:
                 requirement += f"; {markers[0]}"
 
@@ -367,29 +368,23 @@ class Dependency(PackageSpecification):
         from poetry.core.semver.version_union import VersionUnion
 
         if isinstance(constraint, (MultiConstraint, UnionConstraint)):
-            parts = []
+            multi_parts = []
             for c in constraint.constraints:
-                multi = False
-                if isinstance(c, (MultiConstraint, UnionConstraint)):
-                    multi = True
-
-                parts.append((multi, self._create_nested_marker(name, c)))
+                multi = isinstance(c, (MultiConstraint, UnionConstraint))
+                multi_parts.append((multi, self._create_nested_marker(name, c)))
 
             glue = " and "
             if isinstance(constraint, UnionConstraint):
-                parts = [f"({part[1]})" if part[0] else part[1] for part in parts]
+                parts = [f"({part[1]})" if part[0] else part[1] for part in multi_parts]
                 glue = " or "
             else:
-                parts = [part[1] for part in parts]
+                parts = [part[1] for part in multi_parts]
 
             marker = glue.join(parts)
         elif isinstance(constraint, Constraint):
             marker = f'{name} {constraint.operator} "{constraint.version}"'
         elif isinstance(constraint, VersionUnion):
-            parts = []
-            for c in constraint.ranges:
-                parts.append(self._create_nested_marker(name, c))
-
+            parts = [self._create_nested_marker(name, c) for c in constraint.ranges]
             glue = " or "
             parts = [f"({part})" for part in parts]
 
@@ -413,7 +408,7 @@ class Dependency(PackageSpecification):
                 if not constraint.include_min:
                     op = ">"
 
-                version = constraint.min.text
+                version: Version | str = constraint.min.text
                 if constraint.max is not None:
                     max_name = name
                     if constraint.max.precision >= 3 and name == "python_version":
@@ -518,7 +513,6 @@ class Dependency(PackageSpecification):
         req = Requirement(name)
 
         name = req.name
-        path = os.path.normpath(os.path.abspath(name))
         link = None
 
         if is_url(name):
@@ -526,7 +520,8 @@ class Dependency(PackageSpecification):
         elif req.url:
             link = Link(req.url)
         else:
-            p, extras = strip_extras(path)
+            path_str = os.path.normpath(os.path.abspath(name))
+            p, extras = strip_extras(path_str)
             if os.path.isdir(p) and (os.path.sep in name or name.startswith(".")):
 
                 if not is_installable_dir(p):
@@ -539,6 +534,7 @@ class Dependency(PackageSpecification):
                 link = Link(path_to_url(p))
 
         # it's a local file, dir, or url
+        dep: Dependency | None
         if link:
             is_file_uri = link.scheme == "file"
             is_relative_uri = is_file_uri and re.search(r"\.\./", link.url)
@@ -559,7 +555,7 @@ class Dependency(PackageSpecification):
                 name = m.group("name")
                 version = m.group("ver")
 
-            name = req.name or link.egg_fragment
+            name = cast(str, req.name or link.egg_fragment)
             dep = None
 
             if link.scheme.startswith("git+"):
@@ -600,11 +596,11 @@ class Dependency(PackageSpecification):
             if version:
                 dep._constraint = parse_constraint(version)
         else:
+            constraint: VersionConstraint | str
             if req.pretty_constraint:
                 constraint = req.constraint
             else:
                 constraint = "*"
-
             dep = Dependency(name, constraint, extras=req.extras)
 
         if req.marker:

--- a/src/poetry/core/packages/directory_dependency.py
+++ b/src/poetry/core/packages/directory_dependency.py
@@ -101,9 +101,7 @@ class DirectoryDependency(Dependency):
             extras=list(self._extras),
         )
 
-        new._constraint = constraint
-        new._pretty_constraint = str(constraint)
-
+        new.set_constraint(constraint)
         new.is_root = self.is_root
         new.python_versions = self.python_versions
         new.marker = self.marker

--- a/src/poetry/core/packages/file_dependency.py
+++ b/src/poetry/core/packages/file_dependency.py
@@ -85,9 +85,7 @@ class FileDependency(Dependency):
             extras=list(self._extras),
         )
 
-        new._constraint = constraint
-        new._pretty_constraint = str(constraint)
-
+        new.set_constraint(constraint)
         new.is_root = self.is_root
         new.python_versions = self.python_versions
         new.marker = self.marker

--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -95,7 +95,7 @@ class Package(PackageSpecification):
         self._license: License | None = None
         self.readmes: tuple[Path, ...] = ()
 
-        self.extras: dict[str, list[str | Dependency]] = {}
+        self.extras: dict[str, list[Dependency]] = {}
         self.requires_extras: list[str] = []
 
         self._dependency_groups: dict[str, DependencyGroup] = {}

--- a/src/poetry/core/packages/url_dependency.py
+++ b/src/poetry/core/packages/url_dependency.py
@@ -65,9 +65,7 @@ class URLDependency(Dependency):
             extras=list(self._extras),
         )
 
-        new._constraint = constraint
-        new._pretty_constraint = str(constraint)
-
+        new.set_constraint(constraint)
         new.is_root = self.is_root
         new.python_versions = self.python_versions
         new.marker = self.marker

--- a/src/poetry/core/packages/vcs_dependency.py
+++ b/src/poetry/core/packages/vcs_dependency.py
@@ -148,9 +148,7 @@ class VCSDependency(Dependency):
             extras=list(self._extras),
         )
 
-        new._constraint = constraint
-        new._pretty_constraint = str(constraint)
-
+        new.set_constraint(constraint)
         new.is_root = self.is_root
         new.python_versions = self.python_versions
         new.marker = self.marker

--- a/src/poetry/core/version/requirements.py
+++ b/src/poetry/core/version/requirements.py
@@ -40,7 +40,7 @@ class Requirement:
                 f" {e.column}\n\n{e.get_context(requirement_string)}"
             )
 
-        self.name = next(parsed.scan_values(lambda t: t.type == "NAME")).value
+        self.name: str = next(parsed.scan_values(lambda t: t.type == "NAME")).value
         url = next(parsed.scan_values(lambda t: t.type == "URI"), None)
 
         if url:


### PR DESCRIPTION
I got excited about completing the typechecking in poetry-core, and took the liberty of rebasing #339.  This MR now removes the allow-mypy-errors list!  

I also made a handful of tweaks per my review of that MR.  I have tried to keep @branchvincent's work and my own separate, though I did have to decide what to do about conflicts in the rebase.

The change relating to https://github.com/python-poetry/poetry-core/pull/339#discussion_r873153018 might be worth some thought.  Per that comment, the original code looks confused so I have tidied it up in a way that looks sensible and doesn't break any tests.  But if anyone has a clearer idea than I do about what was intended, I could believe that a different tidying might be better.