### PR TITLE
remove special-case any/empty code on MarkerUnion

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -128,9 +128,6 @@ class AnyMarker(BaseMarker):
     def is_any(self) -> bool:
         return True
 
-    def is_empty(self) -> bool:
-        return False
-
     def validate(self, environment: dict[str, Any] | None) -> bool:
         return True
 
@@ -168,9 +165,6 @@ class EmptyMarker(BaseMarker):
 
     def union(self, other: BaseMarker) -> BaseMarker:
         return other
-
-    def is_any(self) -> bool:
-        return False
 
     def is_empty(self) -> bool:
         return True
@@ -840,15 +834,7 @@ class MarkerUnion(BaseMarker):
         return h
 
     def __str__(self) -> str:
-        return " or ".join(
-            str(m) for m in self._markers if not m.is_any() and not m.is_empty()
-        )
-
-    def is_any(self) -> bool:
-        return any(m.is_any() for m in self._markers)
-
-    def is_empty(self) -> bool:
-        return all(m.is_empty() for m in self._markers)
+        return " or ".join(str(m) for m in self._markers)
 
 
 @functools.lru_cache(maxsize=None)

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -783,45 +783,29 @@ def test_marker_union_union_duplicates() -> None:
 
 
 def test_marker_union_all_any() -> None:
-    union = MarkerUnion(parse_marker(""), parse_marker(""))
+    union = MarkerUnion.of(parse_marker(""), parse_marker(""))
 
     assert union.is_any()
 
 
 def test_marker_union_not_all_any() -> None:
-    union = MarkerUnion(parse_marker(""), parse_marker(""), parse_marker("<empty>"))
+    union = MarkerUnion.of(parse_marker(""), parse_marker(""), parse_marker("<empty>"))
 
     assert union.is_any()
 
 
 def test_marker_union_all_empty() -> None:
-    union = MarkerUnion(parse_marker("<empty>"), parse_marker("<empty>"))
+    union = MarkerUnion.of(parse_marker("<empty>"), parse_marker("<empty>"))
 
     assert union.is_empty()
 
 
 def test_marker_union_not_all_empty() -> None:
