### PR TITLE
Improve type hints for Package.name etc.

### DIFF
--- a/src/poetry/core/masonry/metadata.py
+++ b/src/poetry/core/masonry/metadata.py
@@ -6,13 +6,15 @@ from poetry.core.utils.helpers import readme_content_type
 
 
 if TYPE_CHECKING:
+    from packaging.utils import NormalizedName
+
     from poetry.core.packages.package import Package
 
 
 class Metadata:
     metadata_version = "2.1"
     # version 1.0
-    name: str | None = None
+    name: NormalizedName | None = None
     version: str
     platforms: tuple[str, ...] = ()
     supported_platforms: tuple[str, ...] = ()

--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -23,6 +23,8 @@ from poetry.core.version.markers import parse_marker
 
 
 if TYPE_CHECKING:
+    from packaging.utils import NormalizedName
+
     from poetry.core.packages.constraints import BaseConstraint
     from poetry.core.packages.directory_dependency import DirectoryDependency
     from poetry.core.packages.file_dependency import FileDependency
@@ -96,7 +98,7 @@ class Dependency(PackageSpecification):
         self.source_name: str | None = None
 
     @property
-    def name(self) -> str:
+    def name(self) -> NormalizedName:
         return self._name
 
     @property

--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -21,6 +21,8 @@ from poetry.core.version.markers import parse_marker
 
 
 if TYPE_CHECKING:
+    from packaging.utils import NormalizedName
+
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.dependency_group import DependencyGroup
     from poetry.core.semver.version import Version
@@ -121,7 +123,7 @@ class Package(PackageSpecification):
         self._yanked = yanked
 
     @property
-    def name(self) -> str:
+    def name(self) -> NormalizedName:
         return self._name
 
     @property

--- a/src/poetry/core/packages/specification.py
+++ b/src/poetry/core/packages/specification.py
@@ -8,6 +8,8 @@ from typing import TypeVar
 
 
 if TYPE_CHECKING:
+    from packaging.utils import NormalizedName
+
     T = TypeVar("T", bound="PackageSpecification")
 
 
@@ -38,7 +40,7 @@ class PackageSpecification:
         self._features = frozenset(features)
 
     @property
-    def name(self) -> str:
+    def name(self) -> NormalizedName:
         return self._name
 
     @property

--- a/src/poetry/core/pyproject/tables.py
+++ b/src/poetry/core/pyproject/tables.py
@@ -4,8 +4,6 @@ from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from packaging.utils import canonicalize_name
-
 
 if TYPE_CHECKING:
     from poetry.core.packages.dependency import Dependency
@@ -44,13 +42,9 @@ class BuildSystem:
                     # https://docs.python.org/3/library/pathlib.html#methods
                     with suppress(OSError):
                         if path.is_file():
-                            dependency = FileDependency(
-                                name=canonicalize_name(path.name), path=path
-                            )
+                            dependency = FileDependency(name=path.name, path=path)
                         elif path.is_dir():
-                            dependency = DirectoryDependency(
-                                name=canonicalize_name(path.name), path=path
-                            )
+                            dependency = DirectoryDependency(name=path.name, path=path)
 
                 if dependency is None:
                     # skip since we could not determine requirement

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import cast
 
@@ -10,6 +11,10 @@ from poetry.core.factory import Factory
 from poetry.core.packages.vcs_dependency import VCSDependency
 from poetry.core.semver.helpers import parse_constraint
 from poetry.core.toml import TOMLFile
+
+
+if TYPE_CHECKING:
+    from poetry.core.packages.dependency import Dependency
 
 
 fixtures_dir = Path(__file__).parent / "fixtures"
@@ -37,7 +42,7 @@ def test_create_poetry() -> None:
     assert package.python_versions == "~2.7 || ^3.6"
     assert str(package.python_constraint) == ">=2.7,<2.8 || >=3.6,<4.0"
 
-    dependencies = {}
+    dependencies: dict[str, Dependency] = {}
     for dep in package.requires:
         dependencies[dep.name] = dep
 


### PR DESCRIPTION
When comparing names it's important to know if a name of a package/dependency is normalized or not. So let's tighten up type hints.