### PR TITLE
deprecate `Package.python_marker`

### DIFF
--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import warnings
 
 from typing import TYPE_CHECKING
 from typing import ClassVar
@@ -272,6 +273,21 @@ class Package(PackageSpecification):
     @property
     def python_constraint(self) -> VersionConstraint:
         return self._python_constraint
+
+    @property
+    def python_marker(self) -> BaseMarker:
+        from poetry.core.packages.utils.utils import create_nested_marker
+        from poetry.core.version.markers import parse_marker
+
+        warnings.warn(
+            "`python_marker` is deprecated and will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return parse_marker(
+            create_nested_marker("python_version", self._python_constraint)
+        )
 
     @property
     def license(self) -> License | None:

--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -12,9 +12,7 @@ from poetry.core.constraints.version import parse_constraint
 from poetry.core.constraints.version.exceptions import ParseConstraintError
 from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.core.packages.specification import PackageSpecification
-from poetry.core.packages.utils.utils import create_nested_marker
 from poetry.core.version.exceptions import InvalidVersionError
-from poetry.core.version.markers import parse_marker
 
 
 if TYPE_CHECKING:
@@ -113,7 +111,6 @@ class Package(PackageSpecification):
 
         self._python_versions = "*"
         self._python_constraint = parse_constraint("*")
-        self._python_marker: BaseMarker = AnyMarker()
 
         self.marker: BaseMarker = AnyMarker()
 
@@ -271,17 +268,10 @@ class Package(PackageSpecification):
 
         self._python_versions = value
         self._python_constraint = constraint
-        self._python_marker = parse_marker(
-            create_nested_marker("python_version", self._python_constraint)
-        )
 
     @property
     def python_constraint(self) -> VersionConstraint:
         return self._python_constraint
-
-    @property
-    def python_marker(self) -> BaseMarker:
-        return self._python_marker
 
     @property
     def license(self) -> License | None:

--- a/src/poetry/core/packages/project_package.py
+++ b/src/poetry/core/packages/project_package.py
@@ -6,7 +6,6 @@ from typing import Mapping
 from typing import Sequence
 
 from poetry.core.constraints.version import parse_constraint
-from poetry.core.version.markers import parse_marker
 
 
 if TYPE_CHECKING:
@@ -14,7 +13,6 @@ if TYPE_CHECKING:
     from poetry.core.packages.dependency import Dependency
 
 from poetry.core.packages.package import Package
-from poetry.core.packages.utils.utils import create_nested_marker
 
 
 class ProjectPackage(Package):
@@ -90,9 +88,6 @@ class ProjectPackage(Package):
                 ' is not a subset of "requires-python" in [project]'
                 f' "{self._requires_python}"'
             )
-        self._python_marker = parse_marker(
-            create_nested_marker("python_version", self._python_constraint)
-        )
 
     @property
     def version(self) -> Version:

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -30,6 +30,17 @@ def test_allows_prerelease(constraint: str, allows_prereleases: bool) -> None:
     assert dependency.allows_prereleases() == allows_prereleases
 
 
+def test_python_versions_are_made_precise() -> None:
+    dependency = Dependency("Django", "^1.23")
+    dependency.python_versions = ">3.6,<=3.10"
+
+    assert (
+        str(dependency.marker)
+        == 'python_full_version > "3.6.0" and python_full_version <= "3.10.0"'
+    )
+    assert str(dependency.python_constraint) == ">3.6,<=3.10"
+
+
 def test_to_pep_508() -> None:
     dependency = Dependency("Django", "^1.23")
 

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -600,17 +600,6 @@ def test_package_pep592_yanked(
     assert package.yanked_reason == expected_yanked_reason
 
 
-def test_python_versions_are_made_precise() -> None:
-    package = Package("foo", "1.2.3")
-    package.python_versions = ">3.6,<=3.10"
-
-    assert (
-        str(package.python_marker)
-        == 'python_full_version > "3.6.0" and python_full_version <= "3.10.0"'
-    )
-    assert str(package.python_constraint) == ">3.6,<=3.10"
-
-
 def test_cannot_update_package_version() -> None:
     package = Package("foo", "1.2.3")
     with pytest.raises(AttributeError):

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -600,6 +600,18 @@ def test_package_pep592_yanked(
     assert package.yanked_reason == expected_yanked_reason
 
 
+def test_python_versions_are_made_precise() -> None:
+    package = Package("foo", "1.2.3")
+    package.python_versions = ">3.6,<=3.10"
+
+    with pytest.warns(DeprecationWarning):
+        assert (
+            str(package.python_marker)
+            == 'python_full_version > "3.6.0" and python_full_version <= "3.10.0"'
+        )
+    assert str(package.python_constraint) == ">3.6,<=3.10"
+
+
 def test_cannot_update_package_version() -> None:
     package = Package("foo", "1.2.3")
     with pytest.raises(AttributeError):


### PR DESCRIPTION
remove with_python_versions() on the grounds that

-  it has had no callers since more than two years now https://github.com/python-poetry/poetry/commit/2433e0e7007edddf6c74635aae5fc4b3dfdcc617
- the naming convention `with_` (or `without_`) on the package is nowadays being used to mean "a clone of the package with (or without) this thing", this collides with and confuses that
- it's bizarre anyway