### PR TITLE
version.text replaces pretty_version

### DIFF
--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -72,7 +72,7 @@ class Factory:
     def get_package(cls, name: str, version: str) -> ProjectPackage:
         from poetry.core.packages.project_package import ProjectPackage
 
-        return ProjectPackage(name, version, version)
+        return ProjectPackage(name, version)
 
     @classmethod
     def _add_package_group_dependencies(

--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -54,7 +54,6 @@ class Package(PackageSpecification):
         self,
         name: str,
         version: str | Version,
-        pretty_version: str | None = None,
         source_type: str | None = None,
         source_url: str | None = None,
         source_reference: str | None = None,
@@ -79,7 +78,7 @@ class Package(PackageSpecification):
             features=features,
         )
 
-        self._set_version(version, pretty_version)
+        self._set_version(version)
 
         self.description = ""
 
@@ -130,7 +129,7 @@ class Package(PackageSpecification):
 
     @property
     def pretty_version(self) -> str:
-        return self._pretty_version
+        return self._version.text
 
     @property
     def unique_name(self) -> str:
@@ -146,22 +145,22 @@ class Package(PackageSpecification):
     @property
     def full_pretty_version(self) -> str:
         if self.source_type in ["file", "directory", "url"]:
-            return f"{self._pretty_version} {self.source_url}"
+            return f"{self.pretty_version} {self.source_url}"
 
         if self.source_type not in ["hg", "git"]:
-            return self._pretty_version
+            return self.pretty_version
 
         ref: str | None
         if self.source_resolved_reference and len(self.source_resolved_reference) == 40:
             ref = self.source_resolved_reference[0:7]
-            return f"{self._pretty_version} {ref}"
+            return f"{self.pretty_version} {ref}"
 
         # if source reference is a sha1 hash -- truncate
         if self.source_reference and len(self.source_reference) == 40:
-            return f"{self._pretty_version} {self.source_reference[0:7]}"
+            return f"{self.pretty_version} {self.source_reference[0:7]}"
 
         ref = self._source_resolved_reference or self._source_reference
-        return f"{self._pretty_version} {ref}"
+        return f"{self.pretty_version} {ref}"
 
     @property
     def authors(self) -> list[str]:
@@ -210,9 +209,7 @@ class Package(PackageSpecification):
             for dependency in group.dependencies
         ]
 
-    def _set_version(
-        self, version: str | Version, pretty_version: str | None = None
-    ) -> None:
+    def _set_version(self, version: str | Version) -> None:
         from poetry.core.constraints.version import Version
 
         if not isinstance(version, Version):
@@ -224,7 +221,6 @@ class Package(PackageSpecification):
                 )
 
         self._version = version
-        self._pretty_version = pretty_version or version.text
 
     def _get_author(self) -> dict[str, str | None]:
         if not self._authors:

--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import re
+import warnings
 
 from contextlib import contextmanager
 from pathlib import Path
@@ -54,6 +55,7 @@ class Package(PackageSpecification):
         self,
         name: str,
         version: str | Version,
+        pretty_version: str | None = None,
         source_type: str | None = None,
         source_url: str | None = None,
         source_reference: str | None = None,
@@ -67,6 +69,14 @@ class Package(PackageSpecification):
         Creates a new in memory package.
         """
         from poetry.core.version.markers import AnyMarker
+
+        if pretty_version is not None:
+            warnings.warn(
+                "The `pretty_version` parameter is deprecated and will be removed"
+                " in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         super().__init__(
             name,
@@ -364,8 +374,6 @@ class Package(PackageSpecification):
 
     @property
     def readme(self) -> Path | None:
-        import warnings
-
         warnings.warn(
             "`readme` is deprecated: you are getting only the first readme file. Please"
             " use the plural form `readmes`.",
@@ -375,8 +383,6 @@ class Package(PackageSpecification):
 
     @readme.setter
     def readme(self, path: Path) -> None:
-        import warnings
-
         warnings.warn(
             "`readme` is deprecated. Please assign a tuple to the plural form"
             " `readmes`.",

--- a/src/poetry/core/packages/project_package.py
+++ b/src/poetry/core/packages/project_package.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import warnings
+
 from typing import TYPE_CHECKING
 from typing import Any
 
@@ -22,7 +24,15 @@ class ProjectPackage(Package):
         version: str | Version,
         pretty_version: str | None = None,
     ) -> None:
-        super().__init__(name, version, pretty_version)
+        if pretty_version is not None:
+            warnings.warn(
+                "The `pretty_version` parameter is deprecated and will be removed"
+                " in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        super().__init__(name, version)
 
         self.build_config: dict[str, Any] = {}
         self.packages: list[dict[str, Any]] = []

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -443,7 +443,6 @@ def test_package_clone(f: Factory) -> None:
     p = Package(
         "lol_wut",
         "3.141.5926535",
-        pretty_version="③.⑭.⑮",
         source_type="git",
         source_url="http://some.url",
         source_reference="fe4d2adabf3feb5d32b70ab5c105285fa713b10c",


### PR DESCRIPTION
Companion to https://github.com/python-poetry/poetry/pull/7305

Downstream tests should fail until https://github.com/python-poetry/poetry/pull/7305 propagates

I suppose the `Package` could instead continue to accept the pretty_version in its constructor but just ignore it: while that would be backwards-compatible it would also be rather misleading.  

I don't think it's worth it myself - but if you really wanted to go through the deprecation cycle I suppose we could check for not-None pretty_version and warn