### PR TITLE
Don't tolerate invalid constraints

### DIFF
--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -106,15 +106,11 @@ class Dependency(PackageSpecification):
 
     @constraint.setter
     def constraint(self, constraint: str | VersionConstraint) -> None:
-        from poetry.core.semver.version_constraint import VersionConstraint
+        if isinstance(constraint, str):
+            self._constraint = parse_constraint(constraint)
+        else:
+            self._constraint = constraint
 
-        try:
-            if not isinstance(constraint, VersionConstraint):
-                self._constraint = parse_constraint(constraint)
-            else:
-                self._constraint = constraint
-        except ValueError:
-            self._constraint = parse_constraint("*")
         self._pretty_constraint = str(constraint)
 
     def set_constraint(self, constraint: str | VersionConstraint) -> None:

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from poetry.core.packages.dependency import Dependency
+from poetry.core.semver.exceptions import ParseConstraintError
 from poetry.core.version.markers import parse_marker
 
 
@@ -236,6 +237,12 @@ def test_set_constraint_sets_pretty_constraint() -> None:
     assert dependency.pretty_constraint == "^1.0"
     dependency.constraint = "^2.0"  # type: ignore[assignment]
     assert dependency.pretty_constraint == "^2.0"
+
+
+def test_set_bogus_constraint_raises_exception() -> None:
+    dependency = Dependency("A", "^1.0")
+    with pytest.raises(ParseConstraintError):
+        dependency.constraint = "^=4.5"  # type: ignore[assignment]
 
 
 def test_with_constraint() -> None:


### PR DESCRIPTION
Fixes https://github.com/python-poetry/poetry/issues/3163, which has gone misunderstood for two years on account of poetry-core not-so-helpfully handling `^=4.5` as if it were valid