### PR TITLE
normalize extras per PEP685

### DIFF
--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -11,6 +11,8 @@ from typing import Mapping
 from typing import Union
 from warnings import warn
 
+from packaging.utils import canonicalize_name
+
 from poetry.core.utils.helpers import combine_unicode
 from poetry.core.utils.helpers import readme_content_type
 
@@ -176,6 +178,7 @@ class Factory:
 
         extras = config.get("extras", {})
         for extra_name, requirements in extras.items():
+            extra_name = canonicalize_name(extra_name)
             package.extras[extra_name] = []
 
             # Checking for dependency

--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING
 from typing import Iterable
 from typing import TypeVar
 
+from packaging.utils import canonicalize_name
+
 from poetry.core.constraints.generic import parse_constraint as parse_generic_constraint
 from poetry.core.constraints.version import VersionRangeConstraint
 from poetry.core.constraints.version import parse_constraint
@@ -86,7 +88,7 @@ class Dependency(PackageSpecification):
         self._transitive_python_constraint: VersionConstraint | None = None
         self._transitive_marker: BaseMarker | None = None
 
-        self._in_extras: list[str] = []
+        self._in_extras: list[NormalizedName] = []
 
         self._activated = not self._optional
 
@@ -183,7 +185,7 @@ class Dependency(PackageSpecification):
 
             for or_ in markers["extra"]:
                 for _, extra in or_:
-                    self.in_extras.append(extra)
+                    self.in_extras.append(canonicalize_name(extra))
 
         # Recalculate python versions.
         self._python_versions = "*"
@@ -218,12 +220,12 @@ class Dependency(PackageSpecification):
         return self._transitive_python_constraint
 
     @property
-    def extras(self) -> frozenset[str]:
+    def extras(self) -> frozenset[NormalizedName]:
         # extras activated in a dependency is the same as features
         return self._features
 
     @property
-    def in_extras(self) -> list[str]:
+    def in_extras(self) -> list[NormalizedName]:
         return self._in_extras
 
     @property

--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -90,7 +90,7 @@ class Package(PackageSpecification):
         self._license: License | None = None
         self.readmes: tuple[Path, ...] = ()
 
-        self.extras: dict[str, list[Dependency]] = {}
+        self.extras: dict[NormalizedName, list[Dependency]] = {}
 
         self._dependency_groups: dict[str, DependencyGroup] = {}
 

--- a/src/poetry/core/packages/specification.py
+++ b/src/poetry/core/packages/specification.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 from typing import Iterable
 from typing import TypeVar
 
+from packaging.utils import canonicalize_name
+
 
 if TYPE_CHECKING:
     from packaging.utils import NormalizedName
@@ -37,7 +39,7 @@ class PackageSpecification:
         if not features:
             features = []
 
-        self._features = frozenset(features)
+        self._features = frozenset(canonicalize_name(feature) for feature in features)
 
     @property
     def name(self) -> NormalizedName:
@@ -78,7 +80,7 @@ class PackageSpecification:
         return self._source_subdirectory
 
     @property
-    def features(self) -> frozenset[str]:
+    def features(self) -> frozenset[NormalizedName]:
         return self._features
 
     def is_direct_origin(self) -> bool:
@@ -167,7 +169,9 @@ class PackageSpecification:
     def with_features(self: T, features: Iterable[str]) -> T:
         package = self.clone()
 
-        package._features = frozenset(features)
+        package._features = frozenset(
+            canonicalize_name(feature) for feature in features
+        )
 
         return package
 

--- a/tests/masonry/builders/test_sdist.py
+++ b/tests/masonry/builders/test_sdist.py
@@ -14,6 +14,8 @@ from typing import Iterator
 
 import pytest
 
+from packaging.utils import canonicalize_name
+
 from poetry.core.factory import Factory
 from poetry.core.masonry.builders.sdist import SdistBuilder
 from poetry.core.masonry.utils.package_include import PackageInclude
@@ -73,7 +75,7 @@ def test_convert_dependencies() -> None:
     assert result == (main, extras)
 
     package = ProjectPackage("foo", "1.2.3")
