### PR TITLE
prefer to avoid casts

### DIFF
--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -9,7 +9,6 @@ from typing import Dict
 from typing import List
 from typing import Mapping
 from typing import Union
-from typing import cast
 from warnings import warn
 
 from poetry.core.utils.helpers import combine_unicode
@@ -56,8 +55,10 @@ class Factory:
             raise RuntimeError("The Poetry configuration is invalid:\n" + message)
 
         # Load package
-        name = cast(str, local_config["name"])
-        version = cast(str, local_config["version"])
+        name = local_config["name"]
+        assert isinstance(name, str)
+        version = local_config["version"]
+        assert isinstance(version, str)
         package = self.get_package(name, version)
         package = self.configure_package(
             package, local_config, poetry_file.parent, with_groups=with_groups

--- a/src/poetry/core/packages/constraints/union_constraint.py
+++ b/src/poetry/core/packages/constraints/union_constraint.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import cast
-
 from poetry.core.packages.constraints.base_constraint import BaseConstraint
 from poetry.core.packages.constraints.constraint import Constraint
 from poetry.core.packages.constraints.empty_constraint import EmptyConstraint
@@ -99,7 +97,7 @@ class UnionConstraint(BaseConstraint):
                         new_constraints.append(intersection)
 
         else:
-            other = cast(MultiConstraint, other)
+            assert isinstance(other, MultiConstraint)
 
             for our_constraint in self._constraints:
                 intersection = our_constraint

--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -10,7 +10,6 @@ from typing import Collection
 from typing import Iterable
 from typing import Iterator
 from typing import TypeVar
-from typing import cast
 
 from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.core.packages.specification import PackageSpecification
@@ -482,9 +481,10 @@ class Package(PackageSpecification):
 
         dep: Dependency
         if self.source_type == "directory":
+            assert self._source_url is not None
             dep = DirectoryDependency(
                 self._name,
-                Path(cast(str, self._source_url)),
+                Path(self._source_url),
                 groups=list(self._dependency_groups.keys()),
                 optional=self.optional,
                 base=self.root_dir,
@@ -492,28 +492,31 @@ class Package(PackageSpecification):
                 extras=self.features,
             )
         elif self.source_type == "file":
+            assert self._source_url is not None
             dep = FileDependency(
                 self._name,
-                Path(cast(str, self._source_url)),
+                Path(self._source_url),
                 groups=list(self._dependency_groups.keys()),
                 optional=self.optional,
                 base=self.root_dir,
                 extras=self.features,
             )
         elif self.source_type == "url":
+            assert self._source_url is not None
             dep = URLDependency(
                 self._name,
-                cast(str, self._source_url),
+                self._source_url,
                 directory=self.source_subdirectory,
                 groups=list(self._dependency_groups.keys()),
                 optional=self.optional,
                 extras=self.features,
             )
         elif self.source_type == "git":
+            assert self._source_url is not None
             dep = VCSDependency(
                 self._name,
                 self.source_type,
-                cast(str, self.source_url),
+                self._source_url,
                 rev=self.source_reference,
                 resolved_rev=self.source_resolved_reference,
                 directory=self.source_subdirectory,

--- a/src/poetry/core/pyproject/toml.py
+++ b/src/poetry/core/pyproject/toml.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import Any
 
-from tomlkit.items import Table
 from tomlkit.api import table
+from tomlkit.items import Table
 
 
 if TYPE_CHECKING:

--- a/src/poetry/core/pyproject/toml.py
+++ b/src/poetry/core/pyproject/toml.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import cast
 
-from tomlkit.container import Container
+from tomlkit.items import Table
+from tomlkit.api import table
 
 
 if TYPE_CHECKING:
@@ -64,11 +64,15 @@ class PyProjectTOML:
         return self._build_system
 
     @property
-    def poetry_config(self) -> Container:
+    def poetry_config(self) -> Table:
         from tomlkit.exceptions import NonExistentKey
 
         try:
-            return cast(Container, self.data["tool"]["poetry"])
+            tool = self.data["tool"]
+            assert isinstance(tool, dict)
+            config = tool["poetry"]
+            assert isinstance(config, Table)
+            return config
         except NonExistentKey as e:
             from poetry.core.pyproject.exceptions import PyProjectException
 
@@ -92,15 +96,15 @@ class PyProjectTOML:
         return getattr(self.data, item)
 
     def save(self) -> None:
-        from tomlkit.container import Container
-
         data = self.data
 
         if self._build_system is not None:
             if "build-system" not in data:
-                data["build-system"] = Container()
+                data["build-system"] = table()
 
-            build_system = cast(Container, data["build-system"])
+            build_system = data["build-system"]
+            assert isinstance(build_system, Table)
+
             build_system["requires"] = self._build_system.requires
             build_system["build-backend"] = self._build_system.build_backend
 

--- a/src/poetry/core/utils/toml_file.py
+++ b/src/poetry/core/utils/toml_file.py
@@ -7,7 +7,7 @@ from poetry.core.toml import TOMLFile
 
 class TomlFile(TOMLFile):
     @classmethod
-    def __new__(cls: type[TOMLFile], *args: Any, **kwargs: Any) -> TOMLFile:
+    def __new__(cls: type[TOMLFile], *args: Any, **kwargs: Any) -> TomlFile:
         import warnings
 
         this_import = f"{cls.__module__}.{cls.__name__}"

--- a/tests/pyproject/test_pyproject_toml.py
+++ b/tests/pyproject/test_pyproject_toml.py
@@ -83,6 +83,7 @@ def test_pyproject_toml_reload(pyproject_toml: Path, poetry_section: str) -> Non
     name_new = str(uuid.uuid4())
 
     pyproject.poetry_config["name"] = name_new
+    assert isinstance(pyproject.poetry_config["name"], str)
     assert pyproject.poetry_config["name"] == name_new
 
     pyproject.reload()
@@ -106,6 +107,7 @@ def test_pyproject_toml_save(
 
     pyproject = PyProjectTOML(pyproject_toml)
 
+    assert isinstance(pyproject.poetry_config["name"], str)
     assert pyproject.poetry_config["name"] == name
     assert pyproject.build_system.build_backend == build_backend
     assert build_requires in pyproject.build_system.requires

--- a/tests/semver/test_helpers.py
+++ b/tests/semver/test_helpers.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import cast
-
 import pytest
 
 from poetry.core.semver.helpers import parse_constraint
@@ -415,7 +413,7 @@ def test_constraints_keep_version_precision(input: str, expected: str) -> None:
     ],
 )
 def test_versions_are_sortable(unsorted: list[str], sorted_: list[str]) -> None:
-    unsorted_parsed = [cast(Version, parse_constraint(u)) for u in unsorted]
-    sorted_parsed = [cast(Version, parse_constraint(s)) for s in sorted_]
+    unsorted_parsed = [Version.parse(u) for u in unsorted]
+    sorted_parsed = [Version.parse(s) for s in sorted_]
 
     assert sorted(unsorted_parsed) == sorted_parsed


### PR DESCRIPTION
prefer to avoid `cast`.  If you're wrong, you never get to find out.

It turns out that some of these _were_ wrong, some tomlkit things are apparently `Table` and not `Container`.