### PR TITLE
Some GitHub actions improvements

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -15,6 +15,9 @@ jobs:
         os: [Ubuntu]
         python-version: [3.9]
         experimental: [false]
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v3
         with:
@@ -32,15 +35,12 @@ jobs:
 
       - name: Get full python version
         id: full-python-version
-        shell: bash
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
 
       - name: Install poetry
-        shell: bash
         run: pip install poetry
 
       - name: Configure poetry
-        shell: bash
         run: poetry config virtualenvs.in-project true
 
       - name: Set up cache
@@ -52,24 +52,20 @@ jobs:
 
       - name: Ensure cache is healthy
         if: steps.cache.outputs.cache-hit == 'true'
-        shell: bash
         working-directory: ./poetry
         run: timeout 10s poetry run pip --version >/dev/null 2>&1 || rm -rf .venv
 
       - name: Update poetry-core version
-        shell: bash
         working-directory: ./poetry
         run: |
           poetry add ../poetry-core
           git diff
 
       - name: Install poetry (downstream)
-        shell: bash
         working-directory: ./poetry
         run: poetry install
 
       # TODO: mark run as success even when this fails and add comment to PR instead
       - name: Run poetry test suite
-        shell: bash
         working-directory: ./poetry
         run: poetry run pytest

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -16,17 +16,17 @@ jobs:
         python-version: [3.9]
         experimental: [false]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: poetry-core
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: python-poetry/poetry
           path: poetry
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -44,7 +44,7 @@ jobs:
         run: poetry config virtualenvs.in-project true
 
       - name: Set up cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: ./poetry/.venv

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,6 +10,9 @@ jobs:
       matrix:
         os: [Ubuntu, MacOS, Windows]
         python-version: [3.7, 3.8, 3.9, "3.10"]
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v3
 
@@ -19,9 +22,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install tox
-        shell: bash
         run: pip install --upgrade tox
 
       - name: Execute integration tests
-        shell: bash
         run: tox -e integration

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,10 +11,10 @@ jobs:
         os: [Ubuntu, MacOS, Windows]
         python-version: [3.7, 3.8, 3.9, "3.10"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,7 @@ jobs:
 
       - name: Install Poetry
         run: |
-          curl -sL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py \
-            | python - -y
+          curl -sSL https://install.python-poetry.org | python - -y
 
       - name: Update PATH
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get tag
         id: tag
         run: echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: "3.9"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,9 @@ jobs:
             experimental: true
             bootstrap-args: "--git https://github.com/python-poetry/poetry.git"
       fail-fast: false
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v3
 
@@ -35,27 +38,22 @@ jobs:
 
       - name: Get full Python version
         id: full-python-version
-        shell: bash
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
 
       - name: Bootstrap poetry
-        shell: bash
         run: |
           curl -sL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py \
             | python - -y ${{ matrix.bootstrap-args }}
 
       - name: Update PATH
         if: ${{ matrix.os != 'Windows' }}
-        shell: bash
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Update Path for Windows
         if: ${{ matrix.os == 'Windows' }}
-        shell: bash
         run: echo "$APPDATA\Python\Scripts" >> $GITHUB_PATH
 
       - name: Configure poetry
-        shell: bash
         run: poetry config virtualenvs.in-project true
 
       - name: Set up cache
@@ -67,17 +65,13 @@ jobs:
 
       - name: Ensure cache is healthy
         if: steps.cache.outputs.cache-hit == 'true'
-        shell: bash
         run: timeout 10s poetry run pip --version || rm -rf .venv
 
       - name: Install dependencies
-        shell: bash
         run: poetry install
 
       - name: Run pytest
-        shell: bash
         run: poetry run python -m pytest -p no:sugar -q tests/
 
       - name: Run mypy
-        shell: bash
         run: poetry run mypy

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,10 +26,10 @@ jobs:
             bootstrap-args: "--git https://github.com/python-poetry/poetry.git"
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -59,7 +59,7 @@ jobs:
         run: poetry config virtualenvs.in-project true
 
       - name: Set up cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: .venv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,8 +42,7 @@ jobs:
 
       - name: Bootstrap poetry
         run: |
-          curl -sL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py \
-            | python - -y ${{ matrix.bootstrap-args }}
+          curl -sSL https://install.python-poetry.org | python - -y ${{ matrix.bootstrap-args }}
 
       - name: Update PATH
         if: ${{ matrix.os != 'Windows' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         bootstrap-args: [""]
         include:
           - os: Ubuntu
-            python-version: pypy3
+            python-version: pypy-3.7
             experimental: false
           - os: Ubuntu
             python-version: "3.10"


### PR DESCRIPTION
- [ ] ~Added **tests** for changed code.~ Not applicable
- [ ] ~Updated **documentation** for changed code.~ Not applicable

Bunch of improvements on GitHub Actions workflows to:
- bump all `actions/*` actions versions
- define the default shell to use, to avoid duplication
- bootstrap Poetry through `install.python-poetry.org` rather than the deprecated `install-poetry.py` script

Also needed to update the name for PyPy from `pypy3` to `pypy-3.7`, since https://github.com/actions/setup-python/releases/tag/v3.0.0 deprecated the usage of `pypy3` keyword for the more explicit `pypy-3.x`  pattern.
`pypy3` used to correspond to `pypy-3.6` and not `pypy-3.7`, but since Poetry dropped support for Python 3.6, I thought it may be better to test against PyPy 3.7.

_Note: Since `pypy3` is a required status check, the CI waits for this job to be run (which will not happen), but you can see the job passing [here](https://github.com/python-poetry/poetry-core/runs/6543803748?check_suite_focus=true)._