### PR TITLE
vcs_dependency: set implicit source reference

### DIFF
--- a/src/poetry/core/packages/vcs_dependency.py
+++ b/src/poetry/core/packages/vcs_dependency.py
@@ -42,7 +42,7 @@ class VCSDependency(Dependency):
             allows_prereleases=True,
             source_type=self._vcs.lower(),
             source_url=self._source,
-            source_reference=branch or tag or rev,
+            source_reference=branch or tag or rev or "HEAD",
             source_resolved_reference=resolved_rev,
             source_subdirectory=directory,
             extras=extras,


### PR DESCRIPTION
Resolves: python-poetry/poetry#2325

When a vcs dependency without a reference (`branch`, `tag` or `rev`) in pyproject.toml is locked, `source_reference` is implicitly set to `HEAD`. Unfortunately, this has the effect that the requested dependency (without `source_reference`) and the locked dependency (with `source_reference`) are not considered equal. This in turn has the effect, that the latest version instead of the locked version is installed.

Downstream test: python-poetry/poetry#6228

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
