### PR TITLE
Follow most recent packaging specification for wheel name normalization

### DIFF
--- a/src/poetry/core/masonry/utils/helpers.py
+++ b/src/poetry/core/masonry/utils/helpers.py
@@ -29,5 +29,8 @@ def escape_version(version: str) -> str:
 
 
 def escape_name(name: str) -> str:
-    """Escaped wheel name as specified in https://packaging.python.org/en/latest/specifications/binary-distribution-format/#escaping-and-unicode."""
+    """
+    Escaped wheel name as specified in https://packaging.python.org/en/latest/specifications/binary-distribution-format/#escaping-and-unicode.
+    This method should only be used for the generation of wheels, and not for the artifact package names.
+    """
     return re.sub(r"[-_.]+", "_", name, flags=re.UNICODE).lower()

--- a/src/poetry/core/masonry/utils/helpers.py
+++ b/src/poetry/core/masonry/utils/helpers.py
@@ -29,5 +29,5 @@ def escape_version(version: str) -> str:
 
 
 def escape_name(name: str) -> str:
-    """Escaped wheel name as specified in :pep:`427#escaping-and-unicode`."""
-    return re.sub(r"[^\w\d.]+", "_", name, flags=re.UNICODE)
+    """Escaped wheel name as specified in https://packaging.python.org/en/latest/specifications/binary-distribution-format/#escaping-and-unicode."""
+    return re.sub(r"[-_.]+", "_", name, flags=re.UNICODE).lower()

--- a/src/poetry/core/masonry/utils/helpers.py
+++ b/src/poetry/core/masonry/utils/helpers.py
@@ -31,6 +31,6 @@ def escape_version(version: str) -> str:
 def escape_name(name: str) -> str:
     """
     Escaped wheel name as specified in https://packaging.python.org/en/latest/specifications/binary-distribution-format/#escaping-and-unicode.
-    This method should only be used for the generation of wheels, and not for the artifact package names.
+    This function should only be used for the generation of artifact names, and not to normalize or filter existing artifact names.
     """
     return re.sub(r"[-_.]+", "_", name, flags=re.UNICODE).lower()

--- a/tests/masonry/utils/test_helpers.py
+++ b/tests/masonry/utils/test_helpers.py
@@ -28,9 +28,9 @@ def test_escape_version(version: str, expected: str) -> None:
     [
         ("foo", "foo"),
         ("foo-bar", "foo_bar"),
-        ("FOO-bAr", "FOO_bAr"),
-        ("foo.bar", "foo.bar"),
-        ("foo123-ba---.r", "foo123_ba_.r"),
+        ("FOO-bAr", "foo_bar"),
+        ("foo.bar", "foo_bar"),
+        ("foo123-ba---.r", "foo123_ba_r"),
     ],
 )
 def test_escape_name(name: str, expected: str) -> None:

--- a/tests/masonry/utils/test_helpers.py
+++ b/tests/masonry/utils/test_helpers.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from poetry.core.masonry.utils.helpers import escape_name
+from poetry.core.masonry.utils.helpers import escape_version
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        ("1.2.3", "1.2.3"),
+        ("1.2.3_1", "1.2.3_1"),
+        ("1.2.3-1", "1.2.3_1"),
+        ("1.2.3-1", "1.2.3_1"),
+        ("2022.2", "2022.2"),
+        ("12.20.12-----451---14-1-4-41", "12.20.12_451_14_1_4_41"),
+        ("1.0b2.dev1", "1.0b2.dev1"),
+        ("1.0+abc.7", "1.0+abc.7"),
+    ],
+)
+def test_escape_version(version: str, expected: str) -> None:
+    assert escape_version(version) == expected
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("foo", "foo"),
+        ("foo-bar", "foo_bar"),
+        ("FOO-bAr", "FOO_bAr"),
+        ("foo.bar", "foo.bar"),
+        ("foo123-ba---.r", "foo123_ba_.r"),
+    ],
+)
+def test_escape_name(name: str, expected: str) -> None:
+    assert escape_name(name) == expected


### PR DESCRIPTION
Highlighted by https://github.com/python-poetry/poetry/issues/5782 and looking into PyPA [packaging specification](https://packaging.python.org/en/latest/specifications/binary-distribution-format/#escaping-and-unicode) that supersedes [PEP 427](https://peps.python.org/pep-0427/):
> In distribution names, any run of `-_.` characters (HYPHEN-MINUS, LOW LINE and FULL STOP) should be replaced with `_` (LOW LINE), and uppercase characters should be replaced with corresponding lowercase ones. This is equivalent to [PEP 503](https://www.python.org/dev/peps/pep-0503) normalisation followed by replacing `-` with `_`. Tools consuming wheels must be prepared to accept `.` (FULL STOP) and uppercase letters, however, as these were allowed by an earlier version of this specification.

So it looks like the regex we use to escape wheel name should be updated to what [PEP 503 defines](https://peps.python.org/pep-0503/#normalized-names), with the minor change of using `_` for the replacement character instead of `-`.

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.