### PR TITLE
Regression test for VersionRange.allows_all

### DIFF
--- a/tests/constraints/version/test_version_range.py
+++ b/tests/constraints/version/test_version_range.py
@@ -273,6 +273,16 @@ def test_allows_all_contained_unions(
     assert not range.allows_all(VersionRange(v123, v234).union(v140))
 
 
+def test_allows_all_regression() -> None:
+    system_python = VersionRange(
+        Version.parse("3.8"), Version.parse("3.12"), include_min=True
+    )
+    package_version = VersionRange(
+        Version.parse("3.11"), Version.parse("4"), include_min=True
+    )
+    assert package_version.allows_all(system_python)
+
+
 def test_allows_any(
     v003: Version,
     v010: Version,


### PR DESCRIPTION
The environment provides `<VersionRange >=3.11,<4.0>` The package requires `<VersionRange >=3.8,<3.12>`

It should be a match as python 3.11 should be accepted, in this specific example

fixes [#python-poetry/poetry#7642](https://github.com/python-poetry/poetry/issues/7642)

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
