### PR TITLE
Remove usage of distutils in build.py scripts

### DIFF
--- a/src/poetry/core/masonry/builders/sdist.py
+++ b/src/poetry/core/masonry/builders/sdist.py
@@ -251,7 +251,7 @@ class SdistBuilder(Builder):
 
         pkg_name = include.package
         pkg_data: dict[str, list[str]] = defaultdict(list)
-        # Undocumented distutils feature:
+        # Undocumented setup() feature:
         # the empty string matches all package names
         pkg_data[""].append("*")
         packages = [pkg_name]

--- a/tests/masonry/builders/fixtures/extended/build.py
+++ b/tests/masonry/builders/fixtures/extended/build.py
@@ -1,4 +1,4 @@
-from distutils.core import Extension
+from setuptools import Extension
 
 
 extensions = [Extension("extended.extended", ["extended/extended.c"])]

--- a/tests/masonry/builders/fixtures/extended_with_no_setup/build.py
+++ b/tests/masonry/builders/fixtures/extended_with_no_setup/build.py
@@ -1,9 +1,8 @@
 import os
 import shutil
 
-from distutils.command.build_ext import build_ext
-from distutils.core import Distribution
-from distutils.core import Extension
+from setuptools.command.build_ext import build_ext
+from setuptools import Distribution, Extension
 
 
 extensions = [Extension("extended.extended", ["extended/extended.c"])]
@@ -11,10 +10,9 @@ extensions = [Extension("extended.extended", ["extended/extended.c"])]
 
 def build() -> None:
     distribution = Distribution({"name": "extended", "ext_modules": extensions})
-    distribution.package_dir = "extended"
 
     cmd = build_ext(distribution)
-    cmd.ensure_finalized()
+    cmd.finalize_options()
     cmd.run()
 
     # Copy built extensions back to the project

--- a/tests/masonry/builders/fixtures/src_extended/build.py
+++ b/tests/masonry/builders/fixtures/src_extended/build.py
@@ -1,4 +1,4 @@
-from distutils.core import Extension
+from setuptools import Extension
 
 
 extensions = [Extension("extended.extended", ["src/extended/extended.c"])]


### PR DESCRIPTION
PR to remove all usage of `distutils` from the codebase.

`distutils` is currently used in some test fixtures that use `build.py` scripts in order to build C++ extension modules. `distutils` will be deprecated in Python 3.12.