### PR TITLE
Bump `flake8` additional dependencies

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,11 +1,21 @@
 [flake8]
 min_python_version = 3.7.0
 max-line-length = 88
-ignore = E501, E203, W503, ANN101, ANN102, SIM106
 ban-relative-imports = True
 enable-extensions = TC, TC1
 type-checking-exempt-modules = typing, typing-extensions
 format-greedy = 1
+extend-ignore =
+    # E203: Whitespace before ':' (pycqa/pycodestyle#373)
+    E203,
+    # E501: Line too long
+    E501,
+    # SIM106: Handle error-cases first
+    SIM106,
+    # ANN101: Missing type annotation for self in method
+    ANN101,
+    # ANN102: Missing type annotation for cls in classmethod
+    ANN102,
 per-file-ignores =
     __init__.py:F401
     tests/test_*:ANN201

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,13 +38,13 @@ repos:
     hooks:
       - id: yesqa
         additional_dependencies: &flake8_deps
-          - flake8-annotations==2.7.0
-          - flake8-bugbear==22.1.11
-          - flake8-comprehensions==3.8.0
-          - flake8-eradicate==1.2.0
-          - flake8-simplify==0.15.1
-          - flake8-tidy-imports==4.6.0
-          - flake8-type-checking==1.3.3
+          - flake8-annotations==2.9.0
+          - flake8-bugbear==22.4.25
+          - flake8-comprehensions==3.10.0
+          - flake8-eradicate==1.2.1
+          - flake8-simplify==0.19.2
+          - flake8-tidy-imports==4.8.0
+          - flake8-type-checking==1.5.0
           - flake8-use-fstring==1.3
 
   - repo: https://github.com/asottile/pyupgrade

--- a/tests/packages/test_file_dependency.py
+++ b/tests/packages/test_file_dependency.py
@@ -40,7 +40,7 @@ def test_default_hash() -> None:
 try:
     from hashlib import algorithms_guaranteed as ALGORITHMS_GUARANTEED
 except ImportError:
-    ALGORITHMS_GUARANTEED = set("md5,sha1,sha224,sha256,sha384,sha512".split(","))
+    ALGORITHMS_GUARANTEED = {"md5", "sha1", "sha224", "sha256", "sha384", "sha512"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [ ] ~Added **tests** for changed code.~ Not applicable
- [ ] ~Updated **documentation** for changed code.~ Not applicable

Update all `flake8` additional dependencies.

This PR also updates flake8 configuration to use `extend-ignore` instead of `ignore`, to avoid overriding the default `ignore` list that could be set by some plugins (see [flake8 documentation](https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-extend-ignore) for more information).
`poetry` [already uses](https://github.com/python-poetry/poetry/blob/48171301ef032fec1e3ec1ae5d40f71e45c680ea/.flake8#L11-L19) `extend-ignore`,  so this will also make the 2 projects more aligned.

Changelogs:
- [flake8-annotations](https://github.com/sco1/flake8-annotations/blob/ea1e59eb02b0ddc1eb854aea23ea9e74a84deed3/CHANGELOG.md)
- [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear/blob/0d54ee6d14367e444664fa38b8522776aaaee5df/README.rst#change-log)
- [flake8-comprehensions](https://github.com/adamchainz/flake8-comprehensions/blob/05067c706835799ec2fdce403efc2ce115bd8466/HISTORY.rst)
- [flake8-eradicate](https://github.com/wemake-services/flake8-eradicate/blob/275c8963543fbc805fd6d59bbc0d51aecdf65dfc/CHANGELOG.md)
- [flake8-simplify](https://github.com/MartinThoma/flake8-simplify/blob/f1b6c6d003503f71834345f443a13b9ff06d96cd/CHANGELOG.md)
- [flake8-tidy-imports](https://github.com/adamchainz/flake8-tidy-imports/blob/67a1ef5ddddce27fb802fac652632b6466a489ff/HISTORY.rst)
- [flake8-type-checking](https://github.com/snok/flake8-type-checking/releases)