### PR TITLE
PEP 440 compliance: do not implicitly allow pre-releases

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ref: ["master", "1.3"]
+        ref: ["master"]
       fail-fast: false
     defaults:
       run:

--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -13,7 +13,6 @@ from typing import TypeVar
 from packaging.utils import canonicalize_name
 
 from poetry.core.constraints.generic import parse_constraint as parse_generic_constraint
-from poetry.core.constraints.version import VersionRangeConstraint
 from poetry.core.constraints.version import parse_constraint
 from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.core.packages.specification import PackageSpecification
@@ -71,15 +70,6 @@ class Dependency(PackageSpecification):
             groups = [MAIN_GROUP]
 
         self._groups = frozenset(groups)
-
-        if (
-            isinstance(self._constraint, VersionRangeConstraint)
-            and self._constraint.min
-        ):
-            allows_prereleases = (
-                allows_prereleases or self._constraint.min.is_unstable()
-            )
-
         self._allows_prereleases = allows_prereleases
 
         self._python_versions = "*"

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -10,20 +10,22 @@ from poetry.core.version.markers import parse_marker
 
 
 @pytest.mark.parametrize(
-    "constraint,result",
+    "constraint",
     [
-        ("^1.0", False),
-        ("^1.0.dev0", True),
-        ("^1.0.0", False),
-        ("^1.0.0.dev0", True),
-        ("^1.0.0.alpha0", True),
-        ("^1.0.0.alpha0+local", True),
-        ("^1.0.0.rc0+local", True),
-        ("^1.0.0-1", False),
+        "^1.0",
+        "^1.0.dev0",
+        "^1.0.0",
+        "^1.0.0.dev0",
+        "^1.0.0.alpha0",
+        "^1.0.0.alpha0+local",
+        "^1.0.0.rc0+local",
+        "^1.0.0-1",
     ],
 )
-def test_allows_prerelease(constraint: str, result: bool) -> None:
-    assert Dependency("A", constraint).allows_prereleases() == result
+@pytest.mark.parametrize("allows_prereleases", [False, True])
+def test_allows_prerelease(constraint: str, allows_prereleases: bool) -> None:
+    dependency = Dependency("A", constraint, allows_prereleases=allows_prereleases)
+    assert dependency.allows_prereleases() == allows_prereleases
 
 
 def test_to_pep_508() -> None:


### PR DESCRIPTION
Extracted from #402. Besides being a precondition of #402 it's a fix on its own. And it requires some coordination with downstream.

Requires: python-poetry/poetry#7225 and python-poetry/poetry#7236

PEP 440 says:

> Pre-releases of any kind, including developmental releases, are implicitly excluded from all version specifiers, unless they are already present on the system, explicitly requested by the user, or if the only available version that satisfies the version specifier is a pre-release.

Nothing special about "`>` _pre-release_" or "`>=` _pre-release_"