### PR TITLE
strict flake8-type-checking

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,7 +6,7 @@ ban-relative-imports = True
 format-greedy = 1
 inline-quotes = double
 enable-extensions = TC, TC1
-strict-type-checking = true
+type-checking-strict = true
 eradicate-whitelist-extend = ^-.*;
 extend-ignore =
     # E203: Whitespace before ':' (pycqa/pycodestyle#373)

--- a/.flake8
+++ b/.flake8
@@ -6,7 +6,7 @@ ban-relative-imports = True
 format-greedy = 1
 inline-quotes = double
 enable-extensions = TC, TC1
-type-checking-exempt-modules = typing, typing-extensions
+strict-type-checking = true
 eradicate-whitelist-extend = ^-.*;
 extend-ignore =
     # E203: Whitespace before ':' (pycqa/pycodestyle#373)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
           - flake8-quotes==3.3.1
           - flake8-simplify==0.19.3
           - flake8-tidy-imports==4.8.0
-          - flake8-type-checking==2.1.2
+          - flake8-type-checking==2.2.0
           - flake8-typing-imports==1.12.0
           - flake8-use-fstring==1.4
           - pep8-naming==0.13.1

--- a/src/poetry/core/masonry/utils/helpers.py
+++ b/src/poetry/core/masonry/utils/helpers.py
@@ -80,4 +80,4 @@ def distribution_name(name: NormalizedName) -> DistributionName:
     respectively), and replace dash (-) characters with underscore (_) characters ...
     """
     distribution_name = name.replace("-", "_")
-    return cast(DistributionName, distribution_name)
+    return cast("DistributionName", distribution_name)

--- a/tests/packages/test_directory_dependency.py
+++ b/tests/packages/test_directory_dependency.py
@@ -26,7 +26,7 @@ def _test_directory_dependency_pep_508(
     )
 
     assert dep.is_directory()
-    dep = cast(DirectoryDependency, dep)
+    dep = cast("DirectoryDependency", dep)
     assert dep.name == name
     assert dep.path == path
     assert dep.to_pep_508() == (pep_508_output or pep_508_input)

--- a/tests/packages/test_file_dependency.py
+++ b/tests/packages/test_file_dependency.py
@@ -111,7 +111,7 @@ def _test_file_dependency_pep_508(
         dep.marker = marker
 
     assert dep.is_file()
-    dep = cast(FileDependency, dep)
+    dep = cast("FileDependency", dep)
     assert dep.name == name
     assert dep.path == path
     assert dep.to_pep_508() == (pep_508_output or pep_508_input)

--- a/tests/packages/test_main.py
+++ b/tests/packages/test_main.py
@@ -186,7 +186,7 @@ def test_dependency_from_pep_508_with_git_url() -> None:
 
     assert dep.name == "django-utils"
     assert dep.is_vcs()
-    dep = cast(VCSDependency, dep)
+    dep = cast("VCSDependency", dep)
     assert dep.vcs == "git"
     assert dep.source == "ssh://git@corp-gitlab.com/corp-utils.git"
     assert dep.reference == "1.2"
@@ -202,7 +202,7 @@ def test_dependency_from_pep_508_with_git_url_and_subdirectory() -> None:
 
     assert dep.name == "django-utils"
     assert dep.is_vcs()
-    dep = cast(VCSDependency, dep)
+    dep = cast("VCSDependency", dep)
     assert dep.vcs == "git"
     assert dep.source == "ssh://git@corp-gitlab.com/corp-utils.git"
     assert dep.reference == "1.2"
@@ -219,7 +219,7 @@ def test_dependency_from_pep_508_with_git_url_and_comment_and_extra() -> None:
 
     assert dep.name == "poetry"
     assert dep.is_vcs()
-    dep = cast(VCSDependency, dep)
+    dep = cast("VCSDependency", dep)
     assert dep.vcs == "git"
     assert dep.source == "https://github.com/python-poetry/poetry.git"
     assert dep.reference == "b;ar;"
@@ -233,7 +233,7 @@ def test_dependency_from_pep_508_with_url() -> None:
 
     assert dep.name == "django-utils"
     assert dep.is_url()
-    dep = cast(URLDependency, dep)
+    dep = cast("URLDependency", dep)
     assert dep.url == "https://example.com/django-utils-1.0.0.tar.gz"
 
 
@@ -247,7 +247,7 @@ def test_dependency_from_pep_508_with_url_and_subdirectory() -> None:
 
     assert dep.name == "django-utils"
     assert dep.is_url()
-    dep = cast(URLDependency, dep)
+    dep = cast("URLDependency", dep)
     assert dep.url == "https://example.com/django-utils-1.0.0.tar.gz"
     assert dep.directory == "django"
 

--- a/tests/packages/test_main.py
+++ b/tests/packages/test_main.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from typing import cast
 
 from poetry.core.constraints.version import Version
 from poetry.core.packages.dependency import Dependency
-from poetry.core.packages.url_dependency import URLDependency
-from poetry.core.packages.vcs_dependency import VCSDependency
+
+
+if TYPE_CHECKING:
+    from poetry.core.packages.url_dependency import URLDependency
+    from poetry.core.packages.vcs_dependency import VCSDependency
 
 
 def test_dependency_from_pep_508() -> None:

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -350,7 +350,7 @@ def test_to_dependency_for_directory() -> None:
     assert dep.constraint == package.version
     assert dep.features == frozenset({"bar", "baz"})
     assert dep.is_directory()
-    dep = cast(DirectoryDependency, dep)
+    dep = cast("DirectoryDependency", dep)
     assert dep.path == path
     assert dep.source_type == "directory"
     assert dep.source_url == path.as_posix()
@@ -373,7 +373,7 @@ def test_to_dependency_for_file() -> None:
     assert dep.constraint == package.version
     assert dep.features == frozenset({"bar", "baz"})
     assert dep.is_file()
-    dep = cast(FileDependency, dep)
+    dep = cast("FileDependency", dep)
     assert dep.path == path
     assert dep.source_type == "file"
     assert dep.source_url == path.as_posix()
@@ -394,7 +394,7 @@ def test_to_dependency_for_url() -> None:
     assert dep.constraint == package.version
     assert dep.features == frozenset({"bar", "baz"})
     assert dep.is_url()
-    dep = cast(URLDependency, dep)
+    dep = cast("URLDependency", dep)
     assert dep.url == "https://example.com/path.tar.gz"
     assert dep.source_type == "url"
     assert dep.source_url == "https://example.com/path.tar.gz"
@@ -418,7 +418,7 @@ def test_to_dependency_for_vcs() -> None:
     assert dep.constraint == package.version
     assert dep.features == frozenset({"bar", "baz"})
     assert dep.is_vcs()
-    dep = cast(VCSDependency, dep)
+    dep = cast("VCSDependency", dep)
     assert dep.source_type == "git"
     assert dep.source == "https://github.com/foo/foo.git"
     assert dep.reference == "master"

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import random
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 from typing import cast
 
 import pytest
@@ -11,12 +12,15 @@ from poetry.core.constraints.version import Version
 from poetry.core.factory import Factory
 from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.dependency_group import DependencyGroup
-from poetry.core.packages.directory_dependency import DirectoryDependency
-from poetry.core.packages.file_dependency import FileDependency
 from poetry.core.packages.package import Package
 from poetry.core.packages.project_package import ProjectPackage
-from poetry.core.packages.url_dependency import URLDependency
-from poetry.core.packages.vcs_dependency import VCSDependency
+
+
+if TYPE_CHECKING:
+    from poetry.core.packages.directory_dependency import DirectoryDependency
+    from poetry.core.packages.file_dependency import FileDependency
+    from poetry.core.packages.url_dependency import URLDependency
+    from poetry.core.packages.vcs_dependency import VCSDependency
 
 
 @pytest.fixture()

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -57,7 +57,7 @@ def test_create_poetry() -> None:
     pendulum = dependencies["pendulum"]
     assert pendulum.pretty_constraint == "branch 2.0"
     assert pendulum.is_vcs()
-    pendulum = cast(VCSDependency, pendulum)
+    pendulum = cast("VCSDependency", pendulum)
     assert pendulum.vcs == "git"
     assert pendulum.branch == "2.0"
     assert pendulum.source == "https://github.com/sdispater/pendulum.git"
@@ -67,7 +67,7 @@ def test_create_poetry() -> None:
     tomlkit = dependencies["tomlkit"]
     assert tomlkit.pretty_constraint == "rev 3bff550"
     assert tomlkit.is_vcs()
-    tomlkit = cast(VCSDependency, tomlkit)
+    tomlkit = cast("VCSDependency", tomlkit)
     assert tomlkit.vcs == "git"
     assert tomlkit.rev == "3bff550"
     assert tomlkit.source == "https://github.com/sdispater/tomlkit.git"

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -12,13 +12,13 @@ from packaging.utils import canonicalize_name
 from poetry.core.constraints.version import parse_constraint
 from poetry.core.factory import Factory
 from poetry.core.packages.url_dependency import URLDependency
-from poetry.core.packages.vcs_dependency import VCSDependency
 from poetry.core.toml import TOMLFile
 from poetry.core.version.markers import SingleMarker
 
 
 if TYPE_CHECKING:
     from poetry.core.packages.dependency import Dependency
+    from poetry.core.packages.vcs_dependency import VCSDependency
 
 
 fixtures_dir = Path(__file__).parent / "fixtures"


### PR DESCRIPTION
recent flake8-type-checking encourages `cast()` using the name of the class rather than the actual class, presumably with the aim that you might find more things you don't need to import at runtime