### PR TITLE
version: fix allows for local and post releases according to PEP 440

### DIFF
--- a/src/poetry/core/semver/version.py
+++ b/src/poetry/core/semver/version.py
@@ -86,12 +86,6 @@ class Version(PEP440Version, VersionRangeConstraint):
         # allow weak equality to allow `3.0.0+local.1` for `3.0.0`
         if not _this.is_local() and _other.is_local():
             _other = _other.without_local()
-        elif _this.is_local() and not _other.is_local():
-            _this = _this.without_local()
-
-        # allow weak equality to allow `3.0.0-1` for `3.0.0`
-        if not _this.is_postrelease() and _other.is_postrelease():
-            _other = _other.without_postrelease()
 
         return _this == _other
 

--- a/tests/semver/test_version.py
+++ b/tests/semver/test_version.py
@@ -122,25 +122,30 @@ def test_allows() -> None:
     assert not v.allows(Version.parse("1.3.3"))
     assert not v.allows(Version.parse("1.2.4"))
     assert not v.allows(Version.parse("1.2.3-dev"))
+    assert not v.allows(Version.parse("1.2.3-1"))
+    assert not v.allows(Version.parse("1.2.3-1+build"))
     assert v.allows(Version.parse("1.2.3+build"))
-    assert v.allows(Version.parse("1.2.3-1"))
-    assert v.allows(Version.parse("1.2.3-1+build"))
 
 
 def test_allows_with_local() -> None:
     v = Version.parse("1.2.3+build.1")
     assert v.allows(v)
+    assert not v.allows(Version.parse("1.2.3"))
     assert not v.allows(Version.parse("1.3.3"))
     assert not v.allows(Version.parse("1.2.3-dev"))
     assert not v.allows(Version.parse("1.2.3+build.2"))
-    assert v.allows(Version.parse("1.2.3-1"))
-    assert v.allows(Version.parse("1.2.3-1+build.1"))
+    # local version with a great number of segments will always compare as
+    # greater than a local version with fewer segments
+    assert not v.allows(Version.parse("1.2.3+build.1.0"))
+    assert not v.allows(Version.parse("1.2.3-1"))
+    assert not v.allows(Version.parse("1.2.3-1+build.1"))
 
 
 def test_allows_with_post() -> None:
     v = Version.parse("1.2.3-1")
     assert v.allows(v)
     assert not v.allows(Version.parse("1.2.3"))
+    assert not v.allows(Version.parse("1.2.3-2"))
     assert not v.allows(Version.parse("2.2.3"))
     assert not v.allows(Version.parse("1.2.3-dev"))
     assert not v.allows(Version.parse("1.2.3+build.2"))
@@ -190,7 +195,12 @@ def test_allows_any() -> None:
         (
             Version.parse("1.2.3"),
             Version.parse("1.2.3.post0"),
-            Version.parse("1.2.3.post0"),
+            EmptyConstraint(),
+        ),
+        (
+            Version.parse("1.2.3"),
+            Version.parse("1.2.3+local"),
+            Version.parse("1.2.3+local"),
         ),
     ],
 )


### PR DESCRIPTION
Resolves: python-poetry/poetry#4729

Partially overlaps with #379 but only considers simple version (not ranges).

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

According to PEP 440:

> For example, given the version 1.1.post1, the following clauses would match or not as shown:
> 
> == 1.1        # Not equal, so 1.1.post1 does not match clause
> == 1.1.post1  # Equal, so 1.1.post1 matches clause
> == 1.1.*      # Same prefix, so 1.1.post1 matches clause

and

> If the specified version identifier is a public version identifier (no local version label), then the local version label of any candidate versions MUST be ignored when matching versions.
> 
> If the specified version identifier is a local version identifier, then the local version labels of candidate versions MUST be considered when matching versions, with the public version identifier being matched as described above, and the local version label being checked for equivalence using a strict string equality comparison.