### PR TITLE
Package.satisfies() considers sources more carefully

### DIFF
--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -562,6 +562,34 @@ def test_package_satisfies(
     assert package.satisfies(dependency, ignore_source_type) == result
 
 
+@pytest.mark.parametrize(
+    ("package_repo", "dependency_repo", "result"),
+    [
+        ("pypi", None, True),
+        ("private", None, True),
+        ("pypi", "pypi", True),
+        ("private", "private", True),
+        ("pypi", "private", False),
+        ("private", "pypi", False),
+    ],
+)
+def test_package_satisfies_on_repositories(
+    package_repo: str,
+    dependency_repo: str | None,
+    result: bool,
+) -> None:
+    source_type = None if package_repo == "pypi" else "legacy"
+    source_reference = None if package_repo == "pypi" else package_repo
+    package = Package(
+        "foo", "0.1.0", source_type=source_type, source_reference=source_reference
+    )
+
+    dependency = Dependency("foo", ">=0.1.0")
+    dependency.source_name = dependency_repo
+
+    assert package.satisfies(dependency) == result
+
+
 def test_package_pep592_default_not_yanked() -> None:
     package = Package("foo", "1.0")
 


### PR DESCRIPTION
`Package.satisfies(dependency)` has been asking the wrong question about the sources: it doesn't need the sources to be identical, it needs the package source to satisfy the dependency source.

These are different mostly because of the confusing handling of pypi and legacy repositories
- on a dependency, setting source type and source name to None means "any source is fine"
- on a dependency, setting source type to None but specifying source name means "this specific repository"
- on a package, setting source type to None means "pypi"

I've also removed the check on features: it's not wanted by callers of this method in poetry, so it was just getting in the way.

A companion MR in poetry will follow, between them these should fix https://github.com/python-poetry/poetry/issues/6710