### PR TITLE
More specific error message when project name contains disallowed characters

### DIFF
--- a/src/poetry/core/masonry/utils/module.py
+++ b/src/poetry/core/masonry/utils/module.py
@@ -66,9 +66,9 @@ class Module:
                         }
                     ]
                 else:
-                    raise ModuleOrPackageNotFound(
-                        f"No file/folder found for package {name}"
-                    )
+                    if self._name != name:
+                        raise ModuleOrPackageNotFound(f"Project file/folder contains disallowed characters - expected naming: {name}")
+                    raise ModuleOrPackageNotFound(f"No file/folder found for package {name}")
 
         for package in packages:
             formats = package.get("format")

--- a/src/poetry/core/masonry/utils/module.py
+++ b/src/poetry/core/masonry/utils/module.py
@@ -66,7 +66,7 @@ class Module:
                         }
                     ]
                 else:
-                    if self._name != name:
+                    if self._name != name.lower():
                         raise ModuleOrPackageNotFound(f"Project file/folder contains disallowed characters - expected naming: {name}")
                     raise ModuleOrPackageNotFound(f"No file/folder found for package {name}")
 


### PR DESCRIPTION
<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

## Context
Recently I was working on a project using poetry, and ended up in a state where I was unable to use `poetry build`, due to getting a "`No file/folder found for package <project_name>`" error repeatedly, despite the folder structure etc being correct to what poetry expects to see

After a bunch of google searching and diving into the source code myself, I was able to see that the cause was that the project name I was using was "molpro-dirman", containing an illegal `-` character. Once I sussed this out and [changed all the project naming](https://github.com/MolarFox-Prototyping/molpro-dirman/commit/d5247f16fa54174a6c084c797f1e6e26f94391e8) to use an underscore instead, everything worked nominally.

In this change I've added an error trap and more specific error message when this case arises for the next person :slightly_smiling_face: 

## Changes
- Catch specific subcase where dir not found due to substitution of disallowed chars
    - Log more specific error message in this case

## Checklist
- [ ] Added **tests** for changed code. (n/a / minor error trapping code change only)
- [ ] Updated **documentation** for changed code. (n/a / minor change / self-documenting changes)

<!--
**Note**: If your Pull Request introduces a new feature or changes the current behavior, it should be based
on the `develop` branch. If it's a bug fix or only a documentation update, it should be based on the `master` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
