### PR TITLE
Treat marker intersection more symmetrically

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -475,6 +475,9 @@ class MultiMarker(BaseMarker):
         if other.is_empty():
             return other
 
+        if isinstance(other, MarkerUnion):
+            return other.intersect(self)
+
         new_markers = self._markers + [other]
 
         return MultiMarker.of(*new_markers)

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -372,6 +372,24 @@ def test_multi_marker_is_empty_is_contradictory() -> None:
     assert m.is_empty()
 
 
+def test_multi_complex_multi_marker_is_empty() -> None:
+    m1 = parse_marker(
+        'python_full_version >= "3.0.0" and python_full_version < "3.4.0"'
+    )
+    m2 = parse_marker(
+        'python_version >= "3.6" and python_full_version < "3.0.0" and python_version <'
+        ' "3.7"'
+    )
+    m3 = parse_marker(
+        'python_version >= "3.6" and python_version < "3.7" and python_full_version >='
+        ' "3.5.0"'
+    )
+
+    m = m1.intersect(m2.union(m3))
+
+    assert m.is_empty()
+
+
 def test_multi_marker_intersect_multi() -> None:
     m = parse_marker('sys_platform == "darwin" and implementation_name == "cpython"')
 

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -612,17 +612,20 @@ def test_marker_union_intersect_marker_union_drops_unnecessary_markers() -> None
 
 
 def test_marker_union_intersect_multi_marker() -> None:
-    m = parse_marker('sys_platform == "darwin" or python_version < "3.4"')
+    m1 = parse_marker('sys_platform == "darwin" or python_version < "3.4"')
+    m2 = parse_marker('implementation_name == "cpython" and os_name == "Windows"')
 
-    intersection = m.intersect(
-        parse_marker('implementation_name == "cpython" and os_name == "Windows"')
-    )
-    assert (
-        str(intersection)
-        == 'implementation_name == "cpython" and os_name == "Windows" and sys_platform'
+    expected = (
+        'implementation_name == "cpython" and os_name == "Windows" and sys_platform'
         ' == "darwin" or implementation_name == "cpython" and os_name == "Windows"'
         ' and python_version < "3.4"'
     )
+
+    intersection = m1.intersect(m2)
+    assert str(intersection) == expected
+
+    intersection = m2.intersect(m1)
+    assert str(intersection) == expected
 
 
 def test_marker_union_union_with_union() -> None:


### PR DESCRIPTION
The somewhat elaborate real-life example that motivated this change is given as a testcase.  

But on further consideration, this is also a symmetry improvement: both `union.intersect(intersection)` and `intersection.intersect(union)` now behave the same way (preferring to return a union),