### PR TITLE
Improve parsing of author information

### DIFF
--- a/src/poetry/core/masonry/builders/builder.py
+++ b/src/poetry/core/masonry/builders/builder.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import re
 import sys
 import warnings
 
@@ -13,8 +12,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from poetry.core.poetry import Poetry
 
-
-AUTHOR_REGEX = re.compile(r"(?u)^(?P<name>[- .,\w\d'’\"()]+) <(?P<email>.+?)>$")
 
 METADATA_BASE = """\
 Metadata-Version: 2.1
@@ -344,12 +341,11 @@ class Builder:
 
     @classmethod
     def convert_author(cls, author: str) -> dict[str, str]:
-        m = AUTHOR_REGEX.match(author)
-        if m is None:
-            raise RuntimeError(f"{author} does not match regex")
+        from poetry.core.utils.helpers import parse_author
 
-        name = m.group("name")
-        email = m.group("email")
+        name, email = parse_author(author)
+        if not name or not email:
+            raise RuntimeError(f"{author} does not match regex")
 
         return {"name": name, "email": email}
 

--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -16,6 +16,7 @@ from poetry.core.constraints.version.exceptions import ParseConstraintError
 from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.core.packages.specification import PackageSpecification
 from poetry.core.packages.utils.utils import create_nested_marker
+from poetry.core.utils.helpers import parse_author
 from poetry.core.version.exceptions import InvalidVersion
 from poetry.core.version.markers import parse_marker
 
@@ -32,6 +33,8 @@ if TYPE_CHECKING:
 
     T = TypeVar("T", bound="Package")
 
+# TODO: once poetry.console.commands.init.InitCommand._validate_author
+# uses poetry.core.utils.helpers.parse_author, this can be removed.
 AUTHOR_REGEX = re.compile(r"(?u)^(?P<name>[- .,\w\d'’\"():&]+)(?: <(?P<email>.+?)>)?$")
 
 
@@ -231,16 +234,13 @@ class Package(PackageSpecification):
         if not self._authors:
             return {"name": None, "email": None}
 
-        m = AUTHOR_REGEX.match(self._authors[0])
+        name, email = parse_author(self._authors[0])
 
-        if m is None:
+        if not name or not email:
             raise ValueError(
                 "Invalid author string. Must be in the format: "
                 "John Smith <john@example.com>"
             )
-
-        name = m.group("name")
-        email = m.group("email")
 
         return {"name": name, "email": email}
 
@@ -248,16 +248,13 @@ class Package(PackageSpecification):
         if not self._maintainers:
             return {"name": None, "email": None}
 
-        m = AUTHOR_REGEX.match(self._maintainers[0])
+        name, email = parse_author(self._maintainers[0])
 
-        if m is None:
+        if not name or not email:
             raise ValueError(
                 "Invalid maintainer string. Must be in the format: "
                 "John Smith <john@example.com>"
             )
-
-        name = m.group("name")
-        email = m.group("email")
 
         return {"name": name, "email": email}
 

--- a/src/poetry/core/utils/helpers.py
+++ b/src/poetry/core/utils/helpers.py
@@ -8,6 +8,7 @@ import unicodedata
 import warnings
 
 from contextlib import contextmanager
+from email.utils import parseaddr
 from pathlib import Path
 from typing import Any
 from typing import Iterator
@@ -105,3 +106,26 @@ def readme_content_type(path: str | Path) -> str:
         return "text/markdown"
     else:
         return "text/plain"
+
+
+def parse_author(address: str) -> tuple[str | None, str | None]:
+    """Parse name and address parts from an email address string.
+
+    >>> parse_author("John Doe <john.doe@example.com>")
+    ('John Doe', 'john.doe@example.com')
+
+    .. note::
+
+       If the input string does not contain an ``@`` character, it is
+       assumed that it represents only a name without an email address.
+
+    :param address: the email address string to parse.
+    :return: a 2-tuple with the parsed name and email address.  If a
+             part is missing, ``None`` will be returned in its place.
+    """
+    if "@" not in address:
+        return address, None
+    name, email = parseaddr(address)
+    if not name and "@" not in email:
+        return email, None
+    return name or None, email or None


### PR DESCRIPTION
Instead of relying on regular expressions, this patch leverages Python’s builtin `email.utils.parseaddr()` functionality to parse an RFC-822-compliant email address string into its name and address parts.

This should also resolve issues with special characters in the name part; see for example:

  * https://github.com/sdispater/poetry/issues/370
  * https://github.com/sdispater/poetry/issues/798

This is a followup to [python-poetry/poetry PR #1040](https://github.com/python-poetry/poetry/pull/1040), as advised by [@Secrus’ comment](https://github.com/python-poetry/poetry/pull/1040#issuecomment-1223645536).

If this PR gets accepted, there will be two additional steps:

 1. Refactor `poetry.console.commands.init.InitCommand._validate_author()` to use the new `parse_author()` helper, see https://github.com/python-poetry/poetry/blob/master/src/poetry/console/commands/init.py#L441
 2. Remove `AUTHOR_REGEX` from `poetry.core.packages.package`.

- [X] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
