### PR TITLE
tests: xfail test_pip_install_no_binary on Python 3.7

### DIFF
--- a/tests/integration/test_pep517.py
+++ b/tests/integration/test_pep517.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -75,6 +77,12 @@ def test_pip_wheel_build(temporary_directory: Path, project_source_root: Path) -
     assert len(wheels) == 1
 
 
+@pytest.mark.xfail(
+    sys.version_info < (3, 8),
+    # see https://github.com/python/importlib_metadata/issues/392
+    reason="importlib-metadata can't be installed with --no-binary anymore",
+    strict=True,
+)
 def test_pip_install_no_binary(python: str, project_source_root: Path) -> None:
     subprocess_run(
         python,


### PR DESCRIPTION
The test case fails due to the new release of `setuptools_scm`, which now depends on `importlib-metadata` for `python_version < "3.8"`. Due to the fact that importlib-metadata itself depends on setuptools_scm, it's not possible anymore to `pip install --no-binary importlib-metadata` on Python 3.7.

Related to python/importlib_metadata#392