### PR TITLE
don't merge python_version and python_full_version

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -47,8 +47,6 @@ ALIASES = {
     "python_implementation": "platform_python_implementation",
 }
 
-PYTHON_VERSION_MARKERS = ["python_version", "python_full_version"]
-
 # Parser: PEP 508 Environment Markers
 _parser = Parser(GRAMMAR_PEP_508_MARKERS, "lalr")
 
@@ -416,10 +414,6 @@ class MultiMarker(BaseMarker):
                     for i, mark in enumerate(new_markers):
                         if isinstance(mark, SingleMarker) and (
                             mark.name == marker.name
-                            or (
-                                mark.name in PYTHON_VERSION_MARKERS
-                                and marker.name in PYTHON_VERSION_MARKERS
-                            )
                         ):
                             # Markers with the same name have the same constraint type,
                             # but mypy can't see that.
@@ -626,10 +620,6 @@ class MarkerUnion(BaseMarker):
                     for i, mark in enumerate(new_markers):
                         if isinstance(mark, SingleMarker) and (
                             mark.name == marker.name
-                            or (
-                                mark.name in PYTHON_VERSION_MARKERS
-                                and marker.name in PYTHON_VERSION_MARKERS
-                            )
                         ):
                             # Markers with the same name have the same constraint type,
                             # but mypy can't see that.

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -41,7 +41,12 @@ from poetry.core.version.markers import parse_marker
         (
             '(python_version < "2.7" or python_full_version >= "3.0.0") and'
             ' python_full_version < "3.6.0"',
-            {"python_version": [[("<", "2.7")], [(">=", "3.0.0"), ("<", "3.6.0")]]},
+            {
+                "python_version": [
+                    [("<", "2.7"), ("<", "3.6.0")],
+                    [(">=", "3.0.0"), ("<", "3.6.0")],
+                ]
+            },
         ),
         (
             '(python_version < "2.7" or python_full_version >= "3.0.0") and'

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -167,11 +167,15 @@ def test_single_marker_not_in_python_intersection() -> None:
 
 
 def test_marker_intersection_of_python_version_and_python_full_version() -> None:
-    m = parse_marker('python_version >= "3.6"')
-    m2 = parse_marker('python_full_version >= "3.0.0"')
+    m = parse_marker('python_version > "3.6"')
+    m2 = parse_marker('python_full_version >= "3.6.2"')
     intersection = m.intersect(m2)
 
-    assert str(intersection) == 'python_version >= "3.6"'
+    # 'python_version > "3.6"' would be good, but not
+    # 'python_full_version >= "3.6.2"'.
+    assert (
+        str(intersection) == 'python_version > "3.6" and python_full_version >= "3.6.2"'
+    )
 
 
 def test_single_marker_union() -> None:
@@ -521,11 +525,13 @@ def test_marker_union_deduplicate() -> None:
 
 
 def test_marker_union_of_python_version_and_python_full_version() -> None:
-    m = parse_marker('python_version >= "3.6"')
-    m2 = parse_marker('python_full_version >= "3.0.0"')
+    m = parse_marker('python_version > "3.6"')
+    m2 = parse_marker('python_full_version >= "3.6.2"')
     union = m.union(m2)
 
-    assert str(union) == 'python_full_version >= "3.0.0"'
+    # 'python_full_version >= "3.6.2"' would be good, but not
+    # 'python_version > "3.6"'.
+    assert str(union) == 'python_version > "3.6" or python_full_version >= "3.6.2"'
 
 
 def test_marker_union_intersect_single_marker() -> None:


### PR DESCRIPTION
These markers are not quite equivalent; I've updated the relevant testcases to give examples where the previous code got it wrong.

cf https://github.com/python-poetry/poetry/issues/5717

I do not claim that this is the only code that confuses `python_version` and `python_full_version`, I just remember this particular example because I wrote it myself!