### PR TITLE
dependency: base_pep_508_name always posix + fix tests

### DIFF
--- a/src/poetry/core/packages/directory_dependency.py
+++ b/src/poetry/core/packages/directory_dependency.py
@@ -89,7 +89,9 @@ class DirectoryDependency(Dependency):
             extras = ",".join(sorted(self.extras))
             requirement += f"[{extras}]"
 
-        path = path_to_url(self.path) if self.path.is_absolute() else self.path
+        path = (
+            path_to_url(self.path) if self.path.is_absolute() else self.path.as_posix()
+        )
         requirement += f" @ {path}"
 
         return requirement

--- a/src/poetry/core/packages/file_dependency.py
+++ b/src/poetry/core/packages/file_dependency.py
@@ -78,7 +78,9 @@ class FileDependency(Dependency):
             extras = ",".join(sorted(self.extras))
             requirement += f"[{extras}]"
 
-        path = path_to_url(self.path) if self.path.is_absolute() else self.path
+        path = (
+            path_to_url(self.path) if self.path.is_absolute() else self.path.as_posix()
+        )
         requirement += f" @ {path}"
 
         return requirement

--- a/tests/packages/test_directory_dependency.py
+++ b/tests/packages/test_directory_dependency.py
@@ -29,7 +29,7 @@ def _test_directory_dependency_pep_508(
     dep = cast(DirectoryDependency, dep)
     assert dep.name == name
     assert dep.path == path
-    assert dep.to_pep_508() == pep_508_output or pep_508_input
+    assert dep.to_pep_508() == (pep_508_output or pep_508_input)
 
 
 def test_directory_dependency_pep_508_local_absolute() -> None:
@@ -38,11 +38,13 @@ def test_directory_dependency_pep_508_local_absolute() -> None:
         / "fixtures"
         / "project_with_multi_constraints_dependency"
     )
+    expected = f"demo @ {path.as_uri()}"
+
     requirement = f"demo @ file://{path.as_posix()}"
-    _test_directory_dependency_pep_508("demo", path, requirement)
+    _test_directory_dependency_pep_508("demo", path, requirement, expected)
 
     requirement = f"demo @ {path}"
-    _test_directory_dependency_pep_508("demo", path, requirement)
+    _test_directory_dependency_pep_508("demo", path, requirement, expected)
 
 
 def test_directory_dependency_pep_508_localhost() -> None:
@@ -52,8 +54,8 @@ def test_directory_dependency_pep_508_localhost() -> None:
         / "project_with_multi_constraints_dependency"
     )
     requirement = f"demo @ file://localhost{path.as_posix()}"
-    requirement_expected = f"demo @ file://{path.as_posix()}"
-    _test_directory_dependency_pep_508("demo", path, requirement, requirement_expected)
+    expected = f"demo @ {path.as_uri()}"
+    _test_directory_dependency_pep_508("demo", path, requirement, expected)
 
 
 def test_directory_dependency_pep_508_local_relative() -> None:
@@ -64,7 +66,8 @@ def test_directory_dependency_pep_508_local_relative() -> None:
         _test_directory_dependency_pep_508("demo", path, requirement)
 
     requirement = f"demo @ {path}"
-    _test_directory_dependency_pep_508("demo", path, requirement)
+    expected = f"demo @ {path.as_posix()}"
+    _test_directory_dependency_pep_508("demo", path, requirement, expected)
 
 
 def test_directory_dependency_pep_508_extras() -> None:
@@ -74,8 +77,8 @@ def test_directory_dependency_pep_508_extras() -> None:
         / "project_with_multi_constraints_dependency"
     )
     requirement = f"demo[foo,bar] @ file://{path.as_posix()}"
-    requirement_expected = f"demo[bar,foo] @ file://{path.as_posix()}"
-    _test_directory_dependency_pep_508("demo", path, requirement, requirement_expected)
+    expected = f"demo[bar,foo] @ {path.as_uri()}"
+    _test_directory_dependency_pep_508("demo", path, requirement, expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/packages/test_file_dependency.py
+++ b/tests/packages/test_file_dependency.py
@@ -114,25 +114,25 @@ def _test_file_dependency_pep_508(
     dep = cast(FileDependency, dep)
     assert dep.name == name
     assert dep.path == path
-    assert dep.to_pep_508() == pep_508_output or pep_508_input
+    assert dep.to_pep_508() == (pep_508_output or pep_508_input)
 
 
 def test_file_dependency_pep_508_local_file_absolute(mocker: MockerFixture) -> None:
     path = DIST_PATH / "demo-0.2.0.tar.gz"
+    expected = f"demo @ {path.as_uri()}"
+
     requirement = f"demo @ file://{path.as_posix()}"
-    _test_file_dependency_pep_508(mocker, "demo", path, requirement)
+    _test_file_dependency_pep_508(mocker, "demo", path, requirement, expected)
 
     requirement = f"demo @ {path}"
-    _test_file_dependency_pep_508(mocker, "demo", path, requirement)
+    _test_file_dependency_pep_508(mocker, "demo", path, requirement, expected)
 
 
 def test_file_dependency_pep_508_local_file_localhost(mocker: MockerFixture) -> None:
     path = DIST_PATH / "demo-0.2.0.tar.gz"
     requirement = f"demo @ file://localhost{path.as_posix()}"
-    requirement_expected = f"demo @ file://{path.as_posix()}"
-    _test_file_dependency_pep_508(
-        mocker, "demo", path, requirement, requirement_expected
-    )
+    expected = f"demo @ {path.as_uri()}"
+    _test_file_dependency_pep_508(mocker, "demo", path, requirement, expected)
 
 
 def test_file_dependency_pep_508_local_file_relative_path(
@@ -145,14 +145,15 @@ def test_file_dependency_pep_508_local_file_relative_path(
         _test_file_dependency_pep_508(mocker, "demo", path, requirement)
 
     requirement = f"demo @ {path}"
-    _test_file_dependency_pep_508(mocker, "demo", path, requirement)
+    expected = f"demo @ {path.as_posix()}"
+    _test_file_dependency_pep_508(mocker, "demo", path, requirement, expected)
 
 
 def test_absolute_file_dependency_to_pep_508_with_marker(mocker: MockerFixture) -> None:
     wheel = "demo-0.1.0-py2.py3-none-any.whl"
 
     abs_path = DIST_PATH / wheel
-    requirement = f'demo @ file://{abs_path.as_posix()} ; sys_platform == "linux"'
+    requirement = f'demo @ {abs_path.as_uri()} ; sys_platform == "linux"'
     _test_file_dependency_pep_508(
         mocker,
         "demo",


### PR DESCRIPTION
The tests for `FileDependency` and `DirectoryDependency` use the following assert:

```
assert dep.to_pep_508() == pep_508_output or pep_508_input
```

which is equal to
```
assert (dep.to_pep_508() == pep_508_output) or pep_508_input
```

and thus, always true if there is an `pep_508_input`. Actually it should be

```
assert dep.to_pep_508() == (pep_508_output or pep_508_input)
```

While fixing the tests, I noticed that the output for relative paths was platform-dependent. I changed it to always return posix paths.

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
