### PR TITLE
performance: cache parsed markers, constraints and versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
         args: [--all]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: [--add-import, from __future__ import annotations]

--- a/src/poetry/core/constraints/generic/parser.py
+++ b/src/poetry/core/constraints/generic/parser.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import re
 
 from typing import TYPE_CHECKING
@@ -17,6 +18,7 @@ if TYPE_CHECKING:
 BASIC_CONSTRAINT = re.compile(r"^(!?==?)?\s*([^\s]+?)\s*$")
 
 
+@functools.lru_cache(maxsize=None)
 def parse_constraint(constraints: str) -> BaseConstraint:
     if constraints == "*":
         return AnyConstraint()

--- a/src/poetry/core/constraints/version/parser.py
+++ b/src/poetry/core/constraints/version/parser.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import re
 
 from typing import TYPE_CHECKING
@@ -12,6 +13,7 @@ if TYPE_CHECKING:
     from poetry.core.constraints.version.version_constraint import VersionConstraint
 
 
+@functools.lru_cache(maxsize=None)
 def parse_constraint(constraints: str) -> VersionConstraint:
     if constraints == "*":
         from poetry.core.constraints.version.version_range import VersionRange

--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import functools
 import itertools
 import re
 
+from abc import ABC
+from abc import abstractmethod
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
@@ -53,10 +56,12 @@ PYTHON_VERSION_MARKERS = {"python_version", "python_full_version"}
 _parser = Parser(GRAMMAR_PEP_508_MARKERS, "lalr")
 
 
-class BaseMarker:
+class BaseMarker(ABC):
+    @abstractmethod
     def intersect(self, other: BaseMarker) -> BaseMarker:
         raise NotImplementedError()
 
+    @abstractmethod
     def union(self, other: BaseMarker) -> BaseMarker:
         raise NotImplementedError()
 
@@ -66,23 +71,36 @@ class BaseMarker:
     def is_empty(self) -> bool:
         return False
 
+    @abstractmethod
     def validate(self, environment: dict[str, Any] | None) -> bool:
         raise NotImplementedError()
 
+    @abstractmethod
     def without_extras(self) -> BaseMarker:
         raise NotImplementedError()
 
+    @abstractmethod
     def exclude(self, marker_name: str) -> BaseMarker:
         raise NotImplementedError()
 
+    @abstractmethod
     def only(self, *marker_names: str) -> BaseMarker:
         raise NotImplementedError()
 
+    @abstractmethod
     def invert(self) -> BaseMarker:
         raise NotImplementedError()
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} {str(self)}>"
+
+    @abstractmethod
+    def __hash__(self) -> int:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def __eq__(self, other: object) -> bool:
+        raise NotImplementedError()
 
 
 class AnyMarker(BaseMarker):
@@ -725,6 +743,7 @@ class MarkerUnion(BaseMarker):
         return all(m.is_empty() for m in self._markers)
 
 
+@functools.lru_cache(maxsize=None)
 def parse_marker(marker: str) -> BaseMarker:
     if marker == "<empty>":
         return EmptyMarker()

--- a/src/poetry/core/version/pep440/parser.py
+++ b/src/poetry/core/version/pep440/parser.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import re
 
 from typing import TYPE_CHECKING
@@ -63,6 +64,7 @@ class PEP440Parser:
         )
 
     @classmethod
+    @functools.lru_cache(maxsize=None)
     def parse(cls, value: str, version_class: type[T]) -> T:
         match = cls._regex.search(value) if value else None
         if not match:
@@ -80,4 +82,4 @@ class PEP440Parser:
 
 
 def parse_pep440(value: str, version_class: type[T]) -> T:
-    return PEP440Parser.parse(value, version_class)
+    return PEP440Parser.parse(value, version_class)  # type: ignore[arg-type]


### PR DESCRIPTION
Some more fallout from #530. The parsing of marker strings became a bit slower with measurable effects in real-world examples. It seems in real-world examples, the same marker is used many times for different dependencies. Since markers are immutable, we can just cache the parsed markers and mitigate the performance regression.

Performance for shootout example with warm cache:

|command|1.3.2|master|PR (only markers)|PR (constraints, versions)|
|---|---|---|---|---|
|lock|46 s|57 s|47 s|35 s|
|lock --no-update|14 s|18 s|14 s|10 s|

(There seems to be no significant increase in peak memory usage due to the caching.)

Update: added times for caching parsed constraints and versions in addition to markers.