### PR TITLE
builders/wheel: Ensure dist-info is written deterministically

### DIFF
--- a/src/poetry/core/masonry/builders/wheel.py
+++ b/src/poetry/core/masonry/builders/wheel.py
@@ -294,7 +294,7 @@ class WheelBuilder(Builder):
 
     def _copy_dist_info(self, wheel: zipfile.ZipFile, source: Path) -> None:
         dist_info = Path(self.dist_info)
-        for file in source.glob("**/*"):
+        for file in sorted(source.glob("**/*")):
             if not file.is_file():
                 continue
 

--- a/src/poetry/core/masonry/builders/wheel.py
+++ b/src/poetry/core/masonry/builders/wheel.py
@@ -190,7 +190,7 @@ class WheelBuilder(Builder):
 
                     lib = libs[0]
 
-                    for pkg in lib.glob("**/*"):
+                    for pkg in sorted(lib.glob("**/*")):
                         if pkg.is_dir() or self.is_excluded(pkg):
                             continue
 


### PR DESCRIPTION
glob() returns values in "on disk" order. To make the RECORD file deterministic and consistent between builds we need to sort the data before adding to the records list.

Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>

Resolves: python-poetry#<!-- add issue number/link here -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
