### PR TITLE
remove Package.requires_extras

### DIFF
--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -96,7 +96,6 @@ class Package(PackageSpecification):
         self.readmes: tuple[Path, ...] = ()
 
         self.extras: dict[str, list[Dependency]] = {}
-        self.requires_extras: list[str] = []
 
         self._dependency_groups: dict[str, DependencyGroup] = {}
 


### PR DESCRIPTION
If and when https://github.com/python-poetry/poetry/pull/5688 is merged, there'll be no use for this field. 

(Even today there is no _good_ use for this field)