### PR TITLE
ci: add dependency to test group

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Switch downstream to development poetry-core
         working-directory: ./poetry
-        run: poetry add --lock ../poetry-core
+        run: poetry add --lock --group test ../poetry-core
 
       - name: Install downstream dependencies
         working-directory: ./poetry


### PR DESCRIPTION
Necessary to override existing test dependencies and avoid conflicts.
