### PR TITLE
Deprecate hash function from FileDependency

### DIFF
--- a/src/poetry/core/packages/file_dependency.py
+++ b/src/poetry/core/packages/file_dependency.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import io
+import warnings
 
 from pathlib import Path
 from typing import Iterable
@@ -63,6 +64,11 @@ class FileDependency(Dependency):
         return True
 
     def hash(self, hash_name: str = "sha256") -> str:
+        warnings.warn(
+            "hash() is deprecated. Use poetry.utils.helpers.get_file_hash() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         h = hashlib.new(hash_name)
         with self._full_path.open("rb") as fp:
             for content in iter(lambda: fp.read(io.DEFAULT_BUFFER_SIZE), b""):

--- a/tests/packages/test_file_dependency.py
+++ b/tests/packages/test_file_dependency.py
@@ -31,10 +31,11 @@ def test_file_dependency_dir() -> None:
 
 
 def test_default_hash() -> None:
-    path = DIST_PATH / TEST_FILE
-    dep = FileDependency("demo", path)
-    sha_256 = "72e8531e49038c5f9c4a837b088bfcb8011f4a9f76335c8f0654df6ac539b3d6"
-    assert dep.hash() == sha_256
+    with pytest.warns(DeprecationWarning):
+        path = DIST_PATH / TEST_FILE
+        dep = FileDependency("demo", path)
+        sha_256 = "72e8531e49038c5f9c4a837b088bfcb8011f4a9f76335c8f0654df6ac539b3d6"
+        assert dep.hash() == sha_256
 
 
 try:
@@ -88,9 +89,10 @@ except ImportError:
     ],
 )
 def test_guaranteed_hash(hash_name: str, expected: str) -> None:
-    path = DIST_PATH / TEST_FILE
-    dep = FileDependency("demo", path)
-    assert dep.hash(hash_name) == expected
+    with pytest.warns(DeprecationWarning):
+        path = DIST_PATH / TEST_FILE
+        dep = FileDependency("demo", path)
+        assert dep.hash(hash_name) == expected
 
 
 def _test_file_dependency_pep_508(


### PR DESCRIPTION
This will enable URLDependency to compute the hash for the file at the temporary path. The temporary path should be the path to the downloaded file from `URLDependency.url`.

Relates-to: python-poetry/poetry#7121

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
