### PR TITLE
Add constraint_regions

### DIFF
--- a/src/poetry/core/semver/empty_constraint.py
+++ b/src/poetry/core/semver/empty_constraint.py
@@ -7,6 +7,7 @@ from poetry.core.semver.version_constraint import VersionConstraint
 
 if TYPE_CHECKING:
     from poetry.core.semver.version import Version
+    from poetry.core.semver.version_range_constraint import VersionRangeConstraint
 
 
 class EmptyConstraint(VersionConstraint):
@@ -36,6 +37,9 @@ class EmptyConstraint(VersionConstraint):
 
     def difference(self, other: VersionConstraint) -> EmptyConstraint:
         return self
+
+    def flatten(self) -> list[VersionRangeConstraint]:
+        return []
 
     def __str__(self) -> str:
         return "<empty>"

--- a/src/poetry/core/semver/util.py
+++ b/src/poetry/core/semver/util.py
@@ -9,12 +9,14 @@ if TYPE_CHECKING:
     from poetry.core.semver.version_constraint import VersionConstraint
 
 
-# Transform a list of VersionConstraints into a list of VersionRanges that mark out the
-# distinct regions of version-space.
-#
-# eg input >=3.6 and >=2.7,<3.0.0 || >=3.4.0
-# output <2.7, >=2.7,<3.0.0, >=3.0.0,<3.4.0, >=3.4.0,<3.6, >=3.6.
 def constraint_regions(constraints: list[VersionConstraint]) -> list[VersionRange]:
+    """
+    Transform a list of VersionConstraints into a list of VersionRanges that mark out
+    the distinct regions of version-space.
+
+    eg input >=3.6 and >=2.7,<3.0.0 || >=3.4.0
+    output <2.7, >=2.7,<3.0.0, >=3.0.0,<3.4.0, >=3.4.0,<3.6, >=3.6.
+    """
     flattened = []
     for constraint in constraints:
         flattened += constraint.flatten()

--- a/src/poetry/core/semver/util.py
+++ b/src/poetry/core/semver/util.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from poetry.core.semver.version_range import VersionRange
+
+
+if TYPE_CHECKING:
+    from poetry.core.semver.version_constraint import VersionConstraint
+
+
+# Transform a list of VersionConstraints into a list of VersionRanges that mark out the
+# distinct regions of version-space.
+#
+# eg input >=3.6 and >=2.7,<3.0.0 || >=3.4.0
+# output <2.7, >=2.7,<3.0.0, >=3.0.0,<3.4.0, >=3.4.0,<3.6, >=3.6.
+def constraint_regions(constraints: list[VersionConstraint]) -> list[VersionRange]:
+    flattened = []
+    for constraint in constraints:
+        flattened += constraint.flatten()
+
+    mins = {
+        (constraint.min, not constraint.include_min)
+        for constraint in flattened
+        if constraint.min is not None
+    }
+    maxs = {
+        (constraint.max, constraint.include_max)
+        for constraint in flattened
+        if constraint.max is not None
+    }
+
+    edges = sorted(mins | maxs)
+    if not edges:
+        return [VersionRange(None, None)]
+
+    start = edges[0]
+    regions = [
+        VersionRange(None, start[0], include_max=start[1]),
+    ]
+
+    for low, high in zip(edges, edges[1:]):
+        version_range = VersionRange(
+            low[0],
+            high[0],
+            include_min=not low[1],
+            include_max=high[1],
+        )
+        regions.append(version_range)
+
+    end = edges[-1]
+    regions.append(
+        VersionRange(end[0], None, include_min=not end[1]),
+    )
+
+    return regions

--- a/src/poetry/core/semver/version.py
+++ b/src/poetry/core/semver/version.py
@@ -140,6 +140,9 @@ class Version(PEP440Version, VersionRangeConstraint):
 
         return self
 
+    def flatten(self) -> list[VersionRangeConstraint]:
+        return [self]
+
     def __str__(self) -> str:
         return self.text
 

