### PR TITLE
ci: don't fail fast on downstream tests

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         ref: ["master", "1.2"]
+      fail-fast: false
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Downstream tests are informational, but are less useful if you don't see all failures
