### PR TITLE
Add missing = for subdirectory fragment

### DIFF
--- a/src/poetry/core/packages/vcs_dependency.py
+++ b/src/poetry/core/packages/vcs_dependency.py
@@ -117,7 +117,7 @@ class VCSDependency(Dependency):
             requirement += f"@{self.reference}"
 
         if self._directory:
-            requirement += f"#subdirectory{self._directory}"
+            requirement += f"#subdirectory={self._directory}"
 
         return requirement
 


### PR DESCRIPTION
Missing equal sign prevented pip from installing a package with subdirectory.

Sample pyproject.toml

```
[tool.poetry]
name = "reprod"
version = "0.1.0"
description=""
authors=["John Smith <john@example.com>"]
readme = "README.md"

[tool.poetry.dependencies]
python = "^3.7"
pycocotools = {git = "https://github.com/ashnair1/cocoapi.git", subdirectory = "PythonAPI", branch="master"}

[build-system]
requires = ["poetry-core>=1.1.0rc2"]
build-backend = "poetry.core.masonry.api"
```

Running `pip install .` resulted in the following error:
```
Processing /home/ash/reprod
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting pycocotools@ git+https://github.com/ashnair1/cocoapi.git@master#subdirectoryPythonAPI
  Cloning https://github.com/ashnair1/cocoapi.git (to revision master) to /tmp/pip-install-pepde8j5/pycocotools
  Running command git clone --filter=blob:none --quiet https://github.com/ashnair1/cocoapi.git /tmp/pip-install-pepde8j5/pycocotools
  Resolved https://github.com/ashnair1/cocoapi.git to commit 2ab05524360647addb03d0d347288cda2b41b392
ERROR: pycocotools@ git+https://github.com/ashnair1/cocoapi.git@master#subdirectoryPythonAPI from git+https://github.com/ashnair1/cocoapi.git@master#subdirectoryPythonAPI (from reprod==0.1.0) does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found.
```


Whereas with this PR

```
[tool.poetry]
name = "reprod"
version = "0.1.0"
description=""
authors=["John Smith <john@example.com>"]
readme = "README.md"

[tool.poetry.dependencies]
python = "^3.7"
pycocotools = {git = "https://github.com/ashnair1/cocoapi.git", subdirectory = "PythonAPI", branch="master"}

[build-system]
requires = ["poetry-core @ git+https://github.com/ashnair1/poetry-core.git@subdir-fix"]
build-backend = "poetry.core.masonry.api"
```
Installation works as expected

```
Processing /home/ash/reprod/
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting pycocotools@ git+https://github.com/ashnair1/cocoapi.git@master#subdirectory=PythonAPI
  Cloning https://github.com/ashnair1/cocoapi.git (to revision master) to /tmp/pip-install-kb47uwak/pycocotools
  Running command git clone --filter=blob:none --quiet https://github.com/ashnair1/cocoapi.git /tmp/pip-install-kb47uwak/pycocotools
  Resolved https://github.com/ashnair1/cocoapi.git to commit 2ab05524360647addb03d0d347288cda2b41b392
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: numpy in /home/ashwin/anaconda3/lib/python3.7/site-packages (from pycocotools@ git+https://github.com/ashnair1/cocoapi.git@master#subdirectory=PythonAPI->reprod==0.1.0) (1.21.5)
Requirement already satisfied: matplotlib>=2.1.0 in /home/ashwin/anaconda3/lib/python3.7/site-packages (from pycocotools@ git+https://github.com/ashnair1/cocoapi.git@master#subdirectory=PythonAPI->reprod==0.1.0) (3.4.3)
Requirement already satisfied: cycler>=0.10 in /home/ashwin/anaconda3/lib/python3.7/site-packages (from matplotlib>=2.1.0->pycocotools@ git+https://github.com/ashnair1/cocoapi.git@master#subdirectory=PythonAPI->reprod==0.1.0) (0.11.0)
Requirement already satisfied: pyparsing>=2.2.1 in /home/ashwin/anaconda3/lib/python3.7/site-packages (from matplotlib>=2.1.0->pycocotools@ git+https://github.com/ashnair1/cocoapi.git@master#subdirectory=PythonAPI->reprod==0.1.0) (3.0.7)
Requirement already satisfied: python-dateutil>=2.7 in /home/ashwin/anaconda3/lib/python3.7/site-packages (from matplotlib>=2.1.0->pycocotools@ git+https://github.com/ashnair1/cocoapi.git@master#subdirectory=PythonAPI->reprod==0.1.0) (2.8.2)
Requirement already satisfied: kiwisolver>=1.0.1 in /home/ashwin/anaconda3/lib/python3.7/site-packages (from matplotlib>=2.1.0->pycocotools@ git+https://github.com/ashnair1/cocoapi.git@master#subdirectory=PythonAPI->reprod==0.1.0) (1.4.2)
Requirement already satisfied: pillow>=6.2.0 in /home/ashwin/anaconda3/lib/python3.7/site-packages (from matplotlib>=2.1.0->pycocotools@ git+https://github.com/ashnair1/cocoapi.git@master#subdirectory=PythonAPI->reprod==0.1.0) (9.0.1)
Requirement already satisfied: typing-extensions in /home/ashwin/anaconda3/lib/python3.7/site-packages (from kiwisolver>=1.0.1->matplotlib>=2.1.0->pycocotools@ git+https://github.com/ashnair1/cocoapi.git@master#subdirectory=PythonAPI->reprod==0.1.0) (4.3.0)
Requirement already satisfied: six>=1.5 in /home/ashwin/anaconda3/lib/python3.7/site-packages (from python-dateutil>=2.7->matplotlib>=2.1.0->pycocotools@ git+https://github.com/ashnair1/cocoapi.git@master#subdirectory=PythonAPI->reprod==0.1.0) (1.16.0)
Building wheels for collected packages: reprod
  Building wheel for reprod (pyproject.toml) ... done
  Created wheel for reprod: filename=reprod-0.1.0-py3-none-any.whl size=1092 sha256=772b302d108297ef180043fa8fae5b9de3c1b44a3c3577a6b570a383b4cfdda5
  Stored in directory: /tmp/pip-ephem-wheel-cache-g4ndousl/wheels/48/a2/09/e3b73dda6723f648e807ad483de67950e69253932298d6470f
Successfully built reprod
Installing collected packages: reprod
  Attempting uninstall: reprod
    Found existing installation: reprod 0.1.0
    Uninstalling reprod-0.1.0:
      Successfully uninstalled reprod-0.1.0
Successfully installed reprod-0.1.0
```