### PR TITLE
Do not consider constraints when checking for equality of direct origi…

### DIFF
--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -574,7 +574,9 @@ class Dependency(PackageSpecification):
         if not isinstance(other, Dependency):
             return NotImplemented
 
-        return super().__eq__(other) and self._constraint == other.constraint
+        return super().__eq__(other) and (
+            self._constraint == other.constraint or self.is_direct_origin()
+        )
 
     def __hash__(self) -> int:
         # don't include _constraint in hash because it is mutable!

--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -574,6 +574,11 @@ class Dependency(PackageSpecification):
         if not isinstance(other, Dependency):
             return NotImplemented
 
+        # "constraint" is implicitly given for direct origin dependencies and might not
+        # be set yet ("*"). Thus, it shouldn't be used to determine if two direct origin
+        # dependencies are equal.
+        # Calling is_direct_origin() for one dependency is sufficient because
+        # super().__eq__() returns False for different origins.
         return super().__eq__(other) and (
             self._constraint == other.constraint or self.is_direct_origin()
         )

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -362,6 +362,34 @@ def test_create_from_pep_508_url_with_activated_extras() -> None:
 
 
 @pytest.mark.parametrize(
+    "dependency1, dependency2, expected",
+    [
+        (Dependency("a", "1.0"), Dependency("a", "1.0"), True),
+        (Dependency("a", "1.0"), Dependency("a", "1.0.1"), False),
+        (Dependency("a", "1.0"), Dependency("a1", "1.0"), False),
+        (Dependency("a", "1.0"), Dependency("a", "1.0", source_type="file"), False),
+        # constraint is implicitly given for direct origin dependencies,
+        # but might not be set
+        (
+            Dependency("a", "1.0", source_type="file"),
+            Dependency("a", "*", source_type="file"),
+            True,
+        ),
+        # constraint is not implicit for non direct origin dependencies
+        (Dependency("a", "1.0"), Dependency("a", "*"), False),
+        (
+            Dependency("a", "1.0", source_type="legacy"),
+            Dependency("a", "*", source_type="legacy"),
+            False,
+        ),
+    ],
+)
+def test_eq(dependency1: Dependency, dependency2: Dependency, expected: bool) -> None:
+    assert (dependency1 == dependency2) is expected
+    assert (dependency2 == dependency1) is expected
+
+
+@pytest.mark.parametrize(
     "attr_name, value",
     [
         ("constraint", "2.0"),


### PR DESCRIPTION
…n dependencies

Resolves: python-poetry/poetry#5902 and partially python-poetry/poetry#2415

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [n.a.] Added **tests** for changed code.
- [n.a.] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

An alternative solution to python-poetry/poetry#5902 as proposed in python-poetry/poetry#5903.

Currently poetry re-downloads direct origin packages multiple times during locking because the deferred cache used to store downloaded packages is indexed using a dependency object with an explicit constraint while the lookup is done with a dependency object with an unbounded constraint which do not test equal.

This PR solves that issue by changing the `__eq__` equality check for direct origin dependencies to not consider the constraint. This should pose no problems since direct origin dependencies pointing to the same origin implicitly have the same constraint.

Should I add a test for this or do we consider this an implementation detail for the sake of our current caching mechanism?