### PR TITLE
Prerequisites for supporting yanked releases (PEP 592)

### DIFF
--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -59,6 +59,7 @@ class Package(PackageSpecification):
         source_subdirectory: str | None = None,
         features: Iterable[str] | None = None,
         develop: bool = False,
+        yanked: str | bool = False,
     ) -> None:
         """
         Creates a new in memory package.
@@ -116,6 +117,8 @@ class Package(PackageSpecification):
         self.root_dir: Path | None = None
 
         self.develop = develop
+
+        self._yanked = yanked
 
     @property
     def name(self) -> str:
@@ -367,6 +370,16 @@ class Package(PackageSpecification):
             DeprecationWarning,
         )
         self.readmes = (path,)
+
+    @property
+    def yanked(self) -> bool:
+        return isinstance(self._yanked, str) or bool(self._yanked)
+
+    @property
+    def yanked_reason(self) -> str:
+        if isinstance(self._yanked, str):
+            return self._yanked
+        return ""
 
     def is_prerelease(self) -> bool:
         return self._version.is_unstable()

--- a/src/poetry/core/packages/utils/link.py
+++ b/src/poetry/core/packages/utils/link.py
@@ -14,6 +14,7 @@ class Link:
         url: str,
         requires_python: str | None = None,
         metadata: str | bool | None = None,
+        yanked: str | bool = False,
     ) -> None:
         """
         Object representing a parsed link from https://pypi.python.org/simple/*
@@ -29,6 +30,11 @@ class Link:
             of the Core Metadata file. This may be specified by a
             data-dist-info-metadata attribute in the HTML link tag, as described
             in PEP 658.
+        yanked:
+            False, if the data-yanked attribute is not present.
+            A string, if the data-yanked attribute has a string value.
+            True, if the data-yanked attribute is present but has no value.
+            According to PEP 592.
         """
 
         # url can be a UNC windows share
@@ -44,6 +50,7 @@ class Link:
             )
 
         self._metadata = metadata
+        self._yanked = yanked
 
     def __str__(self) -> str:
         if self.requires_python:
@@ -213,3 +220,13 @@ class Link:
             return False
 
         return True
+
+    @property
+    def yanked(self) -> bool:
+        return isinstance(self._yanked, str) or bool(self._yanked)
+
+    @property
+    def yanked_reason(self) -> str:
+        if isinstance(self._yanked, str):
+            return self._yanked
+        return ""

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -502,3 +502,28 @@ def test_package_satisfies(
     package: Package, dependency: Dependency, ignore_source_type: bool, result: bool
 ) -> None:
     assert package.satisfies(dependency, ignore_source_type) == result
+
+
+def test_package_pep592_default_not_yanked() -> None:
+    package = Package("foo", "1.0")
+
+    assert not package.yanked
+    assert package.yanked_reason == ""
+
+
+@pytest.mark.parametrize(
+    ("yanked", "expected_yanked", "expected_yanked_reason"),
+    [
+        (True, True, ""),
+        (False, False, ""),
+        ("the reason", True, "the reason"),
+        ("", True, ""),
+    ],
+)
+def test_package_pep592_yanked(
+    yanked: str | bool, expected_yanked: bool, expected_yanked_reason: str
+) -> None:
+    package = Package("foo", "1.0", yanked=yanked)
+
+    assert package.yanked == expected_yanked
+    assert package.yanked_reason == expected_yanked_reason

--- a/tests/packages/utils/test_utils_link.py
+++ b/tests/packages/utils/test_utils_link.py
@@ -118,3 +118,28 @@ def test_package_link_pep653_non_hash_metadata_value(
 
     assert not link.metadata_hash
     assert not link.metadata_hash_name
+
+
+def test_package_link_pep592_default_not_yanked() -> None:
+    link = make_url(ext="whl")
+
+    assert not link.yanked
+    assert link.yanked_reason == ""
+
+
+@pytest.mark.parametrize(
+    ("yanked", "expected_yanked", "expected_yanked_reason"),
+    [
+        (True, True, ""),
+        (False, False, ""),
+        ("the reason", True, "the reason"),
+        ("", True, ""),
+    ],
+)
+def test_package_link_pep592_yanked(
+    yanked: str | bool, expected_yanked: bool, expected_yanked_reason: str
+) -> None:
+    link = Link("https://example.org", yanked=yanked)
+
+    assert link.yanked == expected_yanked
+    assert link.yanked_reason == expected_yanked_reason


### PR DESCRIPTION
Related to python-poetry/poetry#2453

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Prerequisites for support of yanked releases in poetry-core.