### PR TITLE
fix: make AUTHOR_REGEX less restrictive

### DIFF
--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 import warnings
 
 from typing import TYPE_CHECKING
@@ -13,6 +12,7 @@ from poetry.core.constraints.version import parse_constraint
 from poetry.core.constraints.version.exceptions import ParseConstraintError
 from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.core.packages.specification import PackageSpecification
+from poetry.core.utils.patterns import AUTHOR_REGEX
 from poetry.core.version.exceptions import InvalidVersionError
 
 
@@ -31,10 +31,6 @@ if TYPE_CHECKING:
     from poetry.core.version.markers import BaseMarker
 
     T = TypeVar("T", bound="Package")
-
-AUTHOR_REGEX = re.compile(
-    r"(?u)^(?P<name>[- .,\w\d'’\"():&]+)(?: <(?P<email>.+?)>)?$"  # noqa: RUF001
-)
 
 
 class Package(PackageSpecification):

--- a/src/poetry/core/utils/patterns.py
+++ b/src/poetry/core/utils/patterns.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import re
 
 
+AUTHOR_REGEX = re.compile(r"(?u)^(?P<name>[^<>]+)(?: <(?P<email>.+?)>)?$")
+
 wheel_file_re = re.compile(
     r"""^(?P<namever>(?P<name>.+?)(-(?P<ver>\d.+?))?)
         ((-(?P<build>\d.*?))?-(?P<pyver>.+?)-(?P<abi>.+?)-(?P<plat>.+?)

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -83,6 +83,8 @@ def test_package_authors_invalid() -> None:
         ("John-Paul: Doe", None),
         ("John-Paul: Doe", "jp@nomail.none"),
         ("John Doe the 3rd", "3rd@jd.net"),
+        ("FirstName LastName firstname.lastname@company.com", None),
+        ("Surname, Given Name [Department]", None),
     ],
 )
 def test_package_authors_valid(name: str, email: str | None) -> None:
@@ -98,12 +100,9 @@ def test_package_authors_valid(name: str, email: str | None) -> None:
     ("name",),
     [
         ("<john@john.doe>",),
-        ("john@john.doe",),
+        ("<john@john.doe",),
+        ("john@john.doe>",),
         ("<John Doe",),
-        ("John? Doe",),
-        ("Jane+Doe",),
-        ("~John Doe",),
-        ("John~Doe",),
     ],
 )
 def test_package_author_names_invalid(name: str) -> None:


### PR DESCRIPTION
https://packaging.python.org/en/latest/specifications/core-metadata/#author makes no restriction to the `Author` name. So this PR makes the regex less restrictive. It also removes a duplication of the regex.

Resolves: https://github.com/python-poetry/poetry/issues/6857
Resolves: https://github.com/python-poetry/poetry/issues/6933