### PR TITLE
Simplify marker simplification

### DIFF
--- a/src/poetry/core/packages/utils/utils.py
+++ b/src/poetry/core/packages/utils/utils.py
@@ -179,8 +179,8 @@ def convert_markers(marker: BaseMarker) -> ConvertedMarkers:
     for i, sub_marker in enumerate(conjunctions):
         if isinstance(sub_marker, MultiMarker):
             for m in sub_marker.markers:
-                if isinstance(m, SingleMarker):
-                    add_constraint(m.name, (m.operator, m.value), i)
+                assert isinstance(m, SingleMarker)
+                add_constraint(m.name, (m.operator, m.value), i)
         elif isinstance(sub_marker, SingleMarker):
             add_constraint(sub_marker.name, (sub_marker.operator, sub_marker.value), i)
 

--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -370,11 +370,14 @@ def _flatten_markers(
 
     for marker in markers:
         if isinstance(marker, flatten_class):
-            flattened += _flatten_markers(
+            for _marker in _flatten_markers(
                 marker.markers,  # type: ignore[attr-defined]
                 flatten_class,
-            )
-        else:
+            ):
+                if _marker not in flattened:
+                    flattened.append(_marker)
+
+        elif marker not in flattened:
             flattened.append(marker)
 
     return flattened

--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -438,9 +438,6 @@ class MultiMarker(BaseMarker):
         return dnf(multi)
 
     def union(self, other: BaseMarker) -> BaseMarker:
-        if isinstance(other, MarkerUnion):
-            return other.union(self)
-
         union = MarkerUnion(self, other)
         conjunction = cnf(union)
         if not isinstance(conjunction, MultiMarker):
@@ -639,9 +636,6 @@ class MarkerUnion(BaseMarker):
         self._markers.append(marker)
 
     def intersect(self, other: BaseMarker) -> BaseMarker:
-        if isinstance(other, MultiMarker):
-            return other.intersect(self)
-
         multi = MultiMarker(self, other)
         return dnf(multi)
 

--- a/tests/packages/test_main.py
+++ b/tests/packages/test_main.py
@@ -102,9 +102,9 @@ def test_dependency_from_pep_508_complex() -> None:
     assert dep.python_versions == ">=2.7 !=3.2.*"
     assert (
         str(dep.marker)
-        == 'python_version >= "2.7" and python_version != "3.2" '
-        'and (sys_platform == "win32" or sys_platform == "darwin") '
-        'and extra == "foo"'
+        == 'python_version >= "2.7" and python_version != "3.2" and sys_platform =='
+        ' "win32" and extra == "foo" or python_version >= "2.7" and python_version'
+        ' != "3.2" and sys_platform == "darwin" and extra == "foo"'
     )
 
 
@@ -278,11 +278,11 @@ def test_dependency_from_pep_508_with_python_full_version() -> None:
     assert dep.name == "requests"
     assert str(dep.constraint) == "2.18.0"
     assert dep.extras == frozenset()
-    assert dep.python_versions == ">=2.7 <2.8 || >=3.4 <3.5.4"
+    assert dep.python_versions == ">=2.7 <2.8 || >=3.4.0 <3.5.4"
     assert (
         str(dep.marker)
         == 'python_version >= "2.7" and python_version < "2.8" '
-        'or python_full_version >= "3.4" and python_full_version < "3.5.4"'
+        'or python_full_version >= "3.4.0" and python_full_version < "3.5.4"'
     )
 
 

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -41,7 +41,10 @@ from poetry.core.version.markers import parse_marker
                 ' "win32" and python_version < "3.6" and python_version >= "3.3" or'
                 ' sys_platform == "win32" and python_version < "3.3"'
             ),
-            {"python_version": [[("<", "3.6")]], "sys_platform": [[("==", "win32")]]},
+            {
+                "python_version": [[("<", "3.6")], [("<", "3.3")]],
+                "sys_platform": [[("==", "win32")]],
+            },
         ),
         (
             'python_version == "2.7" or python_version == "2.6"',

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -25,8 +25,8 @@ from poetry.core.version.markers import parse_marker
             {
                 "python_version": [
                     [("<", "3.6")],
-                    [("<", "3.6"), (">=", "3.3")],
                     [("<", "3.3")],
+                    [("<", "3.6"), (">=", "3.3")],
                 ],
                 "sys_platform": [
                     [("==", "win32")],
@@ -41,10 +41,7 @@ from poetry.core.version.markers import parse_marker
                 ' "win32" and python_version < "3.6" and python_version >= "3.3" or'
                 ' sys_platform == "win32" and python_version < "3.3"'
             ),
-            {
-                "python_version": [[("<", "3.6")], [("<", "3.3")]],
-                "sys_platform": [[("==", "win32")]],
-            },
+            {"python_version": [[("<", "3.6")]], "sys_platform": [[("==", "win32")]]},
         ),
         (
             'python_version == "2.7" or python_version == "2.6"',

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -573,14 +573,21 @@ def test_version_ranges_collapse_on_union(
 
 
 def test_multi_marker_union_with_union() -> None:
-    m = parse_marker('sys_platform == "darwin" and implementation_name == "cpython"')
+    m1 = parse_marker('sys_platform == "darwin" and implementation_name == "cpython"')
+    m2 = parse_marker('python_version >= "3.6" or os_name == "Windows"')
 
-    union = m.union(parse_marker('python_version >= "3.6" or os_name == "Windows"'))
-    assert (
-        str(union)
-        == 'python_version >= "3.6" or os_name == "Windows"'
-        ' or sys_platform == "darwin" and implementation_name == "cpython"'
+    # Union isn't _quite_ symmetrical.
+    expected1 = (
+        'sys_platform == "darwin" and implementation_name == "cpython" or'
+        ' python_version >= "3.6" or os_name == "Windows"'
     )
+    assert str(m1.union(m2)) == expected1
+
+    expected2 = (
+        'python_version >= "3.6" or os_name == "Windows" or'
+        ' sys_platform == "darwin" and implementation_name == "cpython"'
+    )
+    assert str(m2.union(m1)) == expected2
 
 
 def test_multi_marker_union_with_multi_union_is_single_marker() -> None:
@@ -684,17 +691,24 @@ def test_marker_union_intersect_multi_marker() -> None:
     m1 = parse_marker('sys_platform == "darwin" or python_version < "3.4"')
     m2 = parse_marker('implementation_name == "cpython" and os_name == "Windows"')
 
-    expected = (
+    # Intersection isn't _quite_ symmetrical.
+    expected1 = (
+        'sys_platform == "darwin" and implementation_name == "cpython" and os_name =='
+        ' "Windows" or python_version < "3.4" and implementation_name == "cpython" and'
+        ' os_name == "Windows"'
+    )
+
+    intersection = m1.intersect(m2)
+    assert str(intersection) == expected1
+
+    expected2 = (
         'implementation_name == "cpython" and os_name == "Windows" and sys_platform'
         ' == "darwin" or implementation_name == "cpython" and os_name == "Windows"'
         ' and python_version < "3.4"'
     )
 
-    intersection = m1.intersect(m2)
-    assert str(intersection) == expected
-
     intersection = m2.intersect(m1)
-    assert str(intersection) == expected
+    assert str(intersection) == expected2
 
 
 def test_marker_union_union_with_union() -> None:

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -1370,6 +1370,16 @@ def test_empty_marker_is_found_in_complex_intersection(
     assert m2.intersect(m1).is_empty()
 
 
+def test_empty_marker_is_found_in_complex_parse() -> None:
+    marker = parse_marker(
+        '(python_implementation != "pypy" or python_version != "3.6") and '
+        '((python_implementation != "pypy" and python_version != "3.6") or'
+        ' (python_implementation == "pypy" and python_version == "3.6")) and '
+        '(python_implementation == "pypy" or python_version == "3.6")'
+    )
+    assert marker.is_empty()
+
+
 @pytest.mark.parametrize(
     "python_version, python_full_version, "
     "expected_intersection_version, expected_union_version",

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -519,16 +519,16 @@ def test_multi_marker_union_multi_is_multi(
             'python_full_version >= "3.6.2" and python_version < "3.7"',
             'python_version >= "3.6" and python_version < "3.7"',
         ),
-        # Ranges with same end.  Ideally the union would give the lower version first.
+        # Ranges with same end.
         (
             'python_version >= "3.6" and python_version < "3.7"',
             'python_full_version >= "3.6.2" and python_version < "3.7"',
-            'python_version < "3.7" and python_version >= "3.6"',
+            'python_version >= "3.6" and python_version < "3.7"',
         ),
         (
             'python_version >= "3.6" and python_version <= "3.7"',
             'python_full_version >= "3.6.2" and python_version <= "3.7"',
-            'python_version <= "3.7" and python_version >= "3.6"',
+            'python_version >= "3.6" and python_version <= "3.7"',
         ),
         # A range covers an exact marker.
         (


### PR DESCRIPTION
per the discussion from https://github.com/python-poetry/poetry-core/pull/528#issuecomment-1328237347, try to use reduction to DNF and CNF as much as possible to achieve marker simplifications, in the hope that:

- it's more general than the collection of heuristics we currently have
- it simplifies the code

I think this probably is an improvement - and the test coverage is pretty decent here, so there's reason to think that it doesn't break things too badly.  But more opinion is certainly wanted.