### PR TITLE
packages: unify python project check

### DIFF
--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -490,7 +490,7 @@ class Dependency(PackageSpecification):
         from poetry.core.packages.url_dependency import URLDependency
         from poetry.core.packages.utils.link import Link
         from poetry.core.packages.utils.utils import is_archive_file
-        from poetry.core.packages.utils.utils import is_installable_dir
+        from poetry.core.packages.utils.utils import is_python_project
         from poetry.core.packages.utils.utils import is_url
         from poetry.core.packages.utils.utils import path_to_url
         from poetry.core.packages.utils.utils import strip_extras
@@ -521,10 +521,9 @@ class Dependency(PackageSpecification):
             path_str = os.path.normpath(os.path.abspath(name))
             p, extras = strip_extras(path_str)
             if os.path.isdir(p) and (os.path.sep in name or name.startswith(".")):
-
-                if not is_installable_dir(p):
+                if not is_python_project(Path(name)):
                     raise ValueError(
-                        f"Directory {name!r} is not installable. File 'setup.py' "
+                        f"Directory {name!r} is not installable. File 'setup.[py|cfg]' "
                         "not found."
                     )
                 link = Link(path_to_url(p))

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -145,7 +145,7 @@ def test_get_python_constraint_from_marker(marker: str, constraint: str) -> None
         ("project_with_setup", True),
         ("project_with_pep517_non_poetry", True),
         ("project_without_pep517", False),
-        ("does_not_exists", False),
+        ("does_not_exist", False),
     ],
 )
 def test_package_utils_is_python_project(fixture: str, result: bool) -> None:

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from poetry.core.packages.utils.utils import convert_markers
 from poetry.core.packages.utils.utils import get_python_constraint_from_marker
+from poetry.core.packages.utils.utils import is_python_project
 from poetry.core.semver.helpers import parse_constraint
 from poetry.core.version.markers import parse_marker
 
@@ -132,3 +135,19 @@ def test_get_python_constraint_from_marker(marker: str, constraint: str) -> None
     marker_parsed = parse_marker(marker)
     constraint_parsed = parse_constraint(constraint)
     assert get_python_constraint_from_marker(marker_parsed) == constraint_parsed
+
+
+@pytest.mark.parametrize(
+    ("fixture", "result"),
+    [
+        ("simple_project", True),
+        ("project_with_setup_cfg_only", True),
+        ("project_with_setup", True),
+        ("project_with_pep517_non_poetry", True),
+        ("project_without_pep517", False),
+        ("does_not_exists", False),
+    ],
+)
+def test_package_utils_is_python_project(fixture: str, result: bool) -> None:
+    path = Path(__file__).parent.parent.parent / "fixtures" / fixture
+    assert is_python_project(path) == result


### PR DESCRIPTION
Following up from #368 in relation to https://github.com/python-poetry/poetry/issues/5692

Seems we were only checking for `setup.py` when determining if a relative path dependency was installable.