### PR TITLE
Marker fixes

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -342,7 +342,7 @@ class SingleMarker(BaseMarker):
                 )
 
             min_ = self._constraint.min
-            min_operator = ">=" if self._constraint.include_min else "<"
+            min_operator = ">=" if self._constraint.include_min else ">"
             max_ = self._constraint.max
             max_operator = "<=" if self._constraint.include_max else "<"
 

--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -433,6 +433,14 @@ class MultiMarker(BaseMarker):
                                 intersected = True
                             elif constraint_intersection.is_empty():
                                 return EmptyMarker()
+                            elif (
+                                isinstance(constraint_intersection, VersionConstraint)
+                                and constraint_intersection.is_simple()
+                            ):
+                                new_markers[i] = SingleMarker(
+                                    mark.name, constraint_intersection
+                                )
+                                intersected = True
                         elif isinstance(mark, MarkerUnion):
                             intersection = mark.intersect(marker)
                             if isinstance(intersection, SingleMarker):

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -1176,3 +1176,16 @@ def test_union_should_drop_markers_if_their_complement_is_present(
 )
 def test_dnf(scheme: str, marker: BaseMarker, expected: BaseMarker) -> None:
     assert dnf(marker) == expected
+
+
+def test_single_markers_are_found_in_complex_intersection() -> None:
+    m1 = parse_marker('implementation_name != "pypy" and python_version <= "3.6"')
+    m2 = parse_marker(
+        'python_version >= "3.6" and python_version < "4.0" and implementation_name =='
+        ' "cpython"'
+    )
+    intersection = m1.intersect(m2)
+    assert (
+        str(intersection)
+        == 'implementation_name == "cpython" and python_version == "3.6"'
+    )


### PR DESCRIPTION
First fix is I think cosmetic in unhittable code, the second finds a new marker simplification at intersection - code is analogous to the similar case in unions https://github.com/python-poetry/poetry-core/blob/97ab42c6f360b92a32043ed93a3a725e8b7dc858/src/poetry/core/version/markers.py#L640-L647

without the fix the intersection looks like `... and python_version <= "3.6" and python_version >= "3.6"`