### PR TITLE
version: fix "next_" methods and increase test coverage

### DIFF
--- a/tests/semver/test_version.py
+++ b/tests/semver/test_version.py
@@ -293,11 +293,147 @@ def test_difference() -> None:
 @pytest.mark.parametrize(
     "version, expected",
     [
-        ("1.2.3", "1.2.3-dev.0"),
-        ("1.2.3-alpha.0", "1.2.3-alpha.0-dev.0"),
-        ("1.2.3-dev.0", "1.2.3-dev.1"),
+        ("1", "2"),
+        ("2!1", "2!2"),
+        ("1+local", "2"),
+        ("1.2", "2.0"),
+        ("1.2.3", "2.0.0"),
+        ("1.2.3.4", "2.0.0.0"),
+        ("1.dev0", "1"),
+        ("1.2.dev0", "2.0"),
+        ("1.post1", "2"),
+        ("1.2.post1", "2.0"),
+        ("1.post1.dev0", "2"),
+        ("1.2.post1.dev0", "2.0"),
+        ("1.a1", "1"),
+        ("1.2a1", "2.0"),
+        ("1.a1.post2", "1"),
+        ("1.2a1.post2", "2.0"),
+        ("1.a1.post2.dev0", "1"),
+        ("1.2a1.post2.dev0", "2.0"),
     ],
 )
-def test_next_devrelease(version: str, expected: str) -> None:
+def test_next_major(version: str, expected: str) -> None:
     v = Version.parse(version)
-    assert v.next_devrelease() == Version.parse(expected)
+    assert str(v.next_major()) == expected
+
+
+@pytest.mark.parametrize(
+    "version, expected",
+    [
+        ("1", "1.1"),
+        ("1.2", "1.3"),
+        ("2!1.2", "2!1.3"),
+        ("1.2+local", "1.3"),
+        ("1.2.3", "1.3.0"),
+        ("1.2.3.4", "1.3.0.0"),
+        ("1.dev0", "1"),
+        ("1.2dev0", "1.2"),
+        ("1.2.3dev0", "1.3.0"),
+        ("1.post1", "1.1"),
+        ("1.2.post1", "1.3"),
+        ("1.2.3.post1", "1.3.0"),
+        ("1.post1.dev0", "1.1"),
+        ("1.2.post1.dev0", "1.3"),
+        ("1.a1", "1"),
+        ("1.2a1", "1.2"),
+        ("1.2.3a1", "1.3.0"),
+        ("1.a1.post2", "1"),
+        ("1.2a1.post2", "1.2"),
+        ("1.2.3a1.post2", "1.3.0"),
+        ("1.a1.post2.dev0", "1"),
+        ("1.2a1.post2.dev0", "1.2"),
+        ("1.2.3a1.post2.dev0", "1.3.0"),
+    ],
+)
+def test_next_minor(version: str, expected: str) -> None:
+    v = Version.parse(version)
+    assert str(v.next_minor()) == expected
+
+
+@pytest.mark.parametrize(
+    "version, expected",
+    [
+        ("1", "1.0.1"),
+        ("1.2", "1.2.1"),
+        ("1.2.3", "1.2.4"),
+        ("2!1.2.3", "2!1.2.4"),
+        ("1.2.3+local", "1.2.4"),
+        ("1.2.3.4", "1.2.4.0"),
+        ("1.dev0", "1"),
+        ("1.2dev0", "1.2"),
+        ("1.2.3dev0", "1.2.3"),
+        ("1.2.3.4dev0", "1.2.4.0"),
+        ("1.post1", "1.0.1"),
+        ("1.2.post1", "1.2.1"),
+        ("1.2.3.post1", "1.2.4"),
+        ("1.post1.dev0", "1.0.1"),
+        ("1.2.post1.dev0", "1.2.1"),
+        ("1.2.3.post1.dev0", "1.2.4"),
+        ("1.a1", "1"),
+        ("1.2a1", "1.2"),
+        ("1.2.3a1", "1.2.3"),
+        ("1.2.3.4a1", "1.2.4.0"),
+        ("1.a1.post2", "1"),
+        ("1.2a1.post2", "1.2"),
+        ("1.2.3a1.post2", "1.2.3"),
+        ("1.2.3.4a1.post2", "1.2.4.0"),
+        ("1.a1.post2.dev0", "1"),
+        ("1.2a1.post2.dev0", "1.2"),
+        ("1.2.3a1.post2.dev0", "1.2.3"),
+        ("1.2.3.4a1.post2.dev0", "1.2.4.0"),
+    ],
+)
+def test_next_patch(version: str, expected: str) -> None:
+    v = Version.parse(version)
+    assert str(v.next_patch()) == expected
+
+
+@pytest.mark.parametrize(
+    "version, expected",
+    [
+        ("1.2a1", "1.2a2"),
+        ("2!1.2a1", "2!1.2a2"),
+        ("1.2dev0", "1.2a0"),
+        ("1.2a1.dev0", "1.2a1"),
+        ("1.2a1.post1.dev0", "1.2a2"),
+    ],
+)
+def test_next_prerelease(version: str, expected: str) -> None:
+    v = Version.parse(version)
+    assert str(v.next_prerelease()) == expected
+
+
+@pytest.mark.parametrize(
+    "version, expected",
+    [
+        ("1", "1.post0"),
+        ("1.post1", "1.post2"),
+        ("9!1.2.3.4", "9!1.2.3.4.post0"),
+        ("9!1.2.3.4.post2", "9!1.2.3.4.post3"),
+        ("1.dev0", "1.post0"),
+        ("1.post1.dev0", "1.post1"),
+        ("1a1", "1a1.post0"),
+        ("1a1.dev0", "1a1.post0"),
+        ("1a1.post2", "1a1.post3"),
+        ("1a1.post2.dev0", "1a1.post2"),
+    ],
+)
+def test_next_postrelease(version: str, expected: str) -> None:
+    v = Version.parse(version)
+    assert str(v.next_postrelease()) == expected
+
+
+def test_next_devrelease() -> None:
+    v = Version.parse("9!1.2.3a1.post2.dev3")
+    assert str(v.next_devrelease()) == "9!1.2.3a1.post2.dev4"
+
+
+def test_next_firstprerelease() -> None:
+    v = Version.parse("9!1.2.3a1.post2.dev3")
+    assert str(v.first_prerelease()) == "9!1.2.3a0"
+
+
+def test_next_firstdevrelease() -> None:
+    v = Version.parse("9!1.2.3a1.post2.dev3")
+    assert str(v.first_devrelease()) == "9!1.2.3a1.post2.dev0"


### PR DESCRIPTION
Fixes and tests for `next_major()`, `next_minor()`, etc.

Fixed bugs:

- handling of dev releases of post releases (next major of `1.post1.dev0` should be `2` instead of `1`, analogous: minor, patch, etc.
- `next_patch` for versions with more than 3 parts did not work
- deprecated `next_prerelease` for non pre releases due to its ambiguity and because the current implementation is just wrong for most cases (next pre release of `1.2` is not `1.2a0`)
- deprecated `next_devrelease` for non dev releases due to its ambiguity and because the current implementation is just wrong for most cases (next dev release of `1.2` is not `1.2.dev0`)
- introduced `first_devrelease` analogous to `first_prerelease`

One could argue that the next pre release can be determined by incrementing the last part of the version, so e.g. (`1` -> `2a0`, `1.2` -> `1.3a0`). But it might be better to be explicit. (The next pre release of `1.2` could also be `2.0a0` for example depending on the release plan.)