--- a/src/poetry/core/semver/version_constraint.py
+++ b/src/poetry/core/semver/version_constraint.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from poetry.core.semver.version import Version
+    from poetry.core.semver.version_range_constraint import VersionRangeConstraint
 
 
 class VersionConstraint:
@@ -43,4 +44,8 @@ class VersionConstraint:
 
     @abstractmethod
     def difference(self, other: VersionConstraint) -> VersionConstraint:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def flatten(self) -> list[VersionRangeConstraint]:
         raise NotImplementedError()

--- a/src/poetry/core/semver/version_range.py
+++ b/src/poetry/core/semver/version_range.py
@@ -332,6 +332,9 @@ class VersionRange(VersionRangeConstraint):
 
         raise ValueError(f"Unknown VersionConstraint type {other}.")
 
+    def flatten(self) -> list[VersionRangeConstraint]:
+        return [self]
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, VersionRangeConstraint):
             return False

--- a/src/poetry/core/semver/version_union.py
+++ b/src/poetry/core/semver/version_union.py
@@ -230,6 +230,9 @@ class VersionUnion(VersionConstraint):
 
         return VersionUnion.of(*new_ranges)
 
+    def flatten(self) -> list[VersionRangeConstraint]:
+        return self.ranges
+
     def _ranges_for(
         self, constraint: VersionConstraint
     ) -> list[VersionRangeConstraint]:

--- a/src/poetry/core/semver/version_union.py
+++ b/src/poetry/core/semver/version_union.py
@@ -91,7 +91,7 @@ class VersionUnion(VersionConstraint):
 
     def allows_all(self, other: VersionConstraint) -> bool:
         our_ranges = iter(self._ranges)
-        their_ranges = iter(self._ranges_for(other))
+        their_ranges = iter(other.flatten())
 
         our_current_range = next(our_ranges, None)
         their_current_range = next(their_ranges, None)
@@ -106,7 +106,7 @@ class VersionUnion(VersionConstraint):
 
     def allows_any(self, other: VersionConstraint) -> bool:
         our_ranges = iter(self._ranges)
-        their_ranges = iter(self._ranges_for(other))
+        their_ranges = iter(other.flatten())
 
         our_current_range = next(our_ranges, None)
         their_current_range = next(their_ranges, None)
@@ -124,7 +124,7 @@ class VersionUnion(VersionConstraint):
 
     def intersect(self, other: VersionConstraint) -> VersionConstraint:
         our_ranges = iter(self._ranges)
-        their_ranges = iter(self._ranges_for(other))
+        their_ranges = iter(other.flatten())
         new_ranges = []
 
         our_current_range = next(our_ranges, None)
@@ -148,7 +148,7 @@ class VersionUnion(VersionConstraint):
 
     def difference(self, other: VersionConstraint) -> VersionConstraint:
         our_ranges = iter(self._ranges)
