### PR TITLE
markers: improve recognition of empty marker in a complex intersections

### DIFF
--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -1304,11 +1304,24 @@ def test_single_markers_are_found_in_complex_intersection() -> None:
         'python_version >= "3.6" and python_version < "4.0" and implementation_name =='
         ' "cpython"'
     )
-    intersection = m1.intersect(m2)
     assert (
-        str(intersection)
+        str(m1.intersect(m2))
         == 'implementation_name == "cpython" and python_version == "3.6"'
     )
+    assert (
+        str(m2.intersect(m1))
+        == 'python_version == "3.6" and implementation_name == "cpython"'
+    )
+
+
+def test_empty_marker_is_found_in_complex_intersection() -> None:
+    m1 = parse_marker(
+        '(platform_system != "Windows" or platform_machine != "x86") and python_version'
+        ' == "3.8"'
+    )
+    m2 = parse_marker('platform_system == "Windows" and platform_machine == "x86"')
+    assert m1.intersect(m2).is_empty()
+    assert m2.intersect(m1).is_empty()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Resolves: python-poetry/poetry-plugin-export#163
Closes: #528

Alternative approach to #528. Includes some minor cleanup to make `MultiMarker.of` and `MarkerUnion.of` more symmetrical (as far as that is possible). The relevant change is the handling of `MultiMarker` in `_of_marker_union_and_single_marker`.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
