### PR TITLE
Recognise empty marker in a complex intersection

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -459,7 +459,12 @@ class MultiMarker(BaseMarker):
 
         new_markers = self._markers + [other]
 
-        return MultiMarker.of(*new_markers)
+        multi = MultiMarker.of(*new_markers)
+
+        if isinstance(multi, MultiMarker):
+            return dnf(multi)
+
+        return multi
 
     def union(self, other: BaseMarker) -> BaseMarker:
         if isinstance(other, (SingleMarker, MultiMarker)):

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -1311,6 +1311,16 @@ def test_single_markers_are_found_in_complex_intersection() -> None:
     )
 
 
+def test_empty_marker_is_found_in_complex_intersection() -> None:
+    m1 = parse_marker(
+        '(platform_system != "Windows" or platform_machine != "x86") and python_version'
+        ' == "3.8"'
+    )
+    m2 = parse_marker('platform_system == "Windows" and platform_machine == "x86"')
+    intersection = m1.intersect(m2)
+    assert intersection.is_empty()
+
+
 @pytest.mark.parametrize(
     "python_version, python_full_version, "
     "expected_intersection_version, expected_union_version",

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -1311,14 +1311,40 @@ def test_single_markers_are_found_in_complex_intersection() -> None:
     )
 
 
-def test_empty_marker_is_found_in_complex_intersection() -> None:
-    m1 = parse_marker(
-        '(platform_system != "Windows" or platform_machine != "x86") and python_version'
-        ' == "3.8"'
-    )
-    m2 = parse_marker('platform_system == "Windows" and platform_machine == "x86"')
-    intersection = m1.intersect(m2)
-    assert intersection.is_empty()
+@pytest.mark.parametrize(
+    "marker1, marker2",
+    [
+        (
+            (
+                '(platform_system != "Windows" or platform_machine != "x86") and'
+                ' python_version == "3.8"'
+            ),
+            'platform_system == "Windows" and platform_machine == "x86"',
+        ),
+        # Following example via
+        # https://github.com/python-poetry/poetry-plugin-export/issues/163
+        (
+            (
+                'python_version >= "3.8" and python_version < "3.11" and'
+                ' (python_version > "3.9" or platform_system != "Windows" or'
+                ' platform_machine != "x86") or python_version >= "3.11" and'
+                ' python_version < "3.12"'
+            ),
+            (
+                'python_version == "3.8" and platform_system == "Windows" and'
+                ' platform_machine == "x86" or python_version == "3.9" and'
+                ' platform_system == "Windows" and platform_machine == "x86"'
+            ),
+        ),
+    ],
+)
+def test_empty_marker_is_found_in_complex_intersection(
+    marker1: str, marker2: str
+) -> None:
+    m1 = parse_marker(marker1)
+    m2 = parse_marker(marker2)
+    assert m1.intersect(m2).is_empty()
+    assert m2.intersect(m1).is_empty()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes https://github.com/python-poetry/poetry-plugin-export/issues/163, in which the problem turns out to be that the exporter thinks that it has found overlapping markers when it really hasn't.

I'm a bit surprised that this didn't have any effect on existing unit test, but I guess that's good...

Fix feels a bit ad-hoc, better ways welcomed!