### PR TITLE
Speed up builds with large number of git ignored files

### DIFF
--- a/src/poetry/core/vcs/git.py
+++ b/src/poetry/core/vcs/git.py
@@ -324,6 +324,8 @@ class Git:
         return output.strip()
 
     def get_ignored_files(self, folder: Path | None = None) -> list[str]:
+        """Returns the list of files and directories that are ignored by Git."""
+
         args = []
         if folder is None and self._work_dir:
             folder = self._work_dir
@@ -336,7 +338,7 @@ class Git:
                 folder.as_posix(),
             ]
 
-        args += ["ls-files", "--others", "-i", "--exclude-standard"]
+        args += ["ls-files", "--others", "-i", "--exclude-standard", "--directory"]
         output = self.run(*args)
 
         return output.strip().split("\n")


### PR DESCRIPTION
Poetry calls `git ls-files` against the package directory to get the full list of files to exclude during build. This is very slow if you have e.g. hundreds of thousands of files that are ignored (don't ask why I have that).

Calling  `git ls-files --directory` instead is a *lot* faster, as it doesn't return all files in directories that are ignored. 

Doing that, however, requires refactoring `find_excluded_files` to not simply return the set of all files that are to be ignored. Instead, we return a container object that correctly handles ignored directories.

This does change the API of `Builder.find_excluded_files` to return a `Container[str]` rather than `set[str]`, but I'm not sure if that is part of any public API.



<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
