### PR TITLE
deps: support valid PEP 517 projects as dir deps

### DIFF
--- a/src/poetry/core/pyproject/toml.py
+++ b/src/poetry/core/pyproject/toml.py
@@ -40,6 +40,9 @@ class PyProjectTOML:
 
         return self._data
 
+    def is_build_system_defined(self) -> bool:
+        return self._file.exists() and "build-system" in self.data
+
     @property
     def build_system(self) -> BuildSystem:
         from poetry.core.pyproject.tables import BuildSystem

--- a/tests/fixtures/project_with_pep517_non_poetry/pyproject.toml
+++ b/tests/fixtures/project_with_pep517_non_poetry/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["flit_core >=3.7.1,<4"]
+build-backend = "flit_core.buildapi"
+
+[project]
+name = "flit"
+authors = []
+dependencies = [
+    "flit_core >=3.7.1",
+]
+requires-python = ">=3.6"
+readme = "README.rst"
+dynamic = ['version', 'description']

--- a/tests/fixtures/project_with_setup_cfg_only/setup.cfg
+++ b/tests/fixtures/project_with_setup_cfg_only/setup.cfg
@@ -1,0 +1,18 @@
+[metadata]
+name = my_package
+version = attr: my_package.VERSION
+description = My package description
+long_description = file: README.rst, CHANGELOG.rst, LICENSE.rst
+keywords = one, two
+license = BSD 3-Clause License
+classifiers =
+    Framework :: Django
+    Programming Language :: Python :: 3
+
+[options]
+zip_safe = False
+include_package_data = True
+packages = find:
+install_requires =
+    requests
+    importlib-metadata; python_version<"3.8"

--- a/tests/packages/test_directory_dependency.py
+++ b/tests/packages/test_directory_dependency.py
@@ -75,3 +75,21 @@ def test_directory_dependency_pep_508_extras() -> None:
     requirement = f"demo[foo,bar] @ file://{path.as_posix()}"
     requirement_expected = f"demo[bar,foo] @ file://{path.as_posix()}"
     _test_directory_dependency_pep_508("demo", path, requirement, requirement_expected)
+
+
+@pytest.mark.parametrize(
+    ("fixture", "name"),
+    [
+        ("project_with_pep517_non_poetry", "PEP 517"),
+        ("project_with_setup_cfg_only", "setup.cfg"),
+    ],
+)
+def test_directory_dependency_non_poetry_pep517(fixture: str, name: str) -> None:
+    path = Path(__file__).parent.parent / "fixtures" / fixture
+
+    try:
+        DirectoryDependency("package", path)
+    except ValueError as e:
+        if "does not seem to be a Python package" not in str(e):
+            raise e from e
+        pytest.fail(f"A {name} project not recognized as valid directory dependency")


### PR DESCRIPTION
Resolves: python-poetry/poetry#5655
Resolves: https://github.com/python-poetry/poetry/issues/5692

```sh
pipx install --force --suffix=@5655 'poetry @ git+https://github.com/python-poetry/poetry.git'
pipx inject --force --pip-args="--force --no-deps" poetry@5655 'poetry-core @ git+https://github.com/python-poetry/poetry-core.git@refs/pull/368/head'
poetry@5655 --version
```
