### PR TITLE
Correctly run integration tests on macOS and Windows

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   Tests:
     name: ${{ matrix.os }} / ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: "${{ matrix.os }}-latest"
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,6 +1,9 @@
 name: Integration
 
-on: [push, pull_request]
+on:
+  pull_request: {}
+  push:
+    branches: [main]
 
 jobs:
   Tests:
@@ -10,6 +13,7 @@ jobs:
       matrix:
         os: [Ubuntu, MacOS, Windows]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+      fail-fast: false
     defaults:
       run:
         shell: bash

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   Tests:
     name: ${{ matrix.os }} / ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: "${{ matrix.os }}-latest"
     strategy:
       matrix:
         os: [Ubuntu, MacOS, Windows]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ import pytest
 import virtualenv
 
 from poetry.core.factory import Factory
+from poetry.core.utils._compat import WINDOWS
 
 
 if TYPE_CHECKING:
@@ -101,7 +102,7 @@ def venv(temporary_directory: Path) -> Path:
 
 @pytest.fixture
 def python(venv: Path) -> str:
-    return (venv / "bin" / "python").as_posix()
+    return venv.joinpath("Scripts/Python.exe" if WINDOWS else "bin/python").as_posix()
 
 
 @pytest.fixture()


### PR DESCRIPTION
- [ ] ~Added **tests** for changed code.~ Not applicable
- [ ] ~Updated **documentation** for changed code.~ Not applicable

While working on https://github.com/python-poetry/poetry-core/pull/389, I've noticed that the OS is hard coded in integration tests.
You can definitely see that by looking at most recent builds for [macOS](https://github.com/python-poetry/poetry-core/runs/6727343360?check_suite_focus=true#step:1:3) and [Windows](https://github.com/python-poetry/poetry-core/runs/6727343940?check_suite_focus=true#step:1:3).

This PR fixes that, and slightly updates the `integration` workflow to avoid runs on non-main branches and failing fast.
I also needed to update the path to the Python executable, since it's different under Windows.