### PR TITLE
ci: upgrade `pip` for 3.11 on all OSes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
 
       # XXX: https://github.com/pypa/pip/issues/11352 causes random failures -- remove once fixed in a release.
       - name: Upgrade pip on 3.11 for macOS
-        if: ${{ matrix.python-version == '3.11-dev' && matrix.os == 'macOS' }}
+        if: ${{ matrix.python-version == '3.11-dev' }}
         run: poetry run pip install git+https://github.com/pypa/pip.git@f8a25921e5c443b07483017b0ffdeb08b9ba2fdf
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
           timeout 10s poetry run pip --version || rm -rf .venv
 
       # XXX: https://github.com/pypa/pip/issues/11352 causes random failures -- remove once fixed in a release.
-      - name: Upgrade pip on 3.11 for macOS
+      - name: Upgrade pip on Python 3.11
         if: ${{ matrix.python-version == '3.11-dev' }}
         run: poetry run pip install git+https://github.com/pypa/pip.git@f8a25921e5c443b07483017b0ffdeb08b9ba2fdf
 


### PR DESCRIPTION
It looks like the random 3.11 failure does not only affect macOS, as can be seen [here](https://github.com/python-poetry/poetry-core/actions/runs/3230909619/jobs/5289871785), so let's upgrade pip for all OSes.