### PR TITLE
version: minor typing cleanup + increased test coverage

### DIFF
--- a/src/poetry/core/semver/version.py
+++ b/src/poetry/core/semver/version.py
@@ -166,7 +166,7 @@ class Version(PEP440Version, VersionRangeConstraint):
         major: int,
         minor: int | None = None,
         patch: int | None = None,
-        extra: int | tuple[int, ...] | None = None,
+        extra: int | tuple[int, ...] = (),
         pre: ReleaseTag | None = None,
         post: ReleaseTag | None = None,
         dev: ReleaseTag | None = None,
@@ -174,6 +174,8 @@ class Version(PEP440Version, VersionRangeConstraint):
         *,
         epoch: int = 0,
     ) -> Version:
+        if isinstance(extra, int):
+            extra = (extra,)
         return cls(
             release=Release(major=major, minor=minor, patch=patch, extra=extra),
             pre=pre,

--- a/src/poetry/core/version/pep440/segments.py
+++ b/src/poetry/core/version/pep440/segments.py
@@ -32,18 +32,17 @@ class Release:
     minor: int | None = dataclasses.field(default=None, compare=False)
     patch: int | None = dataclasses.field(default=None, compare=False)
     # some projects use non-semver versioning schemes, eg: 1.2.3.4
-    extra: int | tuple[int, ...] | None = dataclasses.field(default=None, compare=False)
+    extra: tuple[int, ...] = dataclasses.field(default=(), compare=False)
     precision: int = dataclasses.field(init=False, compare=False)
     text: str = dataclasses.field(init=False, compare=False)
     _compare_key: tuple[int, ...] = dataclasses.field(init=False, compare=True)
 
     def __post_init__(self) -> None:
-        if self.extra is None:
-            object.__setattr__(self, "extra", ())
-        elif not isinstance(self.extra, tuple):
-            object.__setattr__(self, "extra", (self.extra,))
-        assert isinstance(self.extra, tuple)
-
+        if self.extra:
+            if self.minor is None:
+                object.__setattr__(self, "minor", 0)
+            if self.patch is None:
+                object.__setattr__(self, "patch", 0)
         parts = [
             str(part)
             for part in [self.major, self.minor, self.patch, *self.extra]
@@ -66,14 +65,13 @@ class Release:
             major=parts[0],
             minor=parts[1] if len(parts) > 1 else None,
             patch=parts[2] if len(parts) > 2 else None,
-            extra=parts[3:] if len(parts) > 3 else (),
+            extra=parts[3:],
         )
 
     def to_string(self) -> str:
         return self.text
 
     def next_major(self) -> Release:
-        assert isinstance(self.extra, tuple)
         return dataclasses.replace(
             self,
             major=self.major + 1,
@@ -83,7 +81,6 @@ class Release:
         )
 
     def next_minor(self) -> Release:
-        assert isinstance(self.extra, tuple)
         return dataclasses.replace(
             self,
             major=self.major,
@@ -93,7 +90,6 @@ class Release:
         )
 
     def next_patch(self) -> Release:
-        assert isinstance(self.extra, tuple)
         return dataclasses.replace(
             self,
             major=self.major,

--- a/tests/version/pep440/test_segments.py
+++ b/tests/version/pep440/test_segments.py
@@ -7,20 +7,62 @@ from poetry.core.version.pep440 import ReleaseTag
 from poetry.core.version.pep440.segments import RELEASE_PHASE_NORMALIZATIONS
 
 
+def test_release_post_init_minor_and_patch() -> None:
+    release = Release(1, extra=(0,))
+    assert release.minor == 0
+    assert release.patch == 0
+
+
 @pytest.mark.parametrize(
     "parts,result",
     [
         ((1,), Release(1)),
         ((1, 2), Release(1, 2)),
         ((1, 2, 3), Release(1, 2, 3)),
-        ((1, 2, 3, 4), Release(1, 2, 3, 4)),
+        ((1, 2, 3, 4), Release(1, 2, 3, (4,))),
         ((1, 2, 3, 4, 5, 6), Release(1, 2, 3, (4, 5, 6))),
     ],
 )
-def test_pep440_release_segment_from_parts(
-    parts: tuple[int, ...], result: Release
-) -> None:
+def test_release_from_parts(parts: tuple[int, ...], result: Release) -> None:
     assert Release.from_parts(*parts) == result
+
+
+@pytest.mark.parametrize("precision", list(range(1, 6)))
+def test_release_precision(precision: int) -> None:
+    """
+    Semantically identical releases might have a different precision, e.g. 1 vs. 1.0
+    """
+    assert Release.from_parts(1, *[0] * (precision - 1)).precision == precision
+
+
+@pytest.mark.parametrize("precision", list(range(1, 6)))
+def test_release_text(precision: int) -> None:
+    increments = list(range(1, precision + 1))
+    zeros = [1] + [0] * (precision - 1)
+
+    assert Release.from_parts(*increments).text == ".".join(str(i) for i in increments)
+    assert Release.from_parts(*zeros).text == ".".join(str(i) for i in zeros)
+
+
+@pytest.mark.parametrize("precision", list(range(1, 6)))
+def test_release_next_major(precision: int) -> None:
+    release = Release.from_parts(1, *[0] * (precision - 1))
+    expected = Release.from_parts(2, *[0] * (precision - 1))
+    assert release.next_major() == expected
+
+
+@pytest.mark.parametrize("precision", list(range(1, 6)))
+def test_release_next_minor(precision: int) -> None:
+    release = Release.from_parts(1, *[0] * (precision - 1))
+    expected = Release.from_parts(1, 1, *[0] * (precision - 2))
+    assert release.next_minor() == expected
+
+
+@pytest.mark.parametrize("precision", list(range(1, 6)))
+def test_release_next_patch(precision: int) -> None:
+    release = Release.from_parts(1, *[0] * (precision - 1))
+    expected = Release.from_parts(1, 0, 1, *[0] * (precision - 3))
+    assert release.next_patch() == expected
 
 
 @pytest.mark.parametrize(
@@ -38,7 +80,7 @@ def test_pep440_release_segment_from_parts(
         (("r", 1), ReleaseTag("rev", 1)),
     ],
 )
-def test_pep440_release_tag_normalisation(
+def test_release_tag_normalisation(
     parts: tuple[str] | tuple[str, int], result: ReleaseTag
 ) -> None:
     tag = ReleaseTag(*parts)
@@ -57,14 +99,12 @@ def test_pep440_release_tag_normalisation(
         (("dev",), None),
     ],
 )
-def test_pep440_release_tag_next_phase(
-    parts: tuple[str], result: ReleaseTag | None
-) -> None:
+def test_release_tag_next_phase(parts: tuple[str], result: ReleaseTag | None) -> None:
     assert ReleaseTag(*parts).next_phase() == result
 
 
 @pytest.mark.parametrize("phase", list({*RELEASE_PHASE_NORMALIZATIONS.keys()}))
-def test_pep440_release_tag_next(phase: str) -> None:
+def test_release_tag_next(phase: str) -> None:
     tag = ReleaseTag(phase=phase).next()
     assert tag.phase == RELEASE_PHASE_NORMALIZATIONS[phase]
     assert tag.number == 1

--- a/tests/version/pep440/test_version.py
+++ b/tests/version/pep440/test_version.py
@@ -251,11 +251,11 @@ def test_next_devrelease() -> None:
     assert v.next_devrelease().text == "9!1.2.3a1.post2.dev4"
 
 
-def test_next_firstprerelease() -> None:
+def test_first_prerelease() -> None:
     v = PEP440Version.parse("9!1.2.3a1.post2.dev3")
     assert v.first_prerelease().text == "9!1.2.3a0"
 
 
-def test_next_firstdevrelease() -> None:
+def test_first_devrelease() -> None:
     v = PEP440Version.parse("9!1.2.3a1.post2.dev3")
     assert v.first_devrelease().text == "9!1.2.3a1.post2.dev0"


### PR DESCRIPTION
Some minor changes + test coverage:
- Since `Release` is not instantiated directly but via `Release.from_parts()` we can clean up the type of `extra` to be always a tuple without losing flexibility. That way we can get rid of some asserts and the special handling in `__post_init__()`.
- `minor` and `patch` are set to zero in `__post_init__()` if there are `extra` parts to avoid an inconsistent state
- changed default of `extra` in `Version.from_parts()` to an empty tuple instead of `None`