### PR TITLE
preserver marker order at union

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -517,15 +517,22 @@ class MultiMarker(BaseMarker):
                 return other
 
         elif isinstance(other, MultiMarker):
-            markers = set(self._markers)
-            other_markers = set(other.markers)
-            common_markers = markers & other_markers
-            unique_markers = markers - common_markers
+            common_markers = [
+                marker for marker in self.markers if marker in other.markers
+            ]
+
+            unique_markers = [
+                marker for marker in self.markers if marker not in common_markers
+            ]
             if not unique_markers:
                 return self
-            other_unique_markers = other_markers - common_markers
+
+            other_unique_markers = [
+                marker for marker in other.markers if marker not in common_markers
+            ]
             if not other_unique_markers:
                 return other
+
             if common_markers:
                 unique_union = self.of(*unique_markers).union(
                     self.of(*other_unique_markers)


### PR DESCRIPTION
per https://github.com/python-poetry/poetry/issues/5721, use of a set made the representation of markers non-deterministic.

A set is really the appropriate data structure, and this change is a bit of an uglification.  But the number of elements in a marker union is very rarely going to be more than, say, 5 - so I doubt that efficiency is an issue.

An alternative that I considered was to try and impose an ordering in the `__str__`, but:
- markers don't order
- could do it alphabetically, but that's going to cause significantly more damage to existing unit tests than I would like to have to deal with...

I also decided that unit test wasn't very useful: a regression in the exact same way doesn't seem very likely.  Can add the testcase from https://github.com/python-poetry/poetry/issues/5721 if anyone thinks it's worth the trouble