### PR TITLE
performance fix for simplified marker simplifications

### DIFF
--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -25,8 +25,8 @@ from poetry.core.version.markers import parse_marker
             {
                 "python_version": [
                     [("<", "3.6")],
-                    [("<", "3.3")],
                     [("<", "3.6"), (">=", "3.3")],
+                    [("<", "3.3")],
                 ],
                 "sys_platform": [
                     [("==", "win32")],


### PR DESCRIPTION
While working on full support for overlapping markers, I encountered a combinatorial explosion when building a union of markers (see test case).

The issue is that we introduced `cnf` without introducing a counterpart of `union_simplify`, which leads to unnecessary big markers. Therefore, I added `intersect_simplify` analoguous to `union_simplify`.

Further, the simplifications in #530 went a bit too far in removing the `common_markers`/`unique_markers` simplification in `union_simplify`. I reverted this removal and added analogue functionality to `intersect_simplify`.

Comparing the number of items in `itertools.product` in `dnf` of `union` (after `cnf`) shows the benefit of the simplifications:

|union (see test case)|number and length of markers in conjunction after `cnf`|number of items in `itertools.product` in `dnf`|
|---|---|---|
without PR | 31 (1-4) |  > 2**44
with simple `intersect_simplifiy` | 9 (1-2) | 256
with revival of `common_markers`/`unique_markers` simplification | 3 (1-2) | 4