### PR TITLE
Typechecking tidying

### DIFF
--- a/src/poetry/core/packages/constraints/constraint.py
+++ b/src/poetry/core/packages/constraints/constraint.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import operator
 
-from typing import Any
-
 from poetry.core.packages.constraints import AnyConstraint
 from poetry.core.packages.constraints.base_constraint import BaseConstraint
 from poetry.core.packages.constraints.empty_constraint import EmptyConstraint
@@ -128,7 +126,7 @@ class Constraint(BaseConstraint):
     def is_empty(self) -> bool:
         return False
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, Constraint):
             return NotImplemented
 

--- a/src/poetry/core/packages/constraints/multi_constraint.py
+++ b/src/poetry/core/packages/constraints/multi_constraint.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 from poetry.core.packages.constraints.base_constraint import BaseConstraint
 from poetry.core.packages.constraints.constraint import Constraint
 
@@ -77,7 +75,7 @@ class MultiConstraint(BaseConstraint):
 
         return MultiConstraint(*constraints)
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, MultiConstraint):
             return False
 

--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -7,7 +7,6 @@ import warnings
 from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING
-from typing import Any
 from typing import Iterable
 
 from poetry.core.packages.constraints import (
@@ -587,7 +586,7 @@ class Dependency(PackageSpecification):
 
         return dep
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, Dependency):
             return NotImplemented
 

--- a/src/poetry/core/packages/utils/link.py
+++ b/src/poetry/core/packages/utils/link.py
@@ -4,8 +4,6 @@ import posixpath
 import re
 import urllib.parse as urlparse
 
-from typing import Any
-
 from poetry.core.packages.utils.utils import path_to_url
 from poetry.core.packages.utils.utils import splitext
 
@@ -14,7 +12,6 @@ class Link:
     def __init__(
         self,
         url: str,
-        comes_from: Any | None = None,
         requires_python: str | None = None,
         metadata: str | bool | None = None,
     ) -> None:
@@ -23,8 +20,6 @@ class Link:
 
         url:
             url of the resource pointed to (href of the link)
-        comes_from:
-            instance of HTMLPage where the link was found, or string.
         requires_python:
             String containing the `Requires-Python` metadata field, specified
             in PEP 345. This may be specified by a data-requires-python
@@ -41,7 +36,6 @@ class Link:
             url = path_to_url(url)
 
         self.url = url
-        self.comes_from = comes_from
         self.requires_python = requires_python if requires_python else None
 
         if isinstance(metadata, str):
@@ -56,10 +50,8 @@ class Link:
             rp = f" (requires-python:{self.requires_python})"
         else:
             rp = ""
-        if self.comes_from:
-            return f"{self.url} (from {self.comes_from}){rp}"
-        else:
-            return str(self.url)
+
+        return f"{self.url}{rp}"
 
     def __repr__(self) -> str:
         return f"<Link {self!s}>"

--- a/src/poetry/core/packages/utils/link.py
+++ b/src/poetry/core/packages/utils/link.py
@@ -64,32 +64,32 @@ class Link:
     def __repr__(self) -> str:
         return f"<Link {self!s}>"
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, Link):
             return NotImplemented
         return self.url == other.url
 
-    def __ne__(self, other: Any) -> bool:
+    def __ne__(self, other: object) -> bool:
         if not isinstance(other, Link):
             return NotImplemented
         return self.url != other.url
 
-    def __lt__(self, other: Any) -> bool:
+    def __lt__(self, other: object) -> bool:
         if not isinstance(other, Link):
             return NotImplemented
         return self.url < other.url
 
-    def __le__(self, other: Any) -> bool:
+    def __le__(self, other: object) -> bool:
         if not isinstance(other, Link):
             return NotImplemented
         return self.url <= other.url
 
-    def __gt__(self, other: Any) -> bool:
+    def __gt__(self, other: object) -> bool:
         if not isinstance(other, Link):
             return NotImplemented
         return self.url > other.url
 
-    def __ge__(self, other: Any) -> bool:
+    def __ge__(self, other: object) -> bool:
         if not isinstance(other, Link):
             return NotImplemented
         return self.url >= other.url

--- a/src/poetry/core/semver/version_union.py
+++ b/src/poetry/core/semver/version_union.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import Any
 
 from poetry.core.semver.empty_constraint import EmptyConstraint
 from poetry.core.semver.version_constraint import VersionConstraint
@@ -395,7 +394,7 @@ class VersionUnion(VersionConstraint):
 
         return isinstance(VersionRange().difference(self), Version)
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, VersionUnion):
             return False
 


### PR DESCRIPTION
I was just going to tidy up some `Any` annotations, but in doing so I noticed that nearly all of the code in the `Link` object is unused.  So I removed it.

Did these in separate commits in case it's controversial