-        their_ranges = iter(self._ranges_for(other))
+        their_ranges = iter(other.flatten())
         new_ranges: list[VersionConstraint] = []
 
         state = {
@@ -232,20 +232,6 @@ class VersionUnion(VersionConstraint):
 
     def flatten(self) -> list[VersionRangeConstraint]:
         return self.ranges
-
-    def _ranges_for(
-        self, constraint: VersionConstraint
-    ) -> list[VersionRangeConstraint]:
-        if constraint.is_empty():
-            return []
-
-        if isinstance(constraint, VersionUnion):
-            return constraint.ranges
-
-        if isinstance(constraint, VersionRangeConstraint):
-            return [constraint]
-
-        raise ValueError(f"Unknown VersionConstraint type {constraint}")
 
     def _exclude_single_wildcard_range_string(self) -> str:
         """

--- a/tests/semver/test_utils.py
+++ b/tests/semver/test_utils.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from poetry.core.semver.empty_constraint import EmptyConstraint
+from poetry.core.semver.util import constraint_regions
+from poetry.core.semver.version import Version
+from poetry.core.semver.version_range import VersionRange
+
+
+if TYPE_CHECKING:
+    from poetry.core.semver.version_constraint import VersionConstraint
+
+
+PY27 = Version.parse("2.7")
+PY30 = Version.parse("3")
+PY36 = Version.parse("3.6.0")
+PY37 = Version.parse("3.7")
+PY38 = Version.parse("3.8.0")
+PY40 = Version.parse("4.0.0")
+
+
+@pytest.mark.parametrize(
+    "versions, expected",
+    [
+        ([VersionRange(None, None)], [VersionRange(None, None)]),
+        ([EmptyConstraint()], [VersionRange(None, None)]),
+        (
+            [VersionRange(PY27, None, include_min=True)],
+            [
+                VersionRange(None, PY27, include_max=False),
+                VersionRange(PY27, None, include_min=True),
+            ],
+        ),
+        (
+            [VersionRange(None, PY40, include_max=False)],
+            [
+                VersionRange(None, PY40, include_max=False),
+                VersionRange(PY40, None, include_min=True),
+            ],
+        ),
+        (
+            [VersionRange(PY27, PY27, include_min=True, include_max=True)],
+            [
+                VersionRange(None, PY27, include_max=False),
+                VersionRange(PY27, PY27, include_min=True, include_max=True),
+                VersionRange(PY27, None, include_min=False),
+            ],
+        ),
+        (
+            [VersionRange(PY27, PY30, include_min=True, include_max=False)],
+            [
+                VersionRange(None, PY27, include_max=False),
+                VersionRange(PY27, PY30, include_min=True, include_max=False),
+                VersionRange(PY30, None, include_min=True),
+            ],
+        ),
+        (
+            [
+                VersionRange(PY27, PY30, include_min=True, include_max=False).union(
+                    VersionRange(PY37, PY40, include_min=False, include_max=True)
+                ),
+                VersionRange(PY36, PY38, include_min=True, include_max=False),
+            ],
+            [
+                VersionRange(None, PY27, include_max=False),
+                VersionRange(PY27, PY30, include_min=True, include_max=False),
+                VersionRange(PY30, PY36, include_min=True, include_max=False),
+                VersionRange(PY36, PY37, include_min=True, include_max=True),
+                VersionRange(PY37, PY38, include_min=False, include_max=False),
+                VersionRange(PY38, PY40, include_min=True, include_max=True),
+                VersionRange(PY40, None, include_min=False),
+            ],
+        ),
+    ],
+)
+def test_constraint_regions(
+    versions: list[VersionConstraint], expected: list[VersionRange]
+) -> None:
+    regions = constraint_regions(versions)
+    assert regions == expected


### PR DESCRIPTION
This adds `constraint_regions()` which is a utility that takes a set of python version constraints and spits out the distinct regions that those constraints split the world into.

For instance: input `>=3.6` and `>=2.7,<3.0.0 || >=3.4.0`
output `<2.7`, `>=2.7,<3.0.0`, `>=3.0.0,<3.4.0`, `>=3.4.0,<3.6`, `>=3.6`.

I am expecting views on whether this is the right place for such code to live, and what the method should be called, and requests for unit tests, which we can get to in due course...

The motivation for this is that I think we need it to fix a particularly icky `poetry export` example https://github.com/python-poetry/poetry-plugin-export/issues/32.  There, the tree-walk at some point finds the requirement:

```
{version = "*", markers = "python_version > \"3.6\" and implementation_name != \"pypy\""}
```
and correctly decides that only ipython 7.16.3 can satisfy this.  But that causes it to add a `... or python_version >= "3.6" ... ` marker for ipython 7.16.3, which sadly overlaps with the markers on a newer ipython version.

My intended fix is to split up the python version space and when adding a requirement during the walk, actually add several requirements, one for each range of python versions.  That allows the locker to limit the ipython 7.16.3 selection to `>3.6,<=3.7` and all is right again.

(I'll follow up with an MR in poetry, hopefully clarifying the above).