### PR TITLE
release: bump version to 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 
 
+## [1.5.1] - 2023-02-20
+
+### Changed
+
+- Improve performance by caching parsed markers, constraints and versions ([#556](https://github.com/python-poetry/poetry-core/pull/556)).
+
+
 ## [1.5.0] - 2023-01-27
 
 ### Added
@@ -489,7 +496,8 @@ No changes.
 - Fixed support for stub-only packages ([#28](https://github.com/python-poetry/core/pull/28)).
 
 
-[Unreleased]: https://github.com/python-poetry/poetry-core/compare/1.5.0...main
+[Unreleased]: https://github.com/python-poetry/poetry-core/compare/1.5.1...main
+[1.5.1]: https://github.com/python-poetry/poetry-core/releases/tag/1.5.1
 [1.5.0]: https://github.com/python-poetry/poetry-core/releases/tag/1.5.0
 [1.4.0]: https://github.com/python-poetry/poetry-core/releases/tag/1.4.0
 [1.3.2]: https://github.com/python-poetry/poetry-core/releases/tag/1.3.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-core"
-version = "1.5.0"
+version = "1.5.1"
 description = "Poetry PEP 517 Build Backend"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 

--- a/src/poetry/core/__init__.py
+++ b/src/poetry/core/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 # this cannot presently be replaced with importlib.metadata.version as when building
 # itself, poetry-core is not available as an installed distribution.
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 
 __vendor_site__ = (Path(__file__).parent / "_vendor").as_posix()
 


### PR DESCRIPTION
### Changed

- Improve performance by caching parsed markers, constraints and versions ([#556](https://github.com/python-poetry/poetry-core/pull/556)).