### PR TITLE
fix and make common python version normalization

### DIFF
--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -16,6 +16,7 @@ from poetry.core.packages.constraints import (
 from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.core.packages.specification import PackageSpecification
 from poetry.core.packages.utils.utils import contains_group_without_marker
+from poetry.core.packages.utils.utils import normalize_python_version_markers
 from poetry.core.semver.helpers import parse_constraint
 from poetry.core.semver.version_range_constraint import VersionRangeConstraint
 from poetry.core.version.markers import parse_marker
@@ -192,39 +193,10 @@ class Dependency(PackageSpecification):
         # Recalculate python versions.
         self._python_versions = "*"
         if not contains_group_without_marker(markers, "python_version"):
-            ors = []
-            for or_ in markers["python_version"]:
-                ands = []
-                for op, version in or_:
-                    # Expand python version
-                    if op == "==" and "*" not in version:
-                        version = "~" + version
-                        op = ""
-                    elif op == "!=":
-                        version += ".*"
-                    elif op in ("in", "not in"):
-                        versions = []
-                        for v in re.split("[ ,]+", version):
-                            split = v.split(".")
-                            if len(split) in [1, 2]:
-                                split.append("*")
-                                op_ = "" if op == "in" else "!="
-                            else:
-                                op_ = "==" if op == "in" else "!="
-
-                            versions.append(op_ + ".".join(split))
-
-                        glue = " || " if op == "in" else ", "
-                        if versions:
-                            ands.append(glue.join(versions))
-
-                        continue
-
-                    ands.append(f"{op}{version}")
-
-                ors.append(" ".join(ands))
-
-            self._python_versions = " || ".join(ors)
+            python_version_markers = markers["python_version"]
+            self._python_versions = normalize_python_version_markers(
+                python_version_markers
+            )
 
         self._python_constraint = parse_constraint(self._python_versions)
 

--- a/src/poetry/core/packages/utils/utils.py
+++ b/src/poetry/core/packages/utils/utils.py
@@ -308,7 +308,9 @@ def get_python_constraint_from_marker(
     return constraint
 
 
-def normalize_python_version_markers(disjunction: list[list[tuple[str, str]]]) -> str:
+def normalize_python_version_markers(  # NOSONAR
+    disjunction: list[list[tuple[str, str]]],
+) -> str:
     ors = []
     for or_ in disjunction:
         ands = []
@@ -317,8 +319,10 @@ def normalize_python_version_markers(disjunction: list[list[tuple[str, str]]]) -
             if op == "==" and "*" not in version:
                 version = "~" + version
                 op = ""
+
             elif op == "!=" and "*" not in version:
                 version += ".*"
+
             elif op in ("<=", ">"):
                 # Make adjustments on encountering versions with less than full
                 # precision.

--- a/tests/packages/test_main.py
+++ b/tests/packages/test_main.py
@@ -294,10 +294,10 @@ def test_dependency_from_pep_508_should_not_produce_empty_constraints_for_correc
 
     assert dep.name == "pytest-mypy"
     assert str(dep.constraint) == "*"
-    assert dep.python_versions == "<3.11 >3"
+    assert dep.python_versions == "<3.11 >=3"
     assert dep.python_constraint.allows(Version.parse("3.6"))
     assert dep.python_constraint.allows(Version.parse("3.10.4"))
-    assert not dep.python_constraint.allows(Version.parse("3"))
+    assert dep.python_constraint.allows(Version.parse("3"))
     assert dep.python_constraint.allows(Version.parse("3.0.1"))
     assert (
         str(dep.marker)

--- a/tests/packages/test_main.py
+++ b/tests/packages/test_main.py
@@ -294,9 +294,9 @@ def test_dependency_from_pep_508_should_not_produce_empty_constraints_for_correc
 
     assert dep.name == "pytest-mypy"
     assert str(dep.constraint) == "*"
-    assert dep.python_versions == "<=3.10 >3"
+    assert dep.python_versions == "<3.11 >3"
     assert dep.python_constraint.allows(Version.parse("3.6"))
-    assert dep.python_constraint.allows(Version.parse("3.10"))
+    assert dep.python_constraint.allows(Version.parse("3.10.4"))
     assert not dep.python_constraint.allows(Version.parse("3"))
     assert dep.python_constraint.allows(Version.parse("3.0.1"))
     assert (

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -96,8 +96,8 @@ def test_convert_markers(
         ('python_version != "3.6.* "', "!=3.6.*"),
         # <, <=, >, >= precision 1
         ('python_version < "3"', "<3"),
-        ('python_version <= "3"', "<4"),
-        ('python_version > "3"', ">=4"),
+        ('python_version <= "3"', "<=3"),
+        ('python_version > "3"', ">3"),
         ('python_version >= "3"', ">=3"),
         # <, <=, >, >= precision 2
         ('python_version < "3.6"', "<3.6"),

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -96,8 +96,8 @@ def test_convert_markers(
         ('python_version != "3.6.* "', "!=3.6.*"),
         # <, <=, >, >= precision 1
         ('python_version < "3"', "<3"),
-        ('python_version <= "3"', "<=3"),
-        ('python_version > "3"', ">3"),
+        ('python_version <= "3"', "<3"),
+        ('python_version > "3"', ">=3"),
         ('python_version >= "3"', ">=3"),
         # <, <=, >, >= precision 2
         ('python_version < "3.6"', "<3.6"),


### PR DESCRIPTION
relating to https://github.com/python-poetry/poetry/issues/5717

there were two similar but diverging bits of code.  They really ought to be the same; and the version that I've gone for is actually not quite the same as either of the originals.

Specifically, in the handling of python_version when specified with either one or two digits...

First, the single digit case.  
- I believe that a constraint like `python_version > 3` is strictly not valid, PEP 508 says that the `python_version` should be equivalent to `'.'.join(platform.python_version_tuple()[:2])`.  
- However experiment with `pip` and a `requirements.txt` teaches me that in my 3.8.10 environment, `python_version > 3` _does_ allow a dependency to be installed
- `python_version <= "3"` does not allow installation at 3.8.10
- So I conclude that the interpretation of `>3` as `> 3.0.0` per #155 is reasonable, and have removed code that treats `>3` as `>=4.0.0`

For the two digit case though, experiment shows that `python_version > "3.8"` does indeed cause pip not to install a dependency in my 3.8.10 environment, that I think _should_ be reinterpreted as `>=3.9.0`.  So I have included that code.