### PR TITLE
Test against python 3.11 again

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, MacOS, Windows]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
       fail-fast: false
     defaults:
       run:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,11 @@ jobs:
           # Using `timeout` is a safeguard against the Poetry command hanging for some reason.
           timeout 10s poetry run pip --version || rm -rf .venv
 
+      # XXX: https://github.com/pypa/pip/issues/11352 causes random failures -- remove once fixed in a release.
+      - name: Upgrade pip on 3.11 for macOS
+        if: ${{ matrix.python-version == '3.11-dev' && matrix.os == 'macOS' }}
+        run: poetry run pip install git+https://github.com/pypa/pip.git@f8a25921e5c443b07483017b0ffdeb08b9ba2fdf
+
       - name: Install dependencies
         run: poetry install
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, MacOS, Windows]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
         include:
           - os: Ubuntu
             python-version: pypy-3.8


### PR DESCRIPTION
Add back Python 3.11 on the CI, this time including https://github.com/python-poetry/poetry-core/commit/4bb42666a91125cb2b3c9988f8505aa694d0736f that is the same fix applied in https://github.com/python-poetry/poetry/pull/6586 (although using a more recent version of `pip` from `main` branch). This should prevent the random failures we spotted before reverting this change.