### PR TITLE
Warn about potentially incompatible project name canonicalisations

### DIFF
--- a/src/poetry/core/packages/project_package.py
+++ b/src/poetry/core/packages/project_package.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import warnings, logging
+import logging
+import warnings
 
 from typing import TYPE_CHECKING
 from typing import Any
@@ -15,6 +16,7 @@ if TYPE_CHECKING:
 
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.utils import create_nested_marker
+
 
 logger = logging.getLogger(__name__)
 
@@ -36,11 +38,13 @@ class ProjectPackage(Package):
 
         super().__init__(name, version)
 
-        if name != self.name and '.' in name:
+        if name != self.name and "." in name:
             logger.warning(
-                f"Project name has been canonicalised from <info>{name}</info> to <info>{self.name}</info>. "
-                "This may not be compatible with previous releases or package metadata looks and may cause issues when uploading to package repositories. "
-                "See https://github.com/python-poetry/poetry/issues/6198.",
+                f"Project name has been canonicalised from <info>{name}</info> to"
+                f" <info>{self.name}</info>. This may not be compatible with previous"
+                " releases or package metadata looks and may cause issues when"
+                " uploading to package repositories. See"
+                " https://github.com/python-poetry/poetry/issues/6198.",
             )
 
         self.build_config: dict[str, Any] = {}

--- a/src/poetry/core/packages/project_package.py
+++ b/src/poetry/core/packages/project_package.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import warnings
+import warnings, logging
 
 from typing import TYPE_CHECKING
 from typing import Any
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
 
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.utils import create_nested_marker
+
+logger = logging.getLogger(__name__)
 
 
 class ProjectPackage(Package):
@@ -33,6 +35,13 @@ class ProjectPackage(Package):
             )
 
         super().__init__(name, version)
+
+        if name != self.name and '.' in name:
+            logger.warning(
+                f"Project name has been canonicalised from <info>{name}</info> to <info>{self.name}</info>. "
+                "This may not be compatible with previous releases or package metadata looks and may cause issues when uploading to package repositories. "
+                "See https://github.com/python-poetry/poetry/issues/6198.",
+            )
 
         self.build_config: dict[str, Any] = {}
         self.packages: list[dict[str, Any]] = []


### PR DESCRIPTION
The handling of package names within the Python packaging ecosystem is unfortunately not in a great state at the moment. There exist a large number of packages which contain characters which (some of) the specs indicate are invalid, yet there is not a clear migration path nor destination at the moment.

Poetry's approach is to normalise project names towards their "canonical" form, meaning that existing projects on PyPI which use the more relaxed name forms will be silently renamed if they move to (recent versions of) Poetry. As well as changing the name of these packages (which maintainers are unlikely to expect nor desire) this unfortunately ends up breaking introspection via `importlib.metadata` in Python 3.8 and 3.9 which are not aware of the canonicalisation rules which Poetry is using.

Adding this warning informs maintainers so that they can decide how (and if) they want this name canonicalisation to happen.

- [ ] Added **tests** for changed code.
   Not sure this is worthwhile here?

- [ ] ~Updated **documentation** for changed code.~
   Not planning to do this given the self-documenting nature of this.

Open to suggestions on better wording. Other details which might be worth including are:
- the nature of the breakage on older Python
- clarifying that it's downsteam user code which is broken (not the package being built) in those cases
- maayybe hints on how to fix that (but that feels too detailed for the warning message)
- link to https://github.com/pypi/warehouse/issues/10030, in particular the summary at https://github.com/pypi/warehouse/issues/10030#issuecomment-1445156879

Related to https://github.com/python-poetry/poetry/issues/6198
