### PR TITLE
deprecate package.category

### DIFF
--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -108,8 +108,8 @@ class Package(PackageSpecification):
 
         self._dependency_groups: dict[str, DependencyGroup] = {}
 
-        # For compatibility with previous version, we keep the category
-        self.category = "main"
+        # Category is heading towards deprecation.
+        self._category = "main"
         self.files: list[dict[str, str]] = []
         self.optional = False
 
@@ -373,6 +373,24 @@ class Package(PackageSpecification):
             urls["Documentation"] = self.documentation_url
 
         return urls
+
+    @property
+    def category(self) -> str:
+        warnings.warn(
+            "`category` is deprecated and will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._category
+
+    @category.setter
+    def category(self, category: str) -> None:
+        warnings.warn(
+            "Setting `category` is deprecated and will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self._category = category
 
     @property
     def readme(self) -> Path | None:


### PR DESCRIPTION
`package.category` doesn't make a lot of sense in the richer world of dependency groups.

The only use that is made of the category in poetry and poetry-core is that it is written to and read back from the lockfile.  But no use is made of that information.

(I think it's also a mistake to record `optional` in the lockfile - but probably disentangling that will be harder; maybe another day).