### PR TITLE
add setter for version on ProjectPackage

### DIFF
--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -66,7 +66,6 @@ class Package(PackageSpecification):
         """
         Creates a new in memory package.
         """
-        from poetry.core.semver.version import Version
         from poetry.core.version.markers import AnyMarker
 
         super().__init__(
@@ -79,12 +78,7 @@ class Package(PackageSpecification):
             features=features,
         )
 
-        if not isinstance(version, Version):
-            self._version = Version.parse(version)
-            self._pretty_version = pretty_version or version
-        else:
-            self._version = version
-            self._pretty_version = pretty_version or self._version.text
+        self._set_version(version, pretty_version)
 
         self.description = ""
 
@@ -215,6 +209,18 @@ class Package(PackageSpecification):
             for group in self._dependency_groups.values()
             for dependency in group.dependencies
         ]
+
+    def _set_version(
+        self, version: str | Version, pretty_version: str | None = None
+    ) -> None:
+        from poetry.core.semver.version import Version
+
+        if not isinstance(version, Version):
+            self._version = Version.parse(version)
+            self._pretty_version = pretty_version or version
+        else:
+            self._version = version
+            self._pretty_version = pretty_version or self._version.text
 
     def _get_author(self) -> dict[str, str | None]:
         if not self._authors:

--- a/src/poetry/core/packages/project_package.py
+++ b/src/poetry/core/packages/project_package.py
@@ -64,12 +64,27 @@ class ProjectPackage(Package):
         )
 
     @property
+    def version(self) -> Version:
+        # override version to make it settable
+        return super().version
+
+    @version.setter
+    def version(self, value: str | Version) -> None:
+        self._set_version(value)
+
+    @property
     def urls(self) -> dict[str, str]:
         urls = super().urls
 
         urls.update(self.custom_urls)
 
         return urls
+
+    def __hash__(self) -> int:
+        # The parent Package class's __hash__ incorporates the version because
+        # a Package's version is immutable. But a ProjectPackage's version is
+        # mutable. So call Package's parent hash function.
+        return super(Package, self).__hash__()
 
     def build_should_generate_setup(self) -> bool:
         return self.build_config.get("generate-setup-file", True)

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -13,8 +13,10 @@ from poetry.core.packages.dependency_group import DependencyGroup
 from poetry.core.packages.directory_dependency import DirectoryDependency
 from poetry.core.packages.file_dependency import FileDependency
 from poetry.core.packages.package import Package
+from poetry.core.packages.project_package import ProjectPackage
 from poetry.core.packages.url_dependency import URLDependency
 from poetry.core.packages.vcs_dependency import VCSDependency
+from poetry.core.semver.version import Version
 
 
 @pytest.fixture()
@@ -540,3 +542,24 @@ def test_python_versions_are_normalized() -> None:
         == 'python_version > "3.6" and python_version <= "3.10"'
     )
     assert str(package.python_constraint) == ">=3.7,<3.11"
+
+
+def test_cannot_update_package_version() -> None:
+    package = Package("foo", "1.2.3")
+    with pytest.raises(AttributeError):
+        package.version = "1.2.4"  # type: ignore[misc,assignment]
+
+
+def test_project_package_version_update_string() -> None:
+    package = ProjectPackage("foo", "1.2.3")
+    # TODO: I could use some help deciding what to do about mypy here. The
+    # setter accepts both str and Version, even though the property is always a
+    # Version.
+    package.version = "1.2.4"  # type: ignore[assignment]
+    assert package.version.text == "1.2.4"
+
+
+def test_project_package_version_update_version() -> None:
+    package = ProjectPackage("foo", "1.2.3")
+    package.version = Version.parse("1.2.4")
+    assert package.version.text == "1.2.4"

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -552,9 +552,6 @@ def test_cannot_update_package_version() -> None:
 
 def test_project_package_version_update_string() -> None:
     package = ProjectPackage("foo", "1.2.3")
-    # TODO: I could use some help deciding what to do about mypy here. The
-    # setter accepts both str and Version, even though the property is always a
-    # Version.
     package.version = "1.2.4"  # type: ignore[assignment]
     assert package.version.text == "1.2.4"
 
@@ -563,3 +560,17 @@ def test_project_package_version_update_version() -> None:
     package = ProjectPackage("foo", "1.2.3")
     package.version = Version.parse("1.2.4")
     assert package.version.text == "1.2.4"
+
+
+def test_project_package_hash_not_changed_when_version_is_changed() -> None:
+    package = ProjectPackage("foo", "1.2.3")
+    package_hash = hash(package)
+    package_clone = package.clone()
+    assert package == package_clone
+    assert hash(package) == hash(package_clone)
+
+    package.version = Version.parse("1.2.4")
+
+    assert hash(package) == package_hash, "Hash must not change!"
+    assert hash(package_clone) == package_hash
+    assert package != package_clone


### PR DESCRIPTION
This enables support for dynamically setting the package version
(e.g., from a plugin)

Resolves: python-poetry/poetry#5493

Resolves: python-poetry#<!-- add issue number/link here -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