-    package.extras = {"bar": [Dependency("A", "*")]}
+    package.extras = {canonicalize_name("bar"): [Dependency("A", "*")]}
 
     result = SdistBuilder.convert_dependencies(
         package,
@@ -93,7 +95,7 @@ def test_convert_dependencies() -> None:
     d = Dependency("D", "3.4.5", optional=True)
     d.python_versions = "~2.7 || ^3.4"
 
-    package.extras = {"baz": [Dependency("D", "*")]}
+    package.extras = {canonicalize_name("baz"): [Dependency("D", "*")]}
 
     result = SdistBuilder.convert_dependencies(
         package,

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import pytest
 
+from packaging.utils import canonicalize_name
+
 from poetry.core.constraints.version.exceptions import ParseConstraintError
 from poetry.core.packages.dependency import Dependency
 from poetry.core.version.markers import parse_marker
@@ -51,7 +53,7 @@ def test_to_pep_508_wilcard() -> None:
 
 def test_to_pep_508_in_extras() -> None:
     dependency = Dependency("Django", "^1.23")
-    dependency.in_extras.append("foo")
+    dependency.in_extras.append(canonicalize_name("foo"))
 
     result = dependency.to_pep_508()
     assert result == 'Django (>=1.23,<2.0); extra == "foo"'
@@ -59,7 +61,7 @@ def test_to_pep_508_in_extras() -> None:
     result = dependency.to_pep_508(with_extras=False)
     assert result == "Django (>=1.23,<2.0)"
 
-    dependency.in_extras.append("bar")
+    dependency.in_extras.append(canonicalize_name("bar"))
 
     result = dependency.to_pep_508()
     assert result == 'Django (>=1.23,<2.0); extra == "foo" or extra == "bar"'

--- a/tests/packages/test_vcs_dependency.py
+++ b/tests/packages/test_vcs_dependency.py
@@ -4,6 +4,8 @@ from typing import Any
 
 import pytest
 
+from packaging.utils import canonicalize_name
+
 from poetry.core.packages.vcs_dependency import VCSDependency
 
 
@@ -37,10 +39,8 @@ from poetry.core.packages.vcs_dependency import VCSDependency
         ),
         (
             {"branch": "main", "directory": "sub"},
-            (
-                "poetry @ git+https://github.com/python-poetry/poetry.git"
-                "@main#subdirectory=sub"
-            ),
+            "poetry @ git+https://github.com/python-poetry/poetry.git"
+            "@main#subdirectory=sub",
         ),
     ],
 )
@@ -64,7 +64,7 @@ def test_to_pep_508_in_extras() -> None:
     dependency = VCSDependency(
         "poetry", "git", "https://github.com/python-poetry/poetry.git"
     )
-    dependency.in_extras.append("foo")
+    dependency.in_extras.append(canonicalize_name("foo"))
 
     expected = (
         'poetry @ git+https://github.com/python-poetry/poetry.git ; extra == "foo"'
@@ -74,7 +74,7 @@ def test_to_pep_508_in_extras() -> None:
     dependency = VCSDependency(
         "poetry", "git", "https://github.com/python-poetry/poetry.git", extras=["bar"]
     )
-    dependency.in_extras.append("foo")
+    dependency.in_extras.append(canonicalize_name("foo"))
 
     expected = (
         'poetry[bar] @ git+https://github.com/python-poetry/poetry.git ; extra == "foo"'
@@ -85,7 +85,7 @@ def test_to_pep_508_in_extras() -> None:
     dependency = VCSDependency(
         "poetry", "git", "https://github.com/python-poetry/poetry.git", "b;ar;"
     )
-    dependency.in_extras.append("foo;")
+    dependency.in_extras.append(canonicalize_name("foo;"))
 
     expected = (
         "poetry @ git+https://github.com/python-poetry/poetry.git@b;ar; ; extra =="

--- a/tests/packages/test_vcs_dependency.py
+++ b/tests/packages/test_vcs_dependency.py
@@ -39,8 +39,10 @@ from poetry.core.packages.vcs_dependency import VCSDependency
         ),
         (
             {"branch": "main", "directory": "sub"},
-            "poetry @ git+https://github.com/python-poetry/poetry.git"
-            "@main#subdirectory=sub",
+            (
+                "poetry @ git+https://github.com/python-poetry/poetry.git"
+                "@main#subdirectory=sub"
+            ),
         ),
     ],
 )

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -7,6 +7,8 @@ from typing import cast
 
 import pytest
 
+from packaging.utils import canonicalize_name
+
 from poetry.core.constraints.version import parse_constraint
 from poetry.core.factory import Factory
 from poetry.core.packages.url_dependency import URLDependency
@@ -342,7 +344,7 @@ def test_create_poetry_with_markers_and_extras() -> None:
 
     assert len(dependencies) == 2
     assert {dependency.name for dependency in dependencies} == {"orjson"}
-    assert set(extras["all"]) == set(dependencies)
+    assert set(extras[canonicalize_name("all")]) == set(dependencies)
     for dependency in dependencies:
         assert dependency.in_extras == ["all"]
         assert isinstance(dependency, URLDependency)


### PR DESCRIPTION
https://peps.python.org/pep-0685/#specification says both that all comparisons should be done with normalized extra names, and that normalized extra names should be written to metadata.

Simplest and surest approach seems to be just to deal with normalized names everywhere.

Fixes https://github.com/python-poetry/poetry/issues/6321.

will cause CI failures in the downstream tests because poetry now records normalized extra names in lockfiles.  I think that's correct and will follow up with a poetry MR to fix the unit tests against this.  

However this presents some poetry / poetry-core challenges re merge order and version numbering.  As in other MRs, I'd advocate for allowing such things and being comfortable going 2.0 here - though even then the cross-repository pipelines want some disentangling.