### PR TITLE
tests: Mock Git for gitignore tests

### DIFF
--- a/tests/masonry/builders/test_sdist.py
+++ b/tests/masonry/builders/test_sdist.py
@@ -421,23 +421,27 @@ def test_with_src_module_dir() -> None:
 
 
 def test_default_with_excluded_data(mocker: MockerFixture) -> None:
-    # Patch git module to return specific excluded files
-    p = mocker.patch("poetry.core.vcs.git.Git.get_ignored_files")
-    p.return_value = [
-        (
-            (
-                Path(__file__).parent
-                / "fixtures"
-                / "default_with_excluded_data"
-                / "my_package"
-                / "data"
-                / "sub_data"
-                / "data2.txt"
-            )
-            .relative_to(project("default_with_excluded_data"))
-            .as_posix()
-        )
-    ]
+    class MockGit:
+        def get_ignored_files(self, folder: Path | None = None) -> list[str]:
+            # Patch git module to return specific excluded files
+            return [
+                (
+                    (
+                        Path(__file__).parent
+                        / "fixtures"
+                        / "default_with_excluded_data"
+                        / "my_package"
+                        / "data"
+                        / "sub_data"
+                        / "data2.txt"
+                    )
+                    .relative_to(project("default_with_excluded_data"))
+                    .as_posix()
+                )
+            ]
+
+    p = mocker.patch("poetry.core.vcs.get_vcs")
+    p.return_value = MockGit()
     poetry = Factory().create_poetry(project("default_with_excluded_data"))
 
     builder = SdistBuilder(poetry)

--- a/tests/masonry/builders/test_wheel.py
+++ b/tests/masonry/builders/test_wheel.py
@@ -272,24 +272,28 @@ def test_wheel_with_file_with_comma() -> None:
 
 
 def test_default_src_with_excluded_data(mocker: MockerFixture) -> None:
-    # Patch git module to return specific excluded files
-    p = mocker.patch("poetry.core.vcs.git.Git.get_ignored_files")
-    p.return_value = [
-        (
-            (
-                Path(__file__).parent
-                / "fixtures"
-                / "default_src_with_excluded_data"
-                / "src"
-                / "my_package"
-                / "data"
-                / "sub_data"
-                / "data2.txt"
-            )
-            .relative_to(project("default_src_with_excluded_data"))
-            .as_posix()
-        )
-    ]
+    class MockGit:
+        def get_ignored_files(self, folder: Path | None = None) -> list[str]:
+            # Patch git module to return specific excluded files
+            return [
+                (
+                    (
+                        Path(__file__).parent
+                        / "fixtures"
+                        / "default_src_with_excluded_data"
+                        / "src"
+                        / "my_package"
+                        / "data"
+                        / "sub_data"
+                        / "data2.txt"
+                    )
+                    .relative_to(project("default_src_with_excluded_data"))
+                    .as_posix()
+                )
+            ]
+
+    p = mocker.patch("poetry.core.vcs.get_vcs")
+    p.return_value = MockGit()
     poetry = Factory().create_poetry(project("default_src_with_excluded_data"))
 
     builder = WheelBuilder(poetry)


### PR DESCRIPTION
Upstream run its tests on cloned git repo, but downstreams may or may not run tests in local git tree.
Gitignore tests already use mocked results of Git and the corresponding git object may also be mocked.

Resolves: python-poetry/poetry#4481


