### PR TITLE
Consistent hash

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -362,7 +362,7 @@ class SingleMarker(BaseMarker):
         return self._name == other.name and self._constraint == other.constraint
 
     def __hash__(self) -> int:
-        return hash((self._name, self._constraint_string))
+        return hash((self._name, self._constraint))
 
     def __str__(self) -> str:
         return f'{self._name} {self._operator} "{self._value}"'

--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -192,12 +192,12 @@ class SingleMarker(BaseMarker):
         self._constraint: BaseConstraint | VersionConstraint
         self._parser: Callable[[str], BaseConstraint | VersionConstraint]
         self._name = ALIASES.get(name, name)
-        self._constraint_string = str(constraint)
+        constraint_string = str(constraint)
 
         # Extract operator and value
-        m = self._CONSTRAINT_RE.match(self._constraint_string)
+        m = self._CONSTRAINT_RE.match(constraint_string)
         if m is None:
-            raise ValueError(f"Invalid marker '{self._constraint_string}'")
+            raise ValueError(f"Invalid marker '{constraint_string}'")
 
         self._operator = m.group(1)
         if self._operator is None:
@@ -227,11 +227,10 @@ class SingleMarker(BaseMarker):
 
                 self._constraint = self._parser(glue.join(versions))
             else:
-                self._constraint = self._parser(self._constraint_string)
+                self._constraint = self._parser(constraint_string)
         else:
             # if we have a in/not in operator we split the constraint
             # into a union/multi-constraint of single constraint
-            constraint_string = self._constraint_string
             if self._operator in {"in", "not in"}:
                 op, glue = ("==", " || ") if self._operator == "in" else ("!=", ", ")
                 values = re.split("[ ,]+", self._value)
@@ -242,13 +241,6 @@ class SingleMarker(BaseMarker):
     @property
     def name(self) -> str:
         return self._name
-
-    @property
-    def constraint_string(self) -> str:
-        if self._operator in {"in", "not in"}:
-            return f"{self._operator} {self._value}"
-
-        return self._constraint_string
 
     @property
     def constraint(self) -> BaseConstraint | VersionConstraint:

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -83,6 +83,13 @@ def test_single_marker() -> None:
     )
 
 
+def test_single_marker_normalisation() -> None:
+    m1 = SingleMarker("python_version", ">=3.6")
+    m2 = SingleMarker("python_version", ">= 3.6")
+    assert m1 == m2
+    assert hash(m1) == hash(m2)
+
+
 def test_single_marker_intersect() -> None:
     m = parse_marker('sys_platform == "darwin"')
 

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -24,27 +24,24 @@ def test_single_marker() -> None:
 
     assert isinstance(m, SingleMarker)
     assert m.name == "sys_platform"
-    assert m.constraint_string == "==darwin"
+    assert str(m.constraint) == "darwin"
 
     m = parse_marker('python_version in "2.7, 3.0, 3.1"')
 
     assert isinstance(m, SingleMarker)
     assert m.name == "python_version"
-    assert m.constraint_string == "in 2.7, 3.0, 3.1"
     assert str(m.constraint) == ">=2.7.0,<2.8.0 || >=3.0.0,<3.2.0"
 
     m = parse_marker('"2.7" in python_version')
 
     assert isinstance(m, SingleMarker)
     assert m.name == "python_version"
-    assert m.constraint_string == "in 2.7"
     assert str(m.constraint) == ">=2.7.0,<2.8.0"
 
     m = parse_marker('python_version not in "2.7, 3.0, 3.1"')
 
     assert isinstance(m, SingleMarker)
     assert m.name == "python_version"
-    assert m.constraint_string == "not in 2.7, 3.0, 3.1"
     assert str(m.constraint) == "<2.7.0 || >=2.8.0,<3.0.0 || >=3.2.0"
 
     m = parse_marker(
@@ -54,10 +51,6 @@ def test_single_marker() -> None:
 
     assert isinstance(m, SingleMarker)
     assert m.name == "platform_machine"
-    assert (
-        m.constraint_string
-        == "in x86_64 X86_64 aarch64 AARCH64 ppc64le PPC64LE amd64 AMD64 win32 WIN32"
-    )
     assert (
         str(m.constraint)
         == "x86_64 || X86_64 || aarch64 || AARCH64 || ppc64le || PPC64LE || amd64 ||"
@@ -71,11 +64,6 @@ def test_single_marker() -> None:
 
     assert isinstance(m, SingleMarker)
     assert m.name == "platform_machine"
-    assert (
-        m.constraint_string
-        == "not in x86_64 X86_64 aarch64 AARCH64 ppc64le PPC64LE amd64 AMD64 win32"
-        " WIN32"
-    )
     assert (
         str(m.constraint)
         == "!=x86_64, !=X86_64, !=aarch64, !=AARCH64, !=ppc64le, !=PPC64LE, !=amd64,"


### PR DESCRIPTION
The `__eq__` and `__hash__` implementations on the SingleMarker did not use the same things - one of them looked at the `constraint` and the other at the `constraint_string`.  I've added a testcase demonstrating the difference.

Then I noticed that no-one actually uses the `constraint_string` anyway, so removed it.  I've done that in a separate commit in case it's controversial...