### PR TITLE
Revert "prefer to avoid casts (#468)"

### DIFF
--- a/src/poetry/core/constraints/generic/union_constraint.py
+++ b/src/poetry/core/constraints/generic/union_constraint.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import cast
+
 from poetry.core.constraints.generic.base_constraint import BaseConstraint
 from poetry.core.constraints.generic.constraint import Constraint
 from poetry.core.constraints.generic.empty_constraint import EmptyConstraint
@@ -97,7 +99,7 @@ class UnionConstraint(BaseConstraint):
                         new_constraints.append(intersection)
 
         else:
-            assert isinstance(other, MultiConstraint)
+            other = cast(MultiConstraint, other)
 
             for our_constraint in self._constraints:
                 intersection = our_constraint

--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -9,6 +9,7 @@ from typing import Dict
 from typing import List
 from typing import Mapping
 from typing import Union
+from typing import cast
 from warnings import warn
 
 from packaging.utils import canonicalize_name
@@ -57,10 +58,8 @@ class Factory:
             raise RuntimeError("The Poetry configuration is invalid:\n" + message)
 
         # Load package
-        name = local_config["name"]
-        assert isinstance(name, str)
-        version = local_config["version"]
-        assert isinstance(version, str)
+        name = cast(str, local_config["name"])
+        version = cast(str, local_config["version"])
         package = self.get_package(name, version)
         package = self.configure_package(
             package, local_config, poetry_file.parent, with_groups=with_groups

--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -10,6 +10,7 @@ from typing import Collection
 from typing import Iterable
 from typing import Iterator
 from typing import TypeVar
+from typing import cast
 
 from poetry.core.constraints.version import parse_constraint
 from poetry.core.packages.dependency_group import MAIN_GROUP
@@ -482,10 +483,9 @@ class Package(PackageSpecification):
 
         dep: Dependency
         if self.source_type == "directory":
-            assert self._source_url is not None
             dep = DirectoryDependency(
                 self._name,
-                Path(self._source_url),
+                Path(cast(str, self._source_url)),
                 groups=list(self._dependency_groups.keys()),
                 optional=self.optional,
                 base=self.root_dir,
@@ -493,31 +493,28 @@ class Package(PackageSpecification):
                 extras=self.features,
             )
         elif self.source_type == "file":
-            assert self._source_url is not None
             dep = FileDependency(
                 self._name,
-                Path(self._source_url),
+                Path(cast(str, self._source_url)),
                 groups=list(self._dependency_groups.keys()),
                 optional=self.optional,
                 base=self.root_dir,
                 extras=self.features,
             )
         elif self.source_type == "url":
-            assert self._source_url is not None
             dep = URLDependency(
                 self._name,
-                self._source_url,
+                cast(str, self._source_url),
                 directory=self.source_subdirectory,
                 groups=list(self._dependency_groups.keys()),
                 optional=self.optional,
                 extras=self.features,
             )
         elif self.source_type == "git":
-            assert self._source_url is not None
             dep = VCSDependency(
                 self._name,
                 self.source_type,
-                self._source_url,
+                cast(str, self.source_url),
                 rev=self.source_reference,
                 resolved_rev=self.source_resolved_reference,
                 directory=self.source_subdirectory,

--- a/src/poetry/core/pyproject/toml.py
+++ b/src/poetry/core/pyproject/toml.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import cast
 
-from tomlkit.api import table
-from tomlkit.items import Table
+from tomlkit.container import Container
 
 
 if TYPE_CHECKING:
@@ -64,15 +64,11 @@ class PyProjectTOML:
         return self._build_system
 
     @property
-    def poetry_config(self) -> Table:
+    def poetry_config(self) -> Container:
         from tomlkit.exceptions import NonExistentKey
 
         try:
-            tool = self.data["tool"]
-            assert isinstance(tool, dict)
-            config = tool["poetry"]
-            assert isinstance(config, Table)
-            return config
+            return cast(Container, self.data["tool"]["poetry"])
         except NonExistentKey as e:
             from poetry.core.pyproject.exceptions import PyProjectException
 
@@ -96,15 +92,15 @@ class PyProjectTOML:
         return getattr(self.data, item)
 
     def save(self) -> None:
+        from tomlkit.container import Container
+
         data = self.data
 
         if self._build_system is not None:
             if "build-system" not in data:
-                data["build-system"] = table()
+                data["build-system"] = Container()
 
-            build_system = data["build-system"]
-            assert isinstance(build_system, Table)
-
+            build_system = cast(Container, data["build-system"])
             build_system["requires"] = self._build_system.requires
             build_system["build-backend"] = self._build_system.build_backend
 

--- a/src/poetry/core/utils/toml_file.py
+++ b/src/poetry/core/utils/toml_file.py
@@ -7,7 +7,7 @@ from poetry.core.toml import TOMLFile
 
 class TomlFile(TOMLFile):
     @classmethod
-    def __new__(cls: type[TOMLFile], *args: Any, **kwargs: Any) -> TomlFile:
+    def __new__(cls: type[TOMLFile], *args: Any, **kwargs: Any) -> TOMLFile:
         import warnings
 
         this_import = f"{cls.__module__}.{cls.__name__}"

--- a/tests/constraints/version/test_helpers.py
+++ b/tests/constraints/version/test_helpers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 
 from poetry.core.constraints.version import Version
@@ -446,7 +448,7 @@ def test_constraints_keep_version_precision(input: str, expected: str) -> None:
     ],
 )
 def test_versions_are_sortable(unsorted: list[str], sorted_: list[str]) -> None:
-    unsorted_parsed = [Version.parse(u) for u in unsorted]
-    sorted_parsed = [Version.parse(s) for s in sorted_]
+    unsorted_parsed = [cast(Version, parse_constraint(u)) for u in unsorted]
+    sorted_parsed = [cast(Version, parse_constraint(s)) for s in sorted_]
 
     assert sorted(unsorted_parsed) == sorted_parsed

--- a/tests/pyproject/test_pyproject_toml.py
+++ b/tests/pyproject/test_pyproject_toml.py
@@ -83,7 +83,6 @@ def test_pyproject_toml_reload(pyproject_toml: Path, poetry_section: str) -> Non
     name_new = str(uuid.uuid4())
 
     pyproject.poetry_config["name"] = name_new
-    assert isinstance(pyproject.poetry_config["name"], str)
     assert pyproject.poetry_config["name"] == name_new
 
     pyproject.reload()
@@ -107,7 +106,6 @@ def test_pyproject_toml_save(
 
     pyproject = PyProjectTOML(pyproject_toml)
 
-    assert isinstance(pyproject.poetry_config["name"], str)
     assert pyproject.poetry_config["name"] == name
     assert pyproject.build_system.build_backend == build_backend
     assert build_requires in pyproject.build_system.requires


### PR DESCRIPTION
This reverts commit 743e09cd9014e1638a980be2d8814c9201f91347.

At runtime, during consumption via the prepare_metadata_for_build_wheel,
API, some of these values were in fact not what their typing was
asserted to be. This would cause a failure when the assertion failed.
