### PR TITLE
Add integration test for project using repository `poetry-core` as a backend

### DIFF
--- a/tests/fixtures/pep_517_backend/README.md
+++ b/tests/fixtures/pep_517_backend/README.md
@@ -1,0 +1,2 @@
+This fixture allows testing a project that uses the repository version of `poetry-core`
+as a PEP 517 backend.

--- a/tests/fixtures/pep_517_backend/pyproject.toml
+++ b/tests/fixtures/pep_517_backend/pyproject.toml
@@ -24,7 +24,12 @@ attrs = "^22.1.0"
 [tool.poetry.group.dev.dependencies]
 pytest = "7.1.3"
 
-# Allows testing https://github.com/python-poetry/poetry-core/pull/492
+# Non-regression test for https://github.com/python-poetry/poetry-core/pull/492.
+# The underlying issue occurred because `tomlkit` can either return a TOML table as `Table` instance or an
+# `OutOfOrderProxy` one, if a table is discontinuous and multiple sections of a table are separated by a non-related
+# table, but we were too strict in our type check assertions.
+# So adding `tool.black` here ensure that we have discontinuous tables, so that we don't re-introduce the issue caused
+# by the type check assertion that ended up being reverted.
 [tool.black]
 preview = true
 

--- a/tests/fixtures/pep_517_backend/pyproject.toml
+++ b/tests/fixtures/pep_517_backend/pyproject.toml
@@ -1,0 +1,32 @@
+[tool.poetry]
+name = "foo"
+version = "1.2.3"
+description = "Some description."
+authors = ["Foo <foo@bar.com>"]
+license = "MIT"
+readme = "README.md"
+
+homepage = "https://example.com"
+repository = "https://github.com/example/example"
+documentation = "https://example.com"
+
+keywords = ["example", "packaging"]
+
+classifiers = [
+    "Topic :: Software Development :: Build Tools",
+    "Topic :: Software Development :: Libraries :: Python Modules"
+]
+
+[tool.poetry.dependencies]
+python = "^3.7"
+attrs = "^22.1.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "7.1.3"
+
+# Allows testing https://github.com/python-poetry/poetry-core/pull/492
+[tool.black]
+preview = true
+
+[tool.poetry.scripts]
+my-script = "my_package:main"

--- a/tests/fixtures/sample_project/pyproject.toml
+++ b/tests/fixtures/sample_project/pyproject.toml
@@ -50,6 +50,10 @@ dataclasses = {version = "^0.7", python = ">=3.6.1,<3.7"}
 [tool.poetry.extras]
 db = [ "orator" ]
 
+# Allows testing https://github.com/python-poetry/poetry-core/pull/492
+[tool.black]
+preview = true
+
 [tool.poetry.group.dev.dependencies]
 pytest = "~3.4"
 

--- a/tests/fixtures/sample_project/pyproject.toml
+++ b/tests/fixtures/sample_project/pyproject.toml
@@ -50,7 +50,12 @@ dataclasses = {version = "^0.7", python = ">=3.6.1,<3.7"}
 [tool.poetry.extras]
 db = [ "orator" ]
 
-# Allows testing https://github.com/python-poetry/poetry-core/pull/492
+# Non-regression test for https://github.com/python-poetry/poetry-core/pull/492.
+# The underlying issue occurred because `tomlkit` can either return a TOML table as `Table` instance or an
+# `OutOfOrderProxy` one, if a table is discontinuous and multiple sections of a table are separated by a non-related
+# table, but we were too strict in our type check assertions.
+# So adding `tool.black` here ensure that we have discontinuous tables, so that we don't re-introduce the issue caused
+# by the type check assertion that ended up being reverted.
 [tool.black]
 preview = true
 

--- a/tests/integration/test_pep517_backend.py
+++ b/tests/integration/test_pep517_backend.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import shutil
+
+from pathlib import Path
+
+import pytest
+
+from tests.testutils import subprocess_run
+
+
+pytestmark = pytest.mark.integration
+
+
+BUILD_SYSTEM_TEMPLATE = """
+[build-system]
+requires = ["poetry-core @ file://{project_path}"]
+build-backend = "poetry.core.masonry.api"
+"""
+
+
+def test_pip_install(
+    temporary_directory: Path, project_source_root: Path, python: str
+) -> None:
+    """
+    Ensure that a project using the repository version of poetry-core as a PEP 517 backend can be built.
+    """
+    temp_pep_517_backend_path = temporary_directory / "pep_517_backend"
+
+    # Copy `pep_517_backend` to a temporary directory as we need to dynamically add the
+    # build system during the test. This ensures that we don't update the source, since
+    # the value of `requires` is dynamic.
+    shutil.copytree(
+        Path(__file__).parent.parent / "fixtures/pep_517_backend",
+        temp_pep_517_backend_path,
+    )
+
+    # Append dynamic `build-system` section to `pyproject.toml` in the temporary
+    # project directory.
+    with open(temp_pep_517_backend_path / "pyproject.toml", "a") as f:
+        f.write(
+            BUILD_SYSTEM_TEMPLATE.format(project_path=project_source_root.as_posix())
+        )
+
+    subprocess_run(
+        python,
+        "-m",
+        "pip",
+        "install",
+        temp_pep_517_backend_path.as_posix(),
+    )
+
+    pip_show = subprocess_run(python, "-m", "pip", "show", "foo")
+    assert "Name: foo" in pip_show.stdout


### PR DESCRIPTION
Add an integration test to ensure that a project using the repository version of `poetry-core` is installable via `pip`.

Since it's not possible to use relative paths in `build-system.requires`, the test dynamically adds it by copying the project fixture into a temporary directory, then appending the definition based on the path location.

https://github.com/python-poetry/poetry-core/commit/7c474fdd16c88e6700733459f64809d0d4a93893 also slightly updates some fixtures used by unit tests to ensure we don't re-introduce https://github.com/python-poetry/poetry-core/pull/492.