### PR TITLE
bump poetry.core.__version__ with test coverage

### DIFF
--- a/src/poetry/core/__init__.py
+++ b/src/poetry/core/__init__.py
@@ -5,7 +5,9 @@ import sys
 from pathlib import Path
 
 
-__version__ = "1.1.0a7"
+# this cannot presently be replaced with importlib.metadata.version as when building
+# itself, poetry-core is not available as an installed distribution.
+__version__ = "1.1.0b1"
 
 __vendor_site__ = (Path(__file__).parent / "_vendor").as_posix()
 

--- a/src/poetry/core/masonry/builders/wheel.py
+++ b/src/poetry/core/masonry/builders/wheel.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 
 wheel_file_template = """\
 Wheel-Version: 1.0
-Generator: poetry {version}
+Generator: poetry-core {version}
 Root-Is-Purelib: {pure_lib}
 Tag: {tag}
 """

--- a/tests/masonry/builders/test_complete.py
+++ b/tests/masonry/builders/test_complete.py
@@ -82,7 +82,7 @@ def test_wheel_c_extension() -> None:
             re.match(
                 f"""(?m)^\
 Wheel-Version: 1.0
-Generator: poetry {__version__}
+Generator: poetry-core {__version__}
 Root-Is-Purelib: false
 Tag: cp[23]_?\\d+-cp[23]_?\\d+m?u?-.+
 $""",
@@ -137,7 +137,7 @@ def test_wheel_c_extension_with_no_setup() -> None:
             re.match(
                 f"""(?m)^\
 Wheel-Version: 1.0
-Generator: poetry {__version__}
+Generator: poetry-core {__version__}
 Root-Is-Purelib: false
 Tag: cp[23]_?\\d+-cp[23]_?\\d+m?u?-.+
 $""",
@@ -192,7 +192,7 @@ def test_wheel_c_extension_src_layout() -> None:
             re.match(
                 f"""(?m)^\
 Wheel-Version: 1.0
-Generator: poetry {__version__}
+Generator: poetry-core {__version__}
 Root-Is-Purelib: false
 Tag: cp[23]_?\\d+-cp[23]_?\\d+m?u?-.+
 $""",
@@ -247,7 +247,7 @@ my-script=my_package:main
             wheel_data
             == f"""\
 Wheel-Version: 1.0
-Generator: poetry {__version__}
+Generator: poetry-core {__version__}
 Root-Is-Purelib: true
 Tag: py3-none-any
 """
@@ -371,7 +371,7 @@ my-script=my_package:main
             wheel_data
             == f"""\
 Wheel-Version: 1.0
-Generator: poetry {__version__}
+Generator: poetry-core {__version__}
 Root-Is-Purelib: true
 Tag: py3-none-any
 """

--- a/tests/masonry/test_api.py
+++ b/tests/masonry/test_api.py
@@ -141,7 +141,7 @@ my-script=my_package:main
 """
     wheel_data = f"""\
 Wheel-Version: 1.0
-Generator: poetry {__version__}
+Generator: poetry-core {__version__}
 Root-Is-Purelib: true
 Tag: py3-none-any
 """

--- a/tests/test_core_version.py
+++ b/tests/test_core_version.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from poetry.core import __version__
+from poetry.core.pyproject.toml import PyProjectTOML
+
+
+def test_version_is_synced() -> None:
+    pyproject = PyProjectTOML(Path(__file__).parent.parent.joinpath("pyproject.toml"))
+    assert __version__ == pyproject.poetry_config.get("version")


### PR DESCRIPTION
As discussed with @neersighted on discord, going with the simple bump as `importlib.metadata.version` is a bit more tricky to do here. And if we want to drop `__version__` we need to drop it's use in wheel builder and/or accept that version will not be available for in-tree builds unless we parse `pyproject.toml` file.
 
 Closes: #366 