### PR TITLE
Python version confusion

### DIFF
--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -16,6 +16,7 @@ from poetry.core.packages.constraints import (
 from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.core.packages.specification import PackageSpecification
 from poetry.core.packages.utils.utils import contains_group_without_marker
+from poetry.core.packages.utils.utils import create_nested_marker
 from poetry.core.packages.utils.utils import normalize_python_version_markers
 from poetry.core.semver.helpers import parse_constraint
 from poetry.core.semver.version_range_constraint import VersionRangeConstraint
@@ -25,7 +26,6 @@ from poetry.core.version.markers import parse_marker
 if TYPE_CHECKING:
     from packaging.utils import NormalizedName
 
-    from poetry.core.packages.constraints import BaseConstraint
     from poetry.core.packages.directory_dependency import DirectoryDependency
     from poetry.core.packages.file_dependency import FileDependency
     from poetry.core.semver.version_constraint import VersionConstraint
@@ -149,9 +149,7 @@ class Dependency(PackageSpecification):
         if not self._python_constraint.is_any():
             self._marker = self._marker.intersect(
                 parse_marker(
-                    self._create_nested_marker(
-                        "python_version", self._python_constraint
-                    )
+                    create_nested_marker("python_version", self._python_constraint)
                 )
             )
 
@@ -312,13 +310,13 @@ class Dependency(PackageSpecification):
                 python_constraint = self.python_constraint
 
                 markers.append(
-                    self._create_nested_marker("python_version", python_constraint)
+                    create_nested_marker("python_version", python_constraint)
                 )
 
         in_extras = " || ".join(self._in_extras)
         if in_extras and with_extras and not has_extras:
             markers.append(
-                self._create_nested_marker("extra", parse_generic_constraint(in_extras))
+                create_nested_marker("extra", parse_generic_constraint(in_extras))
             )
 
         if markers:
@@ -332,89 +330,6 @@ class Dependency(PackageSpecification):
                 requirement += f"; {markers[0]}"
 
         return requirement
-
-    def _create_nested_marker(
-        self, name: str, constraint: BaseConstraint | VersionConstraint
-    ) -> str:
-        from poetry.core.packages.constraints.constraint import Constraint
-        from poetry.core.packages.constraints.multi_constraint import MultiConstraint
-        from poetry.core.packages.constraints.union_constraint import UnionConstraint
-        from poetry.core.semver.version import Version
-        from poetry.core.semver.version_union import VersionUnion
-
-        if isinstance(constraint, (MultiConstraint, UnionConstraint)):
-            multi_parts = []
-            for c in constraint.constraints:
-                multi = isinstance(c, (MultiConstraint, UnionConstraint))
-                multi_parts.append((multi, self._create_nested_marker(name, c)))
-
-            glue = " and "
-            if isinstance(constraint, UnionConstraint):
-                parts = [f"({part[1]})" if part[0] else part[1] for part in multi_parts]
-                glue = " or "
-            else:
-                parts = [part[1] for part in multi_parts]
-
-            marker = glue.join(parts)
-        elif isinstance(constraint, Constraint):
-            marker = f'{name} {constraint.operator} "{constraint.version}"'
-        elif isinstance(constraint, VersionUnion):
-            parts = [self._create_nested_marker(name, c) for c in constraint.ranges]
-            glue = " or "
-            parts = [f"({part})" for part in parts]
-
-            marker = glue.join(parts)
-        elif isinstance(constraint, Version):
-            if constraint.precision >= 3 and name == "python_version":
-                name = "python_full_version"
-
-            marker = f'{name} == "{constraint.text}"'
-        else:
-            assert isinstance(constraint, VersionRangeConstraint)
-            if constraint.min is not None:
-                min_name = name
-                if constraint.min.precision >= 3 and name == "python_version":
-                    min_name = "python_full_version"
-
-                    if constraint.max is None:
-                        name = min_name
-
-                op = ">="
-                if not constraint.include_min:
-                    op = ">"
-
-                version = constraint.min.text
-                if constraint.max is not None:
-                    max_name = name
-                    if constraint.max.precision >= 3 and name == "python_version":
-                        max_name = "python_full_version"
-
-                    text = f'{min_name} {op} "{version}"'
-
-                    op = "<="
-                    if not constraint.include_max:
-                        op = "<"
-
-                    version = constraint.max.text
-
-                    text += f' and {max_name} {op} "{version}"'
-
-                    return text
-            elif constraint.max is not None:
-                if constraint.max.precision >= 3 and name == "python_version":
-                    name = "python_full_version"
-
-                op = "<="
-                if not constraint.include_max:
-                    op = "<"
-
-                version = constraint.max.text
-            else:
-                return ""
-
-            marker = f'{name} {op} "{version}"'
-
-        return marker
 
     def activate(self) -> None:
         """

--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -15,7 +15,6 @@ from typing import cast
 from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.core.packages.specification import PackageSpecification
 from poetry.core.packages.utils.utils import create_nested_marker
-from poetry.core.packages.utils.utils import get_python_constraint_from_marker
 from poetry.core.semver.helpers import parse_constraint
 from poetry.core.version.markers import parse_marker
 
@@ -263,11 +262,10 @@ class Package(PackageSpecification):
     @python_versions.setter
     def python_versions(self, value: str) -> None:
         self._python_versions = value
-        constraint = parse_constraint(value)
+        self._python_constraint = parse_constraint(value)
         self._python_marker = parse_marker(
-            create_nested_marker("python_version", constraint)
+            create_nested_marker("python_version", self._python_constraint)
         )
-        self._python_constraint = get_python_constraint_from_marker(self._python_marker)
 
     @property
     def python_constraint(self) -> VersionConstraint:

--- a/src/poetry/core/packages/utils/utils.py
+++ b/src/poetry/core/packages/utils/utils.py
@@ -240,44 +240,57 @@ def create_nested_marker(
         marker = f'{name} == "{constraint.text}"'
     else:
         assert isinstance(constraint, VersionRange)
+        min_name = max_name = name
+
+        parts = []
+
+        # `python_version` is a special case: to keep the constructed marker equivalent
+        # to the constraint we need to be careful with the precision.
+        #
+        # PEP 440 tells us that that when we come to make the comparison the release
+        # segment will be zero padded: eg "<= 3.10" is equivalent to "<= 3.10.0".
+        #
+        # But "python_version <= 3.10" is _not_ equivalent to "python_version <= 3.10.0" -
+        # see normalize_python_version_markers.
+        #
+        # A similar issue arises for a constraint like "> 3.6".
         if constraint.min is not None:
-            op = ">="
-            if not constraint.include_min:
-                op = ">"
-
+            op = ">=" if constraint.include_min else ">"
             version = constraint.min
-            if constraint.max is not None:
-                min_name = max_name = name
-                if min_name == "python_version" and constraint.min.precision >= 3:
-                    min_name = "python_full_version"
+            if min_name == "python_version" and version.precision >= 3:
+                min_name = "python_full_version"
 
-                if max_name == "python_version" and constraint.max.precision >= 3:
-                    max_name = "python_full_version"
+            if (
+                min_name == "python_version"
+                and not constraint.include_min
+                and version.precision < 3
+            ):
+                padding = ".0" * (3 - version.precision)
+                part = f'python_full_version > "{version}{padding}"'
+            else:
+                part = f'{min_name} {op} "{version}"'
 
-                text = f'{min_name} {op} "{version}"'
+            parts.append(part)
 
-                op = "<="
-                if not constraint.include_max:
-                    op = "<"
-
-                version = constraint.max
-
-                text += f' and {max_name} {op} "{version}"'
-
-                return text
-        elif constraint.max is not None:
-            op = "<="
-            if not constraint.include_max:
-                op = "<"
-
+        if constraint.max is not None:
+            op = "<=" if constraint.include_max else "<"
             version = constraint.max
-        else:
-            return ""
+            if max_name == "python_version" and version.precision >= 3:
+                max_name = "python_full_version"
 
-        if name == "python_version" and version.precision >= 3:
-            name = "python_full_version"
+            if (
+                max_name == "python_version"
+                and constraint.include_max
+                and version.precision < 3
+            ):
+                padding = ".0" * (3 - version.precision)
+                part = f'python_full_version <= "{version}{padding}"'
+            else:
+                part = f'{max_name} {op} "{version}"'
 
-        marker = f'{name} {op} "{version}"'
+            parts.append(part)
+
+        marker = " and ".join(parts)
 
     return marker
 

--- a/src/poetry/core/packages/utils/utils.py
+++ b/src/poetry/core/packages/utils/utils.py
@@ -24,7 +24,6 @@ from poetry.core.version.markers import dnf
 if TYPE_CHECKING:
     from poetry.core.packages.constraints import BaseConstraint
     from poetry.core.semver.version_constraint import VersionConstraint
-    from poetry.core.semver.version_union import VersionUnion
     from poetry.core.version.markers import BaseMarker
 
     # Even though we've `from __future__ import annotations`, mypy doesn't seem to like
@@ -202,7 +201,7 @@ def contains_group_without_marker(markers: ConvertedMarkers, marker_name: str) -
 
 def create_nested_marker(
     name: str,
-    constraint: BaseConstraint | VersionUnion | Version | VersionConstraint,
+    constraint: BaseConstraint | VersionConstraint,
 ) -> str:
     from poetry.core.packages.constraints.constraint import Constraint
     from poetry.core.packages.constraints.multi_constraint import MultiConstraint
@@ -247,11 +246,11 @@ def create_nested_marker(
         # `python_version` is a special case: to keep the constructed marker equivalent
         # to the constraint we need to be careful with the precision.
         #
-        # PEP 440 tells us that that when we come to make the comparison the release
+        # PEP 440 tells us that when we come to make the comparison the release
         # segment will be zero padded: eg "<= 3.10" is equivalent to "<= 3.10.0".
         #
-        # But "python_version <= 3.10" is _not_ equivalent to "python_version <= 3.10.0" -
-        # see normalize_python_version_markers.
+        # But "python_version <= 3.10" is _not_ equivalent to "python_version <= 3.10.0"
+        # - see normalize_python_version_markers.
         #
         # A similar issue arises for a constraint like "> 3.6".
         if constraint.min is not None:

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -533,15 +533,15 @@ def test_package_pep592_yanked(
     assert package.yanked_reason == expected_yanked_reason
 
 
-def test_python_versions_are_normalized() -> None:
+def test_python_versions_are_made_precise() -> None:
     package = Package("foo", "1.2.3")
     package.python_versions = ">3.6,<=3.10"
 
     assert (
         str(package.python_marker)
-        == 'python_version > "3.6" and python_version <= "3.10"'
+        == 'python_full_version > "3.6.0" and python_full_version <= "3.10.0"'
     )
-    assert str(package.python_constraint) == ">=3.7,<3.11"
+    assert str(package.python_constraint) == ">3.6,<=3.10"
 
 
 def test_cannot_update_package_version() -> None:


### PR DESCRIPTION
Undoing #407 and taking a different approach.  (Can confirm that this still fixes https://github.com/python-poetry/poetry/issues/5591).

When setting python versions we also construct a marker to carry the same information.  Prior to #407, the python constraint and python marker were not consistent, which that MR fixed by re-parsing the constructed marker into a fresh constraint.

This was nonsense: the constraint was right all along, it was the constructed marker that was wrong.

The result is that as of today a python requirement like `<=3.10` is interpreted as `<3.11` - whereas it should be equivalent to `<=3.10.0`

NB there is no problem with the normalization of python markers: a marker like `python_version <= "3.10"` _is_ equivalent to `python_version < "3.11"`.  But that was never the correct marker for the python requirement.

So in this MR I revert #407, and make the construction of a `python_version` marker from a constraint be more careful of this edge condition, we now explicitly zero-pad and use `python_full_version` when we hit it.

(IMO this is not important enough to delay the upcoming 1.2.0 release).