### PR TITLE
normalize python_versions on packages

### DIFF
--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -15,6 +15,7 @@ from typing import cast
 from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.core.packages.specification import PackageSpecification
 from poetry.core.packages.utils.utils import create_nested_marker
+from poetry.core.packages.utils.utils import get_python_constraint_from_marker
 from poetry.core.semver.helpers import parse_constraint
 from poetry.core.version.markers import parse_marker
 
@@ -255,10 +256,11 @@ class Package(PackageSpecification):
     @python_versions.setter
     def python_versions(self, value: str) -> None:
         self._python_versions = value
-        self._python_constraint = parse_constraint(value)
+        constraint = parse_constraint(value)
         self._python_marker = parse_marker(
-            create_nested_marker("python_version", self._python_constraint)
+            create_nested_marker("python_version", constraint)
         )
+        self._python_constraint = get_python_constraint_from_marker(self._python_marker)
 
     @property
     def python_constraint(self) -> VersionConstraint:

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -527,3 +527,14 @@ def test_package_pep592_yanked(
 
     assert package.yanked == expected_yanked
     assert package.yanked_reason == expected_yanked_reason
+
+
+def test_python_versions_are_normalized() -> None:
+    package = Package("foo", "1.2.3")
+    package.python_versions = ">3.6,<=3.10"
+
+    assert (
+        str(package.python_marker)
+        == 'python_version > "3.6" and python_version <= "3.10"'
+    )
+    assert str(package.python_constraint) == ">=3.7,<3.11"


### PR DESCRIPTION
Fixes https://github.com/python-poetry/poetry/issues/5591, because now the calculations at https://github.com/python-poetry/poetry/blob/8b640886ee39aee4a6c3208f39febf368dc32953/src/poetry/puzzle/provider.py#L456-L466 are correct.