### PR TITLE
dependency: harmonize string representation

### DIFF
--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -583,6 +583,10 @@ class Dependency(PackageSpecification):
     def __str__(self) -> str:
         if self.is_root:
             return self._pretty_name
+        if self.is_direct_origin():
+            # adding version since this information is especially useful in debug output
+            parts = [p.strip() for p in self.base_pep_508_name.split("@", 1)]
+            return f"{parts[0]} ({self._pretty_constraint}) @ {parts[1]}"
         return self.base_pep_508_name
 
     def __repr__(self) -> str:

--- a/src/poetry/core/packages/directory_dependency.py
+++ b/src/poetry/core/packages/directory_dependency.py
@@ -94,10 +94,3 @@ class DirectoryDependency(Dependency):
         requirement += f" @ {path}"
 
         return requirement
-
-    def __str__(self) -> str:
-        if self.is_root:
-            return self._pretty_name
-
-        path = self._path.as_posix()
-        return f"{self._pretty_name} ({self._pretty_constraint} {path})"

--- a/src/poetry/core/packages/file_dependency.py
+++ b/src/poetry/core/packages/file_dependency.py
@@ -82,9 +82,3 @@ class FileDependency(Dependency):
         requirement += f" @ {path}"
 
         return requirement
-
-    def __str__(self) -> str:
-        if self.is_root:
-            return self._pretty_name
-
-        return f"{self._pretty_name} ({self._pretty_constraint} {self._path})"

--- a/src/poetry/core/packages/url_dependency.py
+++ b/src/poetry/core/packages/url_dependency.py
@@ -50,6 +50,3 @@ class URLDependency(Dependency):
 
     def is_url(self) -> bool:
         return True
-
-    def __str__(self) -> str:
-        return f"{self._pretty_name} ({self._pretty_constraint} url)"

--- a/src/poetry/core/packages/vcs_dependency.py
+++ b/src/poetry/core/packages/vcs_dependency.py
@@ -126,14 +126,3 @@ class VCSDependency(Dependency):
 
     def accepts_prereleases(self) -> bool:
         return True
-
-    def __str__(self) -> str:
-        reference = self._vcs
-        if self._branch:
-            reference += f" branch {self._branch}"
-        elif self._tag:
-            reference += f" tag {self._tag}"
-        elif self._rev:
-            reference += f" rev {self._rev}"
-
-        return f"{self._pretty_name} ({self._constraint} {reference})"

--- a/tests/packages/test_directory_dependency.py
+++ b/tests/packages/test_directory_dependency.py
@@ -10,6 +10,7 @@ from poetry.core.packages.directory_dependency import DirectoryDependency
 
 
 DIST_PATH = Path(__file__).parent.parent / "fixtures" / "git" / "github.com" / "demo"
+SAMPLE_PROJECT = Path(__file__).parent.parent / "fixtures" / "sample_project"
 
 
 def test_directory_dependency_must_exist() -> None:
@@ -75,6 +76,38 @@ def test_directory_dependency_pep_508_extras() -> None:
     requirement = f"demo[foo,bar] @ file://{path.as_posix()}"
     requirement_expected = f"demo[bar,foo] @ file://{path.as_posix()}"
     _test_directory_dependency_pep_508("demo", path, requirement, requirement_expected)
+
+
+@pytest.mark.parametrize(
+    "name,path,extras,constraint,expected",
+    [
+        (
+            "my-package",
+            SAMPLE_PROJECT,
+            None,
+            None,
+            f"my-package (*) @ {SAMPLE_PROJECT.as_uri()}",
+        ),
+        (
+            "my-package",
+            SAMPLE_PROJECT,
+            ["db"],
+            "1.2",
+            f"my-package[db] (1.2) @ {SAMPLE_PROJECT.as_uri()}",
+        ),
+    ],
+)
+def test_directory_dependency_string_representation(
+    name: str,
+    path: Path,
+    extras: list[str] | None,
+    constraint: str | None,
+    expected: str,
+) -> None:
+    dependency = DirectoryDependency(name=name, path=path, extras=extras)
+    if constraint:
+        dependency.constraint = constraint  # type: ignore[assignment]
+    assert str(dependency) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/packages/test_file_dependency.py
+++ b/tests/packages/test_file_dependency.py
@@ -188,3 +188,35 @@ def test_file_dependency_pep_508_extras(mocker: MockerFixture) -> None:
         requirement,
         f'demo[bar,foo] @ {rel_path.as_posix()} ; sys_platform == "linux"',
     )
