### PR TITLE
Merge python_version and python_full_version markers

### DIFF
--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -44,12 +44,7 @@ from poetry.core.version.markers import parse_marker
         (
             '(python_version < "2.7" or python_full_version >= "3.0.0") and'
             ' python_full_version < "3.6.0"',
-            {
-                "python_version": [
-                    [("<", "2.7"), ("<", "3.6.0")],
-                    [(">=", "3.0.0"), ("<", "3.6.0")],
-                ]
-            },
+            {"python_version": [[("<", "2.7")], [(">=", "3.0.0"), ("<", "3.6.0")]]},
         ),
         (
             '(python_version < "2.7" or python_full_version >= "3.0.0") and'


### PR DESCRIPTION
Relates-to: python-poetry/poetry#5717

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Reintroduces merging of `python_version` and `python_full_version`, which was removed in #382 because of python-poetry/poetry#5717

The `constraint` of the `python_marker` is converted via `get_python_constraint_from_marker()` and thus should be consistent with the latest findings described in #385.