### PR TITLE
fix without_extras() for marker unions

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -734,9 +734,11 @@ class MarkerUnion(BaseMarker):
                 continue
 
             marker = m.exclude(marker_name)
+            new_markers.append(marker)
 
-            if not marker.is_empty():
-                new_markers.append(marker)
+        if not new_markers:
+            # All markers were the excluded marker.
+            return AnyMarker()
 
         return self.of(*new_markers)
 

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -905,6 +905,8 @@ def test_parse_version_like_markers(marker: str, env: dict[str, str]) -> None:
             ' "pypy" or extra == "bar"',
             'python_version >= "3.6" or implementation_name == "pypy"',
         ),
+        ('extra == "foo"', ''),
+        ('extra == "foo" or extra == "bar"', ''),
     ],
 )
 def test_without_extras(marker: str, expected: str) -> None:

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -905,8 +905,8 @@ def test_parse_version_like_markers(marker: str, env: dict[str, str]) -> None:
             ' "pypy" or extra == "bar"',
             'python_version >= "3.6" or implementation_name == "pypy"',
         ),
-        ('extra == "foo"', ''),
-        ('extra == "foo" or extra == "bar"', ''),
+        ('extra == "foo"', ""),
+        ('extra == "foo" or extra == "bar"', ""),
     ],
 )
 def test_without_extras(marker: str, expected: str) -> None:


### PR DESCRIPTION
Fixes https://github.com/python-poetry/poetry/issues/5999

It's clearly inconsistent that `parse_marker('extra == "foo"').without_extras()` is `AnyMarker()` whereas `parse_marker('extra == "foo" or extra == "bar"').without_extras()` was `EmptyMarker()`.

This caused https://github.com/python-poetry/poetry/issues/5999 at https://github.com/python-poetry/poetry/blob/266e8d2b3b27454f88cc569269ca9ea842faf024/src/poetry/puzzle/provider.py#L743-#L748