-    union = MarkerUnion(
+    union = MarkerUnion.of(
         parse_marker("<empty>"), parse_marker("<empty>"), parse_marker("")
     )
 
     assert not union.is_empty()
-
-
-def test_marker_str_conversion_skips_empty_and_any() -> None:
-    union = MarkerUnion(
-        parse_marker("<empty>"),
-        parse_marker(
-            'sys_platform == "darwin" or python_version <= "3.6" or os_name =='
-            ' "Windows"'
-        ),
-        parse_marker(""),
-    )
-
-    assert (
-        str(union)
-        == 'sys_platform == "darwin" or python_version <= "3.6" or os_name == "Windows"'
-    )
 
 
 def test_intersect_compacts_constraints() -> None:
@@ -1717,10 +1701,8 @@ def test_intersection_avoids_combinatorial_explosion() -> None:
 
 
 @pytest.mark.parametrize(
-    (
-        "python_version, python_full_version, "
-        "expected_intersection_version, expected_union_version"
-    ),
+    "python_version, python_full_version, "
+    "expected_intersection_version, expected_union_version",
     [
         # python_version > 3.6 (equal to python_full_version >= 3.7.0)
         ('> "3.6"', '> "3.5.2"', '> "3.6"', '> "3.5.2"'),

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -24,6 +24,8 @@ from poetry.core.version.markers import union
 if TYPE_CHECKING:
     from poetry.core.version.markers import BaseMarker
 
+EMPTY = "<empty>"
+
 
 @pytest.mark.parametrize(
     "marker",
@@ -789,21 +791,19 @@ def test_marker_union_all_any() -> None:
 
 
 def test_marker_union_not_all_any() -> None:
-    union = MarkerUnion.of(parse_marker(""), parse_marker(""), parse_marker("<empty>"))
+    union = MarkerUnion.of(parse_marker(""), parse_marker(""), parse_marker(EMPTY))
 
     assert union.is_any()
 
 
 def test_marker_union_all_empty() -> None:
-    union = MarkerUnion.of(parse_marker("<empty>"), parse_marker("<empty>"))
+    union = MarkerUnion.of(parse_marker(EMPTY), parse_marker(EMPTY))
 
     assert union.is_empty()
 
 
 def test_marker_union_not_all_empty() -> None:
-    union = MarkerUnion.of(
-        parse_marker("<empty>"), parse_marker("<empty>"), parse_marker("")
-    )
+    union = MarkerUnion.of(parse_marker(EMPTY), parse_marker(EMPTY), parse_marker(""))
 
     assert not union.is_empty()
 
@@ -1713,13 +1713,13 @@ def test_intersection_avoids_combinatorial_explosion() -> None:
         ('> "3.6"', '>= "3.7.0"', '> "3.6"', '> "3.6"'),
         ('> "3.6"', '> "3.7.1"', '> "3.7.1"', '> "3.6"'),
         ('> "3.6"', '>= "3.7.1"', '>= "3.7.1"', '> "3.6"'),
-        ('> "3.6"', '== "3.6.2"', "<empty>", None),
+        ('> "3.6"', '== "3.6.2"', EMPTY, None),
         ('> "3.6"', '== "3.7.0"', '== "3.7.0"', '> "3.6"'),
         ('> "3.6"', '== "3.7.1"', '== "3.7.1"', '> "3.6"'),
         ('> "3.6"', '!= "3.6.2"', '> "3.6"', '!= "3.6.2"'),
         ('> "3.6"', '!= "3.7.0"', '> "3.7.0"', ""),
         ('> "3.6"', '!= "3.7.1"', None, ""),
-        ('> "3.6"', '< "3.7.0"', "<empty>", ""),
+        ('> "3.6"', '< "3.7.0"', EMPTY, ""),
         ('> "3.6"', '<= "3.7.0"', '== "3.7.0"', ""),
         ('> "3.6"', '< "3.7.1"', None, ""),
         ('> "3.6"', '<= "3.7.1"', None, ""),
@@ -1730,13 +1730,13 @@ def test_intersection_avoids_combinatorial_explosion() -> None:
         ('>= "3.6"', '>= "3.6.0"', '>= "3.6"', '>= "3.6"'),
         ('>= "3.6"', '> "3.6.1"', '> "3.6.1"', '>= "3.6"'),
         ('>= "3.6"', '>= "3.6.1"', '>= "3.6.1"', '>= "3.6"'),
-        ('>= "3.6"', '== "3.5.2"', "<empty>", None),
+        ('>= "3.6"', '== "3.5.2"', EMPTY, None),
         ('>= "3.6"', '== "3.6.0"', '== "3.6.0"', '>= "3.6"'),
         ('>= "3.6"', '!= "3.5.2"', '>= "3.6"', '!= "3.5.2"'),
         ('>= "3.6"', '!= "3.6.0"', '> "3.6.0"', ""),
         ('>= "3.6"', '!= "3.6.1"', None, ""),
         ('>= "3.6"', '!= "3.7.1"', None, ""),
-        ('>= "3.6"', '< "3.6.0"', "<empty>", ""),
+        ('>= "3.6"', '< "3.6.0"', EMPTY, ""),
         ('>= "3.6"', '<= "3.6.0"', '== "3.6.0"', ""),
         ('>= "3.6"', '< "3.6.1"', None, ""),  # '== "3.6.0"'
         ('>= "3.6"', '<= "3.6.1"', None, ""),
@@ -1748,11 +1748,11 @@ def test_intersection_avoids_combinatorial_explosion() -> None:
         ('< "3.6"', '< "3.6.1"', '< "3.6"', '< "3.6.1"'),
         ('< "3.6"', '<= "3.6.1"', '< "3.6"', '<= "3.6.1"'),
         ('< "3.6"', '== "3.5.2"', '== "3.5.2"', '< "3.6"'),
-        ('< "3.6"', '== "3.6.0"', "<empty>", '<= "3.6.0"'),
+        ('< "3.6"', '== "3.6.0"', EMPTY, '<= "3.6.0"'),
         ('< "3.6"', '!= "3.5.2"', None, ""),
         ('< "3.6"', '!= "3.6.0"', '< "3.6"', '!= "3.6.0"'),
-        ('< "3.6"', '> "3.6.0"', "<empty>", '!= "3.6.0"'),
-        ('< "3.6"', '>= "3.6.0"', "<empty>", ""),
+        ('< "3.6"', '> "3.6.0"', EMPTY, '!= "3.6.0"'),
+        ('< "3.6"', '>= "3.6.0"', EMPTY, ""),
         ('< "3.6"', '> "3.5.2"', None, ""),
         ('< "3.6"', '>= "3.5.2"', None, ""),
         # python_version <= 3.6 (equal to python_full_version < 3.7.0)
@@ -1761,21 +1761,21 @@ def test_intersection_avoids_combinatorial_explosion() -> None:
         ('<= "3.6"', '< "3.7.0"', '<= "3.6"', '<= "3.6"'),
         ('<= "3.6"', '<= "3.7.0"', '<= "3.6"', '<= "3.7.0"'),
         ('<= "3.6"', '== "3.6.1"', '== "3.6.1"', '<= "3.6"'),
-        ('<= "3.6"', '== "3.7.0"', "<empty>", '<= "3.7.0"'),
+        ('<= "3.6"', '== "3.7.0"', EMPTY, '<= "3.7.0"'),
         ('<= "3.6"', '!= "3.6.1"', None, ""),
         ('<= "3.6"', '!= "3.7.0"', '<= "3.6"', '!= "3.7.0"'),
-        ('<= "3.6"', '> "3.7.0"', "<empty>", '!= "3.7.0"'),
-        ('<= "3.6"', '>= "3.7.0"', "<empty>", ""),
+        ('<= "3.6"', '> "3.7.0"', EMPTY, '!= "3.7.0"'),
+        ('<= "3.6"', '>= "3.7.0"', EMPTY, ""),
         ('<= "3.6"', '> "3.6.2"', None, ""),
         ('<= "3.6"', '>= "3.6.2"', None, ""),
         # python_version == 3.6  # noqa: E800
         # (equal to python_full_version >= 3.6.0 and python_full_version < 3.7.0)
-        ('== "3.6"', '< "3.5.2"', "<empty>", None),
-        ('== "3.6"', '<= "3.5.2"', "<empty>", None),
+        ('== "3.6"', '< "3.5.2"', EMPTY, None),
+        ('== "3.6"', '<= "3.5.2"', EMPTY, None),
         ('== "3.6"', '> "3.5.2"', '== "3.6"', '> "3.5.2"'),
         ('== "3.6"', '>= "3.5.2"', '== "3.6"', '>= "3.5.2"'),
         ('== "3.6"', '!= "3.5.2"', '== "3.6"', '!= "3.5.2"'),
-        ('== "3.6"', '< "3.6.0"', "<empty>", '< "3.7.0"'),
+        ('== "3.6"', '< "3.6.0"', EMPTY, '< "3.7.0"'),
         ('== "3.6"', '<= "3.6.0"', '== "3.6.0"', '< "3.7.0"'),
         ('== "3.6"', '> "3.6.0"', None, '>= "3.6.0"'),
         ('== "3.6"', '>= "3.6.0"', '== "3.6"', '>= "3.6.0"'),
@@ -1787,13 +1787,13 @@ def test_intersection_avoids_combinatorial_explosion() -> None:
         ('== "3.6"', '!= "3.6.1"', None, ""),
         ('== "3.6"', '< "3.7.0"', '== "3.6"', '< "3.7.0"'),
         ('== "3.6"', '<= "3.7.0"', '== "3.6"', '<= "3.7.0"'),
-        ('== "3.6"', '> "3.7.0"', "<empty>", None),
-        ('== "3.6"', '>= "3.7.0"', "<empty>", '>= "3.6.0"'),
+        ('== "3.6"', '> "3.7.0"', EMPTY, None),
+        ('== "3.6"', '>= "3.7.0"', EMPTY, '>= "3.6.0"'),
         ('== "3.6"', '!= "3.7.0"', '== "3.6"', '!= "3.7.0"'),
         ('== "3.6"', '<= "3.7.1"', '== "3.6"', '<= "3.7.1"'),
         ('== "3.6"', '< "3.7.1"', '== "3.6"', '< "3.7.1"'),
-        ('== "3.6"', '> "3.7.1"', "<empty>", None),
-        ('== "3.6"', '>= "3.7.1"', "<empty>", None),
+        ('== "3.6"', '> "3.7.1"', EMPTY, None),
+        ('== "3.6"', '>= "3.7.1"', EMPTY, None),
         ('== "3.6"', '!= "3.7.1"', '== "3.6"', '!= "3.7.1"'),
         # python_version != 3.6  # noqa: E800
         # (equal to python_full_version < 3.6.0 or python_full_version >= 3.7.0)
@@ -1836,7 +1836,7 @@ def test_merging_python_version_and_python_full_version(
     def get_expected_marker(expected_version: str, op: str) -> str:
         if expected_version is None:
             expected = f"{m} {op} {m2}"
-        elif expected_version in ("", "<empty>"):
+        elif expected_version in ("", EMPTY):
             expected = expected_version
         else:
             expected_marker_name = (

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -1701,8 +1701,10 @@ def test_intersection_avoids_combinatorial_explosion() -> None:
 
 
 @pytest.mark.parametrize(
-    "python_version, python_full_version, "
-    "expected_intersection_version, expected_union_version",
+    (
+        "python_version, python_full_version, "
+        "expected_intersection_version, expected_union_version"
+    ),
     [
         # python_version > 3.6 (equal to python_full_version >= 3.7.0)
         ('> "3.6"', '> "3.5.2"', '> "3.6"', '> "3.5.2"'),


### PR DESCRIPTION
`MarkerUnion` had code handling the possibility that one of its markers is `AnyMarker` or `EmptyMarker`, neither of which should ever happen.

Conceivably it makes sense to have this code anyway for defensive purposes, but in that case there ought to be similar on the `MultiMarker`.  I've instead preferred to remove it.  

The testcase that I've removed was testing that the string representation of such a union ignored the any / empty markers.  But this was nonsense: if there ever actually was an "any" marker in there, then the whole union ought to have been "any".

While passing I've also removed `is_empty()` from the `AnyMarker` and `is_any()` from the `EmptyMarker`: they too can inherit the default implementation (`return False`) from the base class.