### PR TITLE
schema: relax validation to allow additional props

### DIFF
--- a/src/poetry/core/json/schemas/poetry-schema.json
+++ b/src/poetry/core/json/schemas/poetry-schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "name": "Package",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
     "name",
     "version",
@@ -187,16 +187,6 @@
     },
     "build": {
       "$ref": "#/definitions/build-section"
-    },
-    "source": {
-      "type": "array",
-      "description": "A set of additional repositories where packages can be found.",
-      "additionalProperties": {
-        "$ref": "#/definitions/repository"
-      },
-      "items": {
-        "$ref": "#/definitions/repository"
-      }
     },
     "scripts": {
       "type": "object",
@@ -624,37 +614,6 @@
           "items": {
             "type": "string"
           }
-        }
-      }
-    },
-    "repository": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The name of the repository"
-        },
-        "url": {
-          "type": "string",
-          "description": "The url of the repository",
-          "format": "uri"
-        },
-        "default": {
-          "type": "boolean",
-          "description": "Make this repository the default (disable PyPI)"
-        },
-        "secondary": {
-          "type": "boolean",
-          "description": "Declare this repository as secondary, i.e. it will only be looked up last for packages."
-        },
-        "links": {
-          "type": "boolean",
-          "description": "Declare this as a link source. Links at uri/path can point to sdist or bdist archives."
-        },
-        "indexed": {
-          "type": "boolean",
-          "description": "For PEP 503 simple API repositories, pre-fetch and index the available packages. (experimental)"
         }
       }
     },

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -184,12 +184,9 @@ def test_validate_fails() -> None:
     complete = TOMLFile(fixtures_dir / "complete.toml")
     doc: dict[str, Any] = complete.read()
     content = doc["tool"]["poetry"]
-    content["this key is not in the schema"] = ""
+    content["authors"] = "this is not a valid array"
 
-    expected = (
-        "Additional properties are not allowed "
-        "('this key is not in the schema' was unexpected)"
-    )
+    expected = "[authors] 'this is not a valid array' is not of type 'array'"
 
     assert Factory.validate(content) == {"errors": [expected], "warnings": []}
 


### PR DESCRIPTION
This change helps migrate validation of non-core specific sections in pyproject.toml into poetry frontend.

Related-to: https://github.com/python-poetry/poetry/pull/5678