+
+
+@pytest.mark.parametrize(
+    "name,path,extras,constraint,expected",
+    [
+        (
+            "demo",
+            DIST_PATH / TEST_FILE,
+            None,
+            None,
+            f"demo (*) @ {(DIST_PATH / TEST_FILE).as_uri()}",
+        ),
+        (
+            "demo",
+            DIST_PATH / TEST_FILE,
+            ["foo"],
+            "1.2",
+            f"demo[foo] (1.2) @ {(DIST_PATH / TEST_FILE).as_uri()}",
+        ),
+    ],
+)
+def test_file_dependency_string_representation(
+    name: str,
+    path: Path,
+    extras: list[str] | None,
+    constraint: str | None,
+    expected: str,
+) -> None:
+    dependency = FileDependency(name=name, path=path, extras=extras)
+    if constraint:
+        dependency.constraint = constraint  # type: ignore[assignment]
+    assert str(dependency) == expected

--- a/tests/packages/test_url_dependency.py
+++ b/tests/packages/test_url_dependency.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from poetry.core.packages.url_dependency import URLDependency
 from poetry.core.version.markers import SingleMarker
 
@@ -44,3 +46,35 @@ def test_to_pep_508_with_marker() -> None:
         ' ; sys_platform == "linux"'
     )
     assert dependency.to_pep_508() == expected
+
+
+@pytest.mark.parametrize(
+    "name,url,extras,constraint,expected",
+    [
+        (
+            "example",
+            "https://example.org/example.whl",
+            None,
+            None,
+            "example (*) @ https://example.org/example.whl",
+        ),
+        (
+            "example",
+            "https://example.org/example.whl",
+            ["foo"],
+            "1.2",
+            "example[foo] (1.2) @ https://example.org/example.whl",
+        ),
+    ],
+)
+def test_directory_dependency_string_representation(
+    name: str,
+    url: str,
+    extras: list[str] | None,
+    constraint: str | None,
+    expected: str,
+) -> None:
+    dependency = URLDependency(name=name, url=url, extras=extras)
+    if constraint:
+        dependency.constraint = constraint  # type: ignore[assignment]
+    assert str(dependency) == expected

--- a/tests/packages/test_vcs_dependency.py
+++ b/tests/packages/test_vcs_dependency.py
@@ -71,6 +71,43 @@ def test_to_pep_508_in_extras() -> None:
     assert dependency.to_pep_508() == expected
 
 
+@pytest.mark.parametrize(
+    "name,source,branch,extras,constraint,expected",
+    [
+        (
+            "example",
+            "https://example.org/example.git",
+            "main",
+            None,
+            None,
+            "example (*) @ git+https://example.org/example.git@main",
+        ),
+        (
+            "example",
+            "https://example.org/example.git",
+            "main",
+            ["foo"],
+            "1.2",
+            "example[foo] (1.2) @ git+https://example.org/example.git@main",
+        ),
+    ],
+)
+def test_directory_dependency_string_representation(
+    name: str,
+    source: str,
+    branch: str,
+    extras: list[str] | None,
+    constraint: str | None,
+    expected: str,
+) -> None:
+    dependency = VCSDependency(
+        name=name, vcs="git", source=source, branch=branch, extras=extras
+    )
+    if constraint:
+        dependency.constraint = constraint  # type: ignore[assignment]
+    assert str(dependency) == expected
+
+
 @pytest.mark.parametrize("groups", [["main"], ["dev"]])
 def test_category(groups: list[str]) -> None:
     dependency = VCSDependency(


### PR DESCRIPTION
- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

In python-poetry/poetry-core#103 `Dependency.__str__` has been changed to return `base_pep_508_name`. Each sub class of `Dependency` still has its own (inconsistent) `__str__` implementation. For example extras are not included, which can be confusing/annoying. Further, `URLDependency` does not even include the url but only hard-coded "url".

I was thinking about only returning `base_pep_508_name`, but that does not include the constraint for direct origin dependencies and thus makes debugging more difficult. Since `__str__` is especially used in (debug) prints, it should be ok not to return a PEP 508 compliant string. (At least, we didn't do that before.) Thus, `base_pep_508_name` enriched with constraint is returned. That way, we can avoid multiple implementations and still have all relevant information.