### PR TITLE
markers: fix `get_python_constraint_by_marker()` for multi markers and marker unions without `python_version`

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -489,22 +489,7 @@ class MultiMarker(BaseMarker):
         return self.of(*new_markers)
 
     def only(self, *marker_names: str) -> BaseMarker:
-        new_markers = []
-
-        for m in self._markers:
-            if isinstance(m, SingleMarker) and m.name not in marker_names:
-                # The marker is not relevant since it's not one we want
-                continue
-
-            marker = m.only(*marker_names)
-
-            if not marker.is_empty():
-                new_markers.append(marker)
-
-        if not new_markers:
-            return EmptyMarker()
-
-        return self.of(*new_markers)
+        return self.of(*(m.only(*marker_names) for m in self._markers))
 
     def invert(self) -> BaseMarker:
         markers = [marker.invert() for marker in self._markers]
@@ -635,19 +620,7 @@ class MarkerUnion(BaseMarker):
         return self.of(*new_markers)
 
     def only(self, *marker_names: str) -> BaseMarker:
-        new_markers = []
-
-        for m in self._markers:
-            if isinstance(m, SingleMarker) and m.name not in marker_names:
-                # The marker is not relevant since it's not one we want
-                continue
-
-            marker = m.only(*marker_names)
-
-            if not marker.is_empty():
-                new_markers.append(marker)
-
-        return self.of(*new_markers)
+        return self.of(*(m.only(*marker_names) for m in self._markers))
 
     def invert(self) -> BaseMarker:
         markers = [marker.invert() for marker in self._markers]

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -212,6 +212,8 @@ def test_create_nested_marker_version_constraint(
         ),
         # no python_version
         ('sys_platform == "linux"', "*"),
+        ('sys_platform != "linux" and sys_platform != "win32"', "*"),
+        ('sys_platform == "linux" or sys_platform == "win32"', "*"),
         # no relevant python_version
         ('python_version >= "3.9" or sys_platform == "linux"', "*"),
         # relevant python_version

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -1017,6 +1017,9 @@ def test_exclude(marker: str, excluded: str, expected: str) -> None:
             ["python_version"],
             'python_version >= "3.6"',
         ),
+        ('python_version >= "3.6" and extra == "foo"', ["sys_platform"], ""),
+        ('python_version >= "3.6" or extra == "foo"', ["sys_platform"], ""),
+        ('python_version >= "3.6" or extra == "foo"', ["python_version"], ""),
         (
             'python_version >= "3.6" and (extra == "foo" or extra == "bar")',
             ["extra"],
@@ -1028,31 +1031,31 @@ def test_exclude(marker: str, excluded: str, expected: str) -> None:
                 ' implementation_name == "pypy"'
             ),
             ["implementation_name"],
-            'implementation_name == "pypy"',
+            "",
+        ),
+        (
+            (
+                'python_version >= "3.6" and (extra == "foo" or extra == "bar") or'
+                ' implementation_name == "pypy"'
+            ),
+            ["implementation_name", "extra"],
+            'extra == "foo" or extra == "bar" or implementation_name == "pypy"',
+        ),
+        (
+            (
+                'python_version >= "3.6" and (extra == "foo" or extra == "bar") or'
+                ' implementation_name == "pypy"'
+            ),
+            ["implementation_name", "python_version"],
+            'python_version >= "3.6" or implementation_name == "pypy"',
         ),
         (
             (
                 'python_version >= "3.6" and extra == "foo" or implementation_name =='
                 ' "pypy" and extra == "bar"'
             ),
-            ["implementation_name"],
-            'implementation_name == "pypy"',
-        ),
-        (
-            (
-                'python_version >= "3.6" or extra == "foo" and implementation_name =='
-                ' "pypy" or extra == "bar"'
-            ),
-            ["implementation_name"],
-            'implementation_name == "pypy"',
-        ),
-        (
-            (
-                'python_version >= "3.6" or extra == "foo" and implementation_name =='
-                ' "pypy" or extra == "bar"'
-            ),
-            ["implementation_name", "python_version"],
-            'python_version >= "3.6" or implementation_name == "pypy"',
+            ["implementation_name", "extra"],
+            'extra == "foo" or implementation_name == "pypy" and extra == "bar"',
         ),
     ],
 )


### PR DESCRIPTION
Actually the same as #307 which only covered single markers.

The actual fix is in `only()` of `MultiMarker` and `MarkerUnion`. The test shows that `get_python_constraint_by_marker()` is fixed.

There were some test cases testing the faulty behaviour of `only()`. I did not only change the expectation (which would have been `""` in most cases) but also the input in some cases to cover some more interesting cases.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
