### PR TITLE
Don't allow trailing newlines in description

### DIFF
--- a/src/poetry/core/json/schemas/poetry-schema.json
+++ b/src/poetry/core/json/schemas/poetry-schema.json
@@ -21,7 +21,7 @@
     "description": {
       "type": "string",
       "description": "Short package description.",
-      "pattern": "^[^\n]*$"
+      "pattern": "\\A[^\n]*\\Z"
     },
     "keywords": {
       "type": "array",

--- a/tests/json/test_poetry_schema.py
+++ b/tests/json/test_poetry_schema.py
@@ -50,10 +50,18 @@ def test_multi_url_dependencies(multi_url_object: dict[str, Any]) -> None:
     assert len(validate_object(multi_url_object, "poetry-schema")) == 0
 
 
-def test_multiline_description(base_object: dict[str, Any]) -> None:
-    bad_description = "Some multi-\nline string"
+@pytest.mark.parametrize(
+    "bad_description",
+    ["Some multi-\nline string", "Some multiline string\n", "\nSome multi-line string"],
+)
+def test_multiline_description(
+    base_object: dict[str, Any], bad_description: str
+) -> None:
     base_object["description"] = bad_description
 
     errors = validate_object(base_object, "poetry-schema")
+
     assert len(errors) == 1
-    assert errors[0] == f"[description] {bad_description!r} does not match '^[^\\n]*$'"
+
+    regex = r"\\A[^\n]*\\Z"
+    assert errors[0] == f"[description] {bad_description!r} does not match '{regex}'"


### PR DESCRIPTION
Resolves: python-poetry/poetry#3610

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

No newlines should be allowed for the description, but trailing newlines still get matched by `$` in the current regex. Instead we can use `\Z`.
