### PR TITLE
Remove unused code

### DIFF
--- a/src/poetry/core/utils/_compat.py
+++ b/src/poetry/core/utils/_compat.py
@@ -4,13 +4,3 @@ import sys
 
 
 WINDOWS = sys.platform == "win32"
-
-
-def list_to_shell_command(cmd: list[str]) -> str:
-    executable = cmd[0]
-
-    if " " in executable:
-        executable = f'"{executable}"'
-        cmd[0] = executable
-
-    return " ".join(cmd)

--- a/src/poetry/core/utils/helpers.py
+++ b/src/poetry/core/utils/helpers.py
@@ -7,7 +7,6 @@ import stat
 import tempfile
 import unicodedata
 
-from collections.abc import Mapping
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
@@ -98,14 +97,6 @@ def safe_rmtree(path: str | Path) -> None:
         return os.unlink(str(path))
 
     shutil.rmtree(path, onerror=_on_rm_error)
-
-
-def merge_dicts(d1: dict[Any, Any], d2: dict[Any, Any]) -> None:
-    for k in d2.keys():
-        if k in d1 and isinstance(d1[k], dict) and isinstance(d2[k], Mapping):
-            merge_dicts(d1[k], d2[k])
-        else:
-            d1[k] = d2[k]
 
 
 def readme_content_type(path: str | Path) -> str:

--- a/src/poetry/core/utils/helpers.py
+++ b/src/poetry/core/utils/helpers.py
@@ -11,7 +11,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 from typing import Iterator
-from typing import no_type_check
 
 from poetry.core.version.pep440 import PEP440Version
 
@@ -42,7 +41,6 @@ def temporary_directory(*args: Any, **kwargs: Any) -> Iterator[str]:
     safe_rmtree(name)
 
 
-@no_type_check
 def parse_requires(requires: str) -> list[str]:
     lines = requires.split("\n")
 
@@ -61,7 +59,7 @@ def parse_requires(requires: str) -> list[str]:
             # extras or conditional dependencies
             marker = line.lstrip("[").rstrip("]")
             if ":" not in marker:
-                extra, marker = marker, None
+                extra, marker = marker, ""
             else:
                 extra, marker = marker.split(":")
 


### PR DESCRIPTION
`list_to_shell_command()` and `merge_dicts()` are both unused here, and duplicated over in poetry.

While I was in the area I removed the "don't typecheck me" flag from `parse_requires()`.