### PR TITLE
Refactor: make method with_features available for Dependency

### DIFF
--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -8,6 +8,7 @@ from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Iterable
+from typing import TypeVar
 
 from poetry.core.packages.constraints import (
     parse_constraint as parse_generic_constraint,
@@ -28,6 +29,8 @@ if TYPE_CHECKING:
     from poetry.core.packages.package import Package
     from poetry.core.semver.version_constraint import VersionConstraint
     from poetry.core.version.markers import BaseMarker
+
+    T = TypeVar("T", bound="Dependency")
 
 
 class Dependency(PackageSpecification):
@@ -437,29 +440,10 @@ class Dependency(PackageSpecification):
 
         self._activated = False
 
-    def with_constraint(self, constraint: str | VersionConstraint) -> Dependency:
-        new = Dependency(
-            self.pretty_name,
-            constraint,
-            optional=self.is_optional(),
-            groups=list(self._groups),
-            allows_prereleases=self.allows_prereleases(),
-            extras=self.extras,
-            source_type=self._source_type,
-            source_url=self._source_url,
-            source_reference=self._source_reference,
-        )
-
-        new.is_root = self.is_root
-        new.python_versions = self.python_versions
-        new.transitive_python_versions = self.transitive_python_versions
-        new.marker = self.marker
-        new.transitive_marker = self.transitive_marker
-
-        for in_extra in self.in_extras:
-            new.in_extras.append(in_extra)
-
-        return new
+    def with_constraint(self: T, constraint: str | VersionConstraint) -> T:
+        dependency = self.clone()
+        dependency.constraint = constraint  # type: ignore[assignment]
+        return dependency
 
     @classmethod
     def create_from_pep_508(

--- a/src/poetry/core/packages/directory_dependency.py
+++ b/src/poetry/core/packages/directory_dependency.py
@@ -3,18 +3,12 @@ from __future__ import annotations
 import functools
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 from typing import Iterable
-
-from poetry.core.pyproject.toml import PyProjectTOML
-
-
-if TYPE_CHECKING:
-    from poetry.core.semver.version_constraint import VersionConstraint
 
 from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.utils.utils import is_python_project
 from poetry.core.packages.utils.utils import path_to_url
+from poetry.core.pyproject.toml import PyProjectTOML
 
 
 class DirectoryDependency(Dependency):
@@ -87,30 +81,6 @@ class DirectoryDependency(Dependency):
 
     def is_directory(self) -> bool:
         return True
-
-    def with_constraint(
-        self, constraint: str | VersionConstraint
-    ) -> DirectoryDependency:
-        new = DirectoryDependency(
-            self.pretty_name,
-            path=self.path,
-            base=self.base,
-            optional=self.is_optional(),
-            groups=list(self._groups),
-            develop=self._develop,
-            extras=list(self.extras),
-        )
-
-        new.constraint = constraint  # type: ignore[assignment]
-        new.is_root = self.is_root
-        new.python_versions = self.python_versions
-        new.marker = self.marker
-        new.transitive_marker = self.transitive_marker
-
-        for in_extra in self.in_extras:
-            new.in_extras.append(in_extra)
-
-        return new
 
     @property
     def base_pep_508_name(self) -> str:

--- a/src/poetry/core/packages/file_dependency.py
+++ b/src/poetry/core/packages/file_dependency.py
@@ -4,15 +4,10 @@ import hashlib
 import io
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 from typing import Iterable
 
 from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.utils.utils import path_to_url
-
-
-if TYPE_CHECKING:
-    from poetry.core.semver.version_constraint import VersionConstraint
 
 
 class FileDependency(Dependency):
@@ -74,27 +69,6 @@ class FileDependency(Dependency):
                 h.update(content)
 
         return h.hexdigest()
-
-    def with_constraint(self, constraint: str | VersionConstraint) -> FileDependency:
-        new = FileDependency(
-            self.pretty_name,
-            path=self.path,
-            base=self.base,
-            optional=self.is_optional(),
-            groups=list(self._groups),
-            extras=list(self.extras),
-        )
-
-        new.constraint = constraint  # type: ignore[assignment]
-        new.is_root = self.is_root
-        new.python_versions = self.python_versions
-        new.marker = self.marker
-        new.transitive_marker = self.transitive_marker
-
-        for in_extra in self.in_extras:
-            new.in_extras.append(in_extra)
-
-        return new
 
     @property
     def base_pep_508_name(self) -> str:

--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -553,9 +553,7 @@ class Package(PackageSpecification):
         return ignore_source_type or self.is_same_source_as(dependency)
 
     def clone(self: T) -> T:
-        clone = self.__class__(self.pretty_name, self.version)
-        clone.__dict__ = copy.deepcopy(self.__dict__)
-        return clone
+        return copy.deepcopy(self)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Package):

--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -27,9 +27,9 @@ if TYPE_CHECKING:
     from poetry.core.spdx.license import License
     from poetry.core.version.markers import BaseMarker
 
-AUTHOR_REGEX = re.compile(r"(?u)^(?P<name>[- .,\w\d'’\"()&]+)(?: <(?P<email>.+?)>)?$")
+    T = TypeVar("T", bound="Package")
 
-T = TypeVar("T", bound="Package")
+AUTHOR_REGEX = re.compile(r"(?u)^(?P<name>[- .,\w\d'’\"()&]+)(?: <(?P<email>.+?)>)?$")
 
 
 class Package(PackageSpecification):
@@ -525,16 +525,6 @@ class Package(PackageSpecification):
 
         self.python_versions = original_python_versions
 
-    def with_features(self: T, features: Iterable[str]) -> T:
-        package = self.clone()
-
-        package._features = frozenset(features)
-
-        return package
-
-    def without_features(self: T) -> T:
-        return self.with_features([])
-
     def satisfies(
         self, dependency: Dependency, ignore_source_type: bool = False
     ) -> bool:
@@ -551,9 +541,6 @@ class Package(PackageSpecification):
             return False
 
         return ignore_source_type or self.is_same_source_as(dependency)
-
-    def clone(self: T) -> T:
-        return copy.deepcopy(self)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Package):

--- a/src/poetry/core/packages/specification.py
+++ b/src/poetry/core/packages/specification.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
+import copy
+
+from typing import TYPE_CHECKING
 from typing import Iterable
+from typing import TypeVar
+
+
+if TYPE_CHECKING:
+    T = TypeVar("T", bound="PackageSpecification")
 
 
 class PackageSpecification:
@@ -150,6 +158,19 @@ class PackageSpecification:
             return False
 
         return self.is_same_source_as(other)
+
+    def clone(self: T) -> T:
+        return copy.deepcopy(self)
+
+    def with_features(self: T, features: Iterable[str]) -> T:
+        package = self.clone()
+
+        package._features = frozenset(features)
+
+        return package
+
+    def without_features(self: T) -> T:
+        return self.with_features([])
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, PackageSpecification):

--- a/src/poetry/core/packages/url_dependency.py
+++ b/src/poetry/core/packages/url_dependency.py
@@ -1,14 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 from typing import Iterable
 from urllib.parse import urlparse
 
 from poetry.core.packages.dependency import Dependency
-
-
-if TYPE_CHECKING:
-    from poetry.core.semver.version_constraint import VersionConstraint
 
 
 class URLDependency(Dependency):
@@ -55,26 +50,6 @@ class URLDependency(Dependency):
 
     def is_url(self) -> bool:
         return True
-
-    def with_constraint(self, constraint: str | VersionConstraint) -> URLDependency:
-        new = URLDependency(
-            self.pretty_name,
-            url=self._url,
-            optional=self.is_optional(),
-            groups=list(self._groups),
-            extras=list(self.extras),
-        )
-
-        new.constraint = constraint  # type: ignore[assignment]
-        new.is_root = self.is_root
-        new.python_versions = self.python_versions
-        new.marker = self.marker
-        new.transitive_marker = self.transitive_marker
-
-        for in_extra in self.in_extras:
-            new.in_extras.append(in_extra)
-
-        return new
 
     def __str__(self) -> str:
         return f"{self._pretty_name} ({self._pretty_constraint} url)"

--- a/src/poetry/core/packages/vcs_dependency.py
+++ b/src/poetry/core/packages/vcs_dependency.py
@@ -1,13 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 from typing import Iterable
 
 from poetry.core.packages.dependency import Dependency
-
-
-if TYPE_CHECKING:
-    from poetry.core.semver.version_constraint import VersionConstraint
 
 
 class VCSDependency(Dependency):
@@ -131,33 +126,6 @@ class VCSDependency(Dependency):
 
     def accepts_prereleases(self) -> bool:
         return True
-
-    def with_constraint(self, constraint: str | VersionConstraint) -> VCSDependency:
-        new = VCSDependency(
-            self.pretty_name,
-            self._vcs,
-            self._source,
-            branch=self._branch,
-            tag=self._tag,
-            rev=self._rev,
-            resolved_rev=self._source_resolved_reference,
-            directory=self.directory,
-            optional=self.is_optional(),
-            groups=list(self._groups),
-            develop=self._develop,
-            extras=list(self.extras),
-        )
-
-        new.constraint = constraint  # type: ignore[assignment]
-        new.is_root = self.is_root
-        new.python_versions = self.python_versions
-        new.marker = self.marker
-        new.transitive_marker = self.transitive_marker
-
-        for in_extra in self.in_extras:
-            new.in_extras.append(in_extra)
-
-        return new
 
     def __str__(self) -> str:
         reference = self._vcs


### PR DESCRIPTION
Originally I just wanted to make the method with_features() available for Dependency. Then, I noticed that some redundant code can be removed with a little refactoring.