### PR TITLE
add Dependency.set_extras()

### DIFF
--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -244,6 +244,9 @@ class Dependency(PackageSpecification):
     def extras(self) -> frozenset[str]:
         return self._extras
 
+    def set_extras(self, extras: Iterable[str]) -> None:
+        self._extras = frozenset(extras)
+
     @property
     def in_extras(self) -> list[str]:
         return self._in_extras

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -285,6 +285,13 @@ def test_dependency_string_representation(
     assert str(dependency) == expected
 
 
+def test_set_extras_sets_extras() -> None:
+    dependency = Dependency("A", "^1.0")
+    assert not dependency.extras
+    dependency.set_extras(["foo", "bar"])
+    assert dependency.extras == frozenset(["foo", "bar"])
+
+
 def test_set_constraint_sets_pretty_constraint() -> None:
     dependency = Dependency("A", "^1.0")
     assert dependency.pretty_constraint == "^1.0"


### PR DESCRIPTION
Will allow tidying of https://github.com/python-poetry/poetry/pull/5688, which currently is manipulating `_extras` directly.

Again the split into multiple repositories makes it complicated to figure out a merge sequence that will work...