### PR TITLE
ci: force poetry-core update in downstream tests

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -58,7 +58,11 @@ jobs:
 
       - name: Install downstream dependencies
         working-directory: ./poetry
-        run: poetry install
+        run: |
+          # force update of directory dependency in cached venv
+          # (even if directory dependency with same version is already installed)
+          poetry run pip uninstall -y poetry-core
+          poetry install
 
       # TODO: mark run as success even when this fails and add comment to PR instead
       - name: Run downstream test suite


### PR DESCRIPTION
As per https://github.com/python-poetry/poetry-core/pull/469#issuecomment-1243000708 downstream tests are not failing even though they should. In the corresponding [pipeline job](https://github.com/python-poetry/poetry-core/runs/8293673752?check_suite_focus=true) (in step "Install downstream dependencies"), it can be seen that poetry-core is not updated. That's probably because a directory dependency is already installed.