### PR TITLE
fix(factory): safe get `extras` in scripts and config

### DIFF
--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -407,13 +407,15 @@ class Factory:
             # Checking for scripts with extras
             if "scripts" in config:
                 scripts = config["scripts"]
+                config_extras = config.get("extras", {})
+
                 for name, script in scripts.items():
                     if not isinstance(script, dict):
                         continue
 
-                    extras = script["extras"]
+                    extras = script.get("extras", [])
                     for extra in extras:
-                        if extra not in config["extras"]:
+                        if extra not in config_extras:
                             result["errors"].append(
                                 f'Script "{name}" requires extra "{extra}" which is not'
                                 " defined."

--- a/tests/fixtures/project_failing_strict_validation/pyproject.toml
+++ b/tests/fixtures/project_failing_strict_validation/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.poetry]
+readme = ["README.rst", "README_WITH_ANOTHER_EXTENSION.md"]
+
+[tool.poetry.dependencies]
+python = "*"
+pathlib2 = { version = "^2.2", python = "3.7", allows-prereleases = true }
+
+[tool.poetry.scripts]
+a_script_with_unknown_extra = { reference = "a_script_with_unknown_extra.py", type = "file", extras = ["foo"] }
+a_script_without_extras = { reference = "a_script_without_extras.py", type = "file" }
+a_script_with_empty_extras = { reference = "a_script_with_empty_extras.py", type = "file", extras = [] }
+another_script = "another_script:main"

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -191,6 +191,49 @@ def test_validate_fails() -> None:
     assert Factory.validate(content) == {"errors": [expected], "warnings": []}
 
 
+def test_validate_without_strict_fails_only_non_strict() -> None:
+    project_failing_strict_validation = TOMLFile(
+        fixtures_dir / "project_failing_strict_validation" / "pyproject.toml"
+    )
+    doc: dict[str, Any] = project_failing_strict_validation.read()
+    content = doc["tool"]["poetry"]
+
+    assert Factory.validate(content) == {
+        "errors": [
+            "'name' is a required property",
+            "'version' is a required property",
+            "'description' is a required property",
+        ],
+        "warnings": [],
+    }
+
+
+def test_validate_strict_fails_strict_and_non_strict() -> None:
+    project_failing_strict_validation = TOMLFile(
+        fixtures_dir / "project_failing_strict_validation" / "pyproject.toml"
+    )
+    doc: dict[str, Any] = project_failing_strict_validation.read()
+    content = doc["tool"]["poetry"]
+
+    assert Factory.validate(content, strict=True) == {
+        "errors": [
+            "'name' is a required property",
+            "'version' is a required property",
+            "'description' is a required property",
+            'Script "a_script_with_unknown_extra" requires extra "foo" which is not'
+            " defined.",
+            "Declared README files must be of same type: found text/markdown,"
+            " text/x-rst",
+        ],
+        "warnings": [
+            "A wildcard Python dependency is ambiguous. Consider specifying a more"
+            " explicit one.",
+            'The "pathlib2" dependency specifies the "allows-prereleases" property,'
+            ' which is deprecated. Use "allow-prereleases" instead.',
+        ],
+    }
+
+
 def test_strict_validation_success_on_multiple_readme_files() -> None:
     with_readme_files = TOMLFile(fixtures_dir / "with_readme_files" / "pyproject.toml")
     doc: dict[str, Any] = with_readme_files.read()


### PR DESCRIPTION
Resolves: python-poetry/poetry#4665

- [x] Added **tests** for changed code.
- [ ] ~Updated **documentation** for changed code.~ Not applicable

According to:
https://github.com/python-poetry/poetry-core/blob/3bf7ad0f1dc2b1a5cabe4bb58cf7e1c6d832870d/src/poetry/core/json/schemas/poetry-schema.json#L6-L10
 https://github.com/python-poetry/poetry-core/blob/3bf7ad0f1dc2b1a5cabe4bb58cf7e1c6d832870d/src/poetry/core/json/schemas/poetry-schema.json#L597-L600

- `extras` is not required in the main config (under `poetry.tools.extras`)
- `extras` is not required when defining a script (under `poetry.tools.scripts`) using the syntax introduced in https://github.com/python-poetry/poetry-core/pull/40

Despite that, `Factory.validate` assumes that `extras` key is always present for both cases by hard accessing it, making the script definition fail for 2 possible reasons:
- `poetry.tool.extras` is not defined at all
- a script defined as a dict doesn't define an `extras` key

This PR fixes those 2 use cases by soft accessing the key and defaulting to an empty list/dict.
It also adds tests to validate the errors/warnings that could happen when using the `strict` flag, since it was lacking some coverage.