### PR TITLE
chore: run downstream tests for 1.3 instead of 1.2

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ref: ["master", "1.2"]
+        ref: ["master", "1.3"]
       fail-fast: false
     defaults:
       run:


### PR DESCRIPTION
With the release of poetry 1.3, we want to run downstream tests for the 1.3 branch instead of 1.2