### PR TITLE
fix(flake8): drop F401 from __init__.py ignores

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -17,7 +17,6 @@ extend-ignore =
     # ANN102: Missing type annotation for cls in classmethod
     ANN102,
 per-file-ignores =
-    __init__.py:F401
     tests/test_*:ANN201
     tests/**/test_*:ANN201
 exclude =


### PR DESCRIPTION
Drop F401 since it came over from Poetry but we've always used an implicit namespace package.