### PR TITLE
release: bump to version 1.1.0rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [1.1.0rc3] - 2022-08-26
+
+### Fixed
+
+- Fixed an issue where a malformed URL was passed to pip when installing from a git subdirectory ([#451](https://github.com/python-poetry/poetry-core/pull/451)).
+
 ## [1.1.0rc2] - 2022-08-26
 
 ### Changed
@@ -355,7 +361,8 @@ No changes.
 - Fixed support for stub-only packages ([#28](https://github.com/python-poetry/core/pull/28)).
 
 
-[Unreleased]: https://github.com/python-poetry/poetry-core/compare/1.1.0rc2...main
+[Unreleased]: https://github.com/python-poetry/poetry-core/compare/1.1.0rc3...main
+[1.1.0rc3]: https://github.com/python-poetry/poetry-core/releases/tag/1.1.0rc3
 [1.1.0rc2]: https://github.com/python-poetry/poetry-core/releases/tag/1.1.0rc2
 [1.1.0rc1]: https://github.com/python-poetry/poetry-core/releases/tag/1.1.0rc1
 [1.1.0b3]: https://github.com/python-poetry/poetry-core/releases/tag/1.1.0b3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-core"
-version = "1.1.0rc2"
+version = "1.1.0rc3"
 description = "Poetry PEP 517 Build Backend"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 

--- a/src/poetry/core/__init__.py
+++ b/src/poetry/core/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 # this cannot presently be replaced with importlib.metadata.version as when building
 # itself, poetry-core is not available as an installed distribution.
-__version__ = "1.1.0rc2"
+__version__ = "1.1.0rc3"
 
 __vendor_site__ = (Path(__file__).parent / "_vendor").as_posix()
 


### PR DESCRIPTION
### Fixed

- Fixed an issue where a malformed URL was passed to pip when installing from a git subdirectory ([#451](https://github.com/python-poetry/poetry-core/pull/451)).