### PR TITLE
markers: avoid combinatorial explosion in certain cases

### DIFF
--- a/src/poetry/core/constraints/generic/any_constraint.py
+++ b/src/poetry/core/constraints/generic/any_constraint.py
@@ -14,6 +14,9 @@ class AnyConstraint(BaseConstraint):
     def allows_any(self, other: BaseConstraint) -> bool:
         return True
 
+    def invert(self) -> BaseConstraint:
+        return EmptyConstraint()
+
     def difference(self, other: BaseConstraint) -> BaseConstraint:
         if other.is_any():
             return EmptyConstraint()

--- a/src/poetry/core/constraints/generic/base_constraint.py
+++ b/src/poetry/core/constraints/generic/base_constraint.py
@@ -11,6 +11,9 @@ class BaseConstraint:
     def allows_any(self, other: BaseConstraint) -> bool:
         raise NotImplementedError()
 
+    def invert(self) -> BaseConstraint:
+        raise NotImplementedError()
+
     def difference(self, other: BaseConstraint) -> BaseConstraint:
         raise NotImplementedError()
 

--- a/src/poetry/core/constraints/generic/constraint.py
+++ b/src/poetry/core/constraints/generic/constraint.py
@@ -84,6 +84,9 @@ class Constraint(BaseConstraint):
 
         return other.allows(self)
 
+    def invert(self) -> Constraint:
+        return Constraint(self._value, "!=" if self._operator == "==" else "==")
+
     def difference(self, other: BaseConstraint) -> Constraint | EmptyConstraint:
         if other.allows(self):
             return EmptyConstraint()

--- a/src/poetry/core/constraints/generic/empty_constraint.py
+++ b/src/poetry/core/constraints/generic/empty_constraint.py
@@ -21,6 +21,11 @@ class EmptyConstraint(BaseConstraint):
     def allows_any(self, other: BaseConstraint) -> bool:
         return False
 
+    def invert(self) -> BaseConstraint:
+        from poetry.core.constraints.generic.any_constraint import AnyConstraint
+
+        return AnyConstraint()
+
     def intersect(self, other: BaseConstraint) -> BaseConstraint:
         return self
 

--- a/src/poetry/core/constraints/generic/multi_constraint.py
+++ b/src/poetry/core/constraints/generic/multi_constraint.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from poetry.core.constraints.generic import AnyConstraint
 from poetry.core.constraints.generic import EmptyConstraint
 from poetry.core.constraints.generic.base_constraint import BaseConstraint
 from poetry.core.constraints.generic.constraint import Constraint
+
+
+if TYPE_CHECKING:
+    from poetry.core.constraints.generic import UnionConstraint
 
 
 class MultiConstraint(BaseConstraint):
@@ -61,6 +67,11 @@ class MultiConstraint(BaseConstraint):
             )
 
         return False
+
+    def invert(self) -> UnionConstraint:
+        from poetry.core.constraints.generic import UnionConstraint
+
+        return UnionConstraint(*(c.invert() for c in self._constraints))
 
     def intersect(self, other: BaseConstraint) -> BaseConstraint:
         if not isinstance(other, Constraint):

--- a/src/poetry/core/constraints/generic/union_constraint.py
+++ b/src/poetry/core/constraints/generic/union_constraint.py
@@ -64,6 +64,14 @@ class UnionConstraint(BaseConstraint):
 
         return their_constraint is None
 
+    def invert(self) -> MultiConstraint:
+        inverted_constraints = [c.invert() for c in self._constraints]
+        if any(not isinstance(c, Constraint) for c in inverted_constraints):
+            raise NotImplementedError(
+                "Inversion of complex union constraints not implemented"
+            )
+        return MultiConstraint(*inverted_constraints)  # type: ignore[arg-type]
+
     def intersect(self, other: BaseConstraint) -> BaseConstraint:
         if other.is_any():
             return self

--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -176,8 +176,12 @@ class Dependency(PackageSpecification):
             self.deactivate()
 
             for or_ in markers["extra"]:
-                for _, extra in or_:
-                    self.in_extras.append(canonicalize_name(extra))
+                for op, extra in or_:
+                    if op == "==":
+                        self.in_extras.append(canonicalize_name(extra))
+                    elif op == "" and "||" in extra:
+                        for _extra in extra.split(" || "):
+                            self.in_extras.append(canonicalize_name(_extra))
 
         # Recalculate python versions.
         self._python_versions = "*"

--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -9,8 +9,15 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
+from typing import Generic
 from typing import Iterable
+from typing import TypeVar
+from typing import Union
 
+from poetry.core.constraints.generic import BaseConstraint
+from poetry.core.constraints.generic import Constraint
+from poetry.core.constraints.generic import MultiConstraint
+from poetry.core.constraints.generic import UnionConstraint
 from poetry.core.constraints.version import VersionConstraint
 from poetry.core.version.grammars import GRAMMAR_PEP_508_MARKERS
 from poetry.core.version.parser import Parser
@@ -18,8 +25,6 @@ from poetry.core.version.parser import Parser
 
 if TYPE_CHECKING:
     from lark import Tree
-
-    from poetry.core.constraints.generic import BaseConstraint
 
 
 class InvalidMarker(ValueError):
@@ -57,6 +62,15 @@ _parser = Parser(GRAMMAR_PEP_508_MARKERS, "lalr")
 
 
 class BaseMarker(ABC):
+    @property
+    def complexity(self) -> tuple[int, int]:
+        """
+        first element: number of single markers, where SingleMarkerLike count as
+                       actual number
+        second element: number of single markers, where SingleMarkerLike count as 1
+        """
+        return 1, 1
+
     @abstractmethod
     def intersect(self, other: BaseMarker) -> BaseMarker:
         raise NotImplementedError()
@@ -169,7 +183,7 @@ class EmptyMarker(BaseMarker):
     def exclude(self, marker_name: str) -> EmptyMarker:
         return self
 
-    def only(self, *marker_names: str) -> EmptyMarker:
+    def only(self, *marker_names: str) -> BaseMarker:
         return self
 
     def invert(self) -> AnyMarker:
@@ -191,17 +205,13 @@ class EmptyMarker(BaseMarker):
         return isinstance(other, EmptyMarker)
 
 
-class SingleMarker(BaseMarker):
-    _CONSTRAINT_RE = re.compile(r"(?i)^(~=|!=|>=?|<=?|==?=?|in|not in)?\s*(.+)$")
-    _VERSION_LIKE_MARKER_NAME = {
-        "python_version",
-        "python_full_version",
-        "platform_release",
-    }
+SingleMarkerConstraint = TypeVar(
+    "SingleMarkerConstraint", bound=Union[BaseConstraint, VersionConstraint]
+)
 
-    def __init__(
-        self, name: str, constraint: str | BaseConstraint | VersionConstraint
-    ) -> None:
+
+class SingleMarkerLike(BaseMarker, ABC, Generic[SingleMarkerConstraint]):
+    def __init__(self, name: str, constraint: SingleMarkerConstraint) -> None:
         from poetry.core.constraints.generic import (
             parse_constraint as parse_generic_constraint,
         )
@@ -209,90 +219,21 @@ class SingleMarker(BaseMarker):
             parse_constraint as parse_version_constraint,
         )
 
-        self._constraint: BaseConstraint | VersionConstraint
-        self._parser: Callable[[str], BaseConstraint | VersionConstraint]
         self._name = ALIASES.get(name, name)
-        constraint_string = str(constraint)
-
-        # Extract operator and value
-        m = self._CONSTRAINT_RE.match(constraint_string)
-        if m is None:
-            raise InvalidMarker(f"Invalid marker '{constraint_string}'")
-
-        self._operator = m.group(1)
-        if self._operator is None:
-            self._operator = "=="
-
-        self._value = m.group(2)
-        self._parser = parse_generic_constraint
-
-        if name in self._VERSION_LIKE_MARKER_NAME:
+        self._constraint = constraint
+        self._parser: Callable[[str], BaseConstraint | VersionConstraint]
+        if isinstance(constraint, VersionConstraint):
             self._parser = parse_version_constraint
-
-            if self._operator in {"in", "not in"}:
-                versions = []
-                for v in re.split("[ ,]+", self._value):
-                    split = v.split(".")
-                    if len(split) in [1, 2]:
-                        split.append("*")
-                        op = "" if self._operator == "in" else "!="
-                    else:
-                        op = "==" if self._operator == "in" else "!="
-
-                    versions.append(op + ".".join(split))
-
-                glue = ", "
-                if self._operator == "in":
-                    glue = " || "
-
-                self._constraint = self._parser(glue.join(versions))
-            else:
-                self._constraint = self._parser(constraint_string)
         else:
-            # if we have a in/not in operator we split the constraint
-            # into a union/multi-constraint of single constraint
-            if self._operator in {"in", "not in"}:
-                op, glue = ("==", " || ") if self._operator == "in" else ("!=", ", ")
-                values = re.split("[ ,]+", self._value)
-                constraint_string = glue.join(f"{op} {value}" for value in values)
-
-            self._constraint = self._parser(constraint_string)
+            self._parser = parse_generic_constraint
 
     @property
     def name(self) -> str:
         return self._name
 
     @property
-    def constraint(self) -> BaseConstraint | VersionConstraint:
+    def constraint(self) -> SingleMarkerConstraint:
         return self._constraint
-
-    @property
-    def operator(self) -> str:
-        return self._operator
-
-    @property
-    def value(self) -> str:
-        return self._value
-
-    def intersect(self, other: BaseMarker) -> BaseMarker:
-        if isinstance(other, SingleMarker):
-            merged = _merge_single_markers(self, other, MultiMarker)
-            if merged is not None:
-                return merged
-
-            return MultiMarker(self, other)
-
-        return other.intersect(self)
-
-    def union(self, other: BaseMarker) -> BaseMarker:
-        if isinstance(other, SingleMarker):
-            merged = _merge_single_markers(self, other, MarkerUnion)
-            if merged is not None:
-                return merged
-
-            return MarkerUnion(self, other)
-
-        return other.union(self)
 
     def validate(self, environment: dict[str, Any] | None) -> bool:
         if environment is None:
@@ -316,11 +257,117 @@ class SingleMarker(BaseMarker):
 
         return self
 
-    def only(self, *marker_names: str) -> SingleMarker | AnyMarker:
+    def only(self, *marker_names: str) -> BaseMarker:
         if self.name not in marker_names:
             return AnyMarker()
 
         return self
+
+    def intersect(self, other: BaseMarker) -> BaseMarker:
+        if isinstance(other, SingleMarkerLike):
+            merged = _merge_single_markers(self, other, MultiMarker)
+            if merged is not None:
+                return merged
+
+            return MultiMarker(self, other)
+
+        return other.intersect(self)
+
+    def union(self, other: BaseMarker) -> BaseMarker:
+        if isinstance(other, SingleMarkerLike):
+            merged = _merge_single_markers(self, other, MarkerUnion)
+            if merged is not None:
+                return merged
+
+            return MarkerUnion(self, other)
+
+        return other.union(self)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SingleMarkerLike):
+            return NotImplemented
+
+        return self._name == other.name and self._constraint == other.constraint
+
+    def __hash__(self) -> int:
+        return hash((self._name, self._constraint))
+
+
+class SingleMarker(SingleMarkerLike[Union[BaseConstraint, VersionConstraint]]):
+    _CONSTRAINT_RE = re.compile(r"(?i)^(~=|!=|>=?|<=?|==?=?|in|not in)?\s*(.+)$")
+    _VERSION_LIKE_MARKER_NAME = {
+        "python_version",
+        "python_full_version",
+        "platform_release",
+    }
+
+    def __init__(
+        self, name: str, constraint: str | BaseConstraint | VersionConstraint
+    ) -> None:
+        from poetry.core.constraints.generic import (
+            parse_constraint as parse_generic_constraint,
+        )
+        from poetry.core.constraints.version import (
+            parse_constraint as parse_version_constraint,
+        )
+
+        parsed_constraint: BaseConstraint | VersionConstraint
+        parser: Callable[[str], BaseConstraint | VersionConstraint]
+        constraint_string = str(constraint)
+
+        # Extract operator and value
+        m = self._CONSTRAINT_RE.match(constraint_string)
+        if m is None:
+            raise InvalidMarker(f"Invalid marker '{constraint_string}'")
+
+        self._operator = m.group(1)
+        if self._operator is None:
+            self._operator = "=="
+
+        self._value = m.group(2)
+        parser = parse_generic_constraint
+
+        if name in self._VERSION_LIKE_MARKER_NAME:
+            parser = parse_version_constraint
+
+            if self._operator in {"in", "not in"}:
+                versions = []
+                for v in re.split("[ ,]+", self._value):
+                    split = v.split(".")
+                    if len(split) in [1, 2]:
+                        split.append("*")
+                        op = "" if self._operator == "in" else "!="
+                    else:
+                        op = "==" if self._operator == "in" else "!="
+
+                    versions.append(op + ".".join(split))
+
+                glue = ", "
+                if self._operator == "in":
+                    glue = " || "
+
+                parsed_constraint = parser(glue.join(versions))
+            else:
+                parsed_constraint = parser(constraint_string)
+        else:
+            # if we have a in/not in operator we split the constraint
+            # into a union/multi-constraint of single constraint
+            if self._operator in {"in", "not in"}:
+                op, glue = ("==", " || ") if self._operator == "in" else ("!=", ", ")
+                values = re.split("[ ,]+", self._value)
+                constraint_string = glue.join(f"{op} {value}" for value in values)
+
+            parsed_constraint = parser(constraint_string)
+
+        super().__init__(name, parsed_constraint)
+
+    @property
+    def operator(self) -> str:
+        return self._operator
+
+    @property
+    def value(self) -> str:
+        return self._value
 
     def invert(self) -> BaseMarker:
         if self._operator in ("===", "=="):
@@ -367,17 +414,62 @@ class SingleMarker(BaseMarker):
 
         return parse_marker(f"{self._name} {operator} '{self._value}'")
 
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, SingleMarker):
-            return False
-
-        return self._name == other.name and self._constraint == other.constraint
-
-    def __hash__(self) -> int:
-        return hash((self._name, self._constraint))
-
     def __str__(self) -> str:
         return f'{self._name} {self._operator} "{self._value}"'
+
+
+class AtomicMultiMarker(SingleMarkerLike[MultiConstraint]):
+    def __init__(self, name: str, constraint: MultiConstraint) -> None:
+        assert all(c.operator == "!=" for c in constraint.constraints)
+        super().__init__(name, constraint)
+        self._values: list[str] = []
+
+    @property
+    def complexity(self) -> tuple[int, int]:
+        return len(self._constraint.constraints), 1
+
+    def invert(self) -> BaseMarker:
+        return AtomicMarkerUnion(self._name, self._constraint.invert())
+
+    def expand(self) -> MultiMarker:
+        return MultiMarker(
+            *(SingleMarker(self._name, c) for c in self._constraint.constraints)
+        )
+
+    def __str__(self) -> str:
+        return " and ".join(
+            f'{self._name} != "{c.value}"' for c in self._constraint.constraints
+        )
+
+
+class AtomicMarkerUnion(SingleMarkerLike[UnionConstraint]):
+    def __init__(self, name: str, constraint: UnionConstraint) -> None:
+        assert all(
+            isinstance(c, Constraint) and c.operator == "=="
+            for c in constraint.constraints
+        )
+        super().__init__(name, constraint)
+
+    @property
+    def complexity(self) -> tuple[int, int]:
+        return len(self._constraint.constraints), 1
+
+    def invert(self) -> BaseMarker:
+        return AtomicMultiMarker(self._name, self._constraint.invert())
+
+    def expand(self) -> MarkerUnion:
+        return MarkerUnion(
+            *(SingleMarker(self._name, c) for c in self._constraint.constraints)
+        )
+
+    def __str__(self) -> str:
+        # In __init__ we've made sure that we have a UnionConstraint that
+        # contains only elements of type Constraint (instead of BaseConstraint)
+        # but mypy can't see that.
+        return " or ".join(
+            f'{self._name} == "{c.value}"'  # type: ignore[attr-defined]
+            for c in self._constraint.constraints
+        )
 
 
 def _flatten_markers(
@@ -409,6 +501,12 @@ class MultiMarker(BaseMarker):
     def markers(self) -> list[BaseMarker]:
         return self._markers
 
+    @property
+    def complexity(self) -> tuple[int, int]:
+        return tuple(  # type: ignore[return-value]
+            sum(c) for c in zip(*(m.complexity for m in self._markers))
+        )
+
     @classmethod
     def of(cls, *markers: BaseMarker) -> BaseMarker:
         new_markers = _flatten_markers(markers, MultiMarker)
@@ -428,12 +526,12 @@ class MultiMarker(BaseMarker):
                 for i, mark in enumerate(new_markers):
                     # If we have a SingleMarker then with any luck after intersection
                     # it'll become another SingleMarker.
-                    if isinstance(mark, SingleMarker):
-                        new_marker = marker.intersect(mark)
+                    if isinstance(mark, SingleMarkerLike):
+                        new_marker = mark.intersect(marker)
                         if new_marker.is_empty():
                             return EmptyMarker()
 
-                        if isinstance(new_marker, SingleMarker):
+                        if isinstance(new_marker, SingleMarkerLike):
                             new_markers[i] = new_marker
                             intersected = True
                             break
@@ -506,7 +604,7 @@ class MultiMarker(BaseMarker):
             unique_union = MultiMarker(*unique_markers).union(
                 MultiMarker(*other_unique_markers)
             )
-            if isinstance(unique_union, (SingleMarker, AnyMarker)):
+            if isinstance(unique_union, (SingleMarkerLike, AnyMarker)):
                 # Use list instead of set for deterministic order.
                 common_markers = [
                     marker for marker in self.markers if marker in shared_markers
@@ -525,7 +623,7 @@ class MultiMarker(BaseMarker):
         new_markers = []
 
         for m in self._markers:
-            if isinstance(m, SingleMarker) and m.name == marker_name:
+            if isinstance(m, SingleMarkerLike) and m.name == marker_name:
                 # The marker is not relevant since it must be excluded
                 continue
 
@@ -576,6 +674,12 @@ class MarkerUnion(BaseMarker):
     def markers(self) -> list[BaseMarker]:
         return self._markers
 
+    @property
+    def complexity(self) -> tuple[int, int]:
+        return tuple(  # type: ignore[return-value]
+            sum(c) for c in zip(*(m.complexity for m in self._markers))
+        )
+
     @classmethod
     def of(cls, *markers: BaseMarker) -> BaseMarker:
         new_markers = _flatten_markers(markers, MarkerUnion)
@@ -595,12 +699,12 @@ class MarkerUnion(BaseMarker):
                 for i, mark in enumerate(new_markers):
                     # If we have a SingleMarker then with any luck after union it'll
                     # become another SingleMarker.
-                    if isinstance(mark, SingleMarker):
-                        new_marker = marker.union(mark)
+                    if isinstance(mark, SingleMarkerLike):
+                        new_marker = mark.union(marker)
                         if new_marker.is_any():
                             return AnyMarker()
 
-                        if isinstance(new_marker, SingleMarker):
+                        if isinstance(new_marker, SingleMarkerLike):
                             new_markers[i] = new_marker
                             included = True
                             break
@@ -679,7 +783,7 @@ class MarkerUnion(BaseMarker):
             unique_intersection = MarkerUnion(*unique_markers).intersect(
                 MarkerUnion(*other_unique_markers)
             )
-            if isinstance(unique_intersection, (SingleMarker, EmptyMarker)):
+            if isinstance(unique_intersection, (SingleMarkerLike, EmptyMarker)):
                 # Use list instead of set for deterministic order.
                 common_markers = [
                     marker for marker in self.markers if marker in shared_markers
@@ -698,7 +802,7 @@ class MarkerUnion(BaseMarker):
         new_markers = []
 
         for m in self._markers:
-            if isinstance(m, SingleMarker) and m.name == marker_name:
+            if isinstance(m, SingleMarkerLike) and m.name == marker_name:
                 # The marker is not relevant since it must be excluded
                 continue
 
@@ -842,19 +946,34 @@ def intersection(*markers: BaseMarker) -> BaseMarker:
 
 
 def union(*markers: BaseMarker) -> BaseMarker:
-    conjunction = cnf(MarkerUnion(*markers))
+    # Sometimes normalization makes it more complicate instead of simple
+    # -> choose candidate with the least complexity
+    unnormalized: BaseMarker = MarkerUnion(*markers)
+    while (
+        isinstance(unnormalized, (MultiMarker, MarkerUnion))
+        and len(unnormalized.markers) == 1
+    ):
+        unnormalized = unnormalized.markers[0]
+
+    conjunction = cnf(unnormalized)
     if not isinstance(conjunction, MultiMarker):
         return conjunction
 
-    return dnf(conjunction)
+    disjunction = dnf(conjunction)
+    if not isinstance(disjunction, MarkerUnion):
+        return disjunction
+
+    return min(disjunction, conjunction, unnormalized, key=lambda x: x.complexity)
 
 
 def _merge_single_markers(
-    marker1: SingleMarker,
-    marker2: SingleMarker,
+    marker1: SingleMarkerLike[SingleMarkerConstraint],
+    marker2: SingleMarkerLike[SingleMarkerConstraint],
     merge_class: type[MultiMarker | MarkerUnion],
 ) -> BaseMarker | None:
     if {marker1.name, marker2.name} == PYTHON_VERSION_MARKERS:
+        assert isinstance(marker1, SingleMarker)
+        assert isinstance(marker2, SingleMarker)
         return _merge_python_version_single_markers(marker1, marker2, merge_class)
 
     if marker1.name != marker2.name:
@@ -877,11 +996,20 @@ def _merge_single_markers(
         result_marker = marker1
     elif result_constraint == marker2.constraint:
         result_marker = marker2
-    elif (
+    elif isinstance(result_constraint, Constraint) or (
         isinstance(result_constraint, VersionConstraint)
         and result_constraint.is_simple()
     ):
         result_marker = SingleMarker(marker1.name, result_constraint)
+    elif isinstance(result_constraint, UnionConstraint) and all(
+        isinstance(c, Constraint) and c.operator == "=="
+        for c in result_constraint.constraints
+    ):
+        result_marker = AtomicMarkerUnion(marker1.name, result_constraint)
+    elif isinstance(result_constraint, MultiConstraint) and all(
+        c.operator == "!=" for c in result_constraint.constraints
+    ):
+        result_marker = AtomicMultiMarker(marker1.name, result_constraint)
     return result_marker
 
 

--- a/tests/constraints/generic/test_constraint.py
+++ b/tests/constraints/generic/test_constraint.py
@@ -53,6 +53,22 @@ def test_allows_all() -> None:
 
 
 @pytest.mark.parametrize(
+    ("constraint", "inverted"),
+    [
+        (EmptyConstraint(), AnyConstraint()),
+        (Constraint("foo"), Constraint("foo", "!=")),
+        (
+            MultiConstraint(Constraint("foo", "!="), Constraint("bar", "!=")),
+            UnionConstraint(Constraint("foo"), Constraint("bar")),
+        ),
+    ],
+)
+def test_invert(constraint: BaseConstraint, inverted: BaseConstraint) -> None:
+    assert constraint.invert() == inverted
+    assert inverted.invert() == constraint
+
+
+@pytest.mark.parametrize(
     ("constraint1", "constraint2", "expected"),
     [
         (

--- a/tests/packages/test_main.py
+++ b/tests/packages/test_main.py
@@ -102,9 +102,9 @@ def test_dependency_from_pep_508_complex() -> None:
     assert dep.python_versions == ">=2.7 !=3.2.*"
     assert (
         str(dep.marker)
-        == 'python_version >= "2.7" and python_version != "3.2" and sys_platform =='
-        ' "win32" and extra == "foo" or python_version >= "2.7" and python_version'
-        ' != "3.2" and sys_platform == "darwin" and extra == "foo"'
+        == 'python_version >= "2.7" and python_version != "3.2" '
+        'and (sys_platform == "win32" or sys_platform == "darwin") '
+        'and extra == "foo"'
     )
 
 


### PR DESCRIPTION
Resolves: python-poetry/poetry#7689

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Implements (more or less) the proposal from https://github.com/python-poetry/poetry/issues/7689#issuecomment-1483071113 by replacing compatible `MultiMarker`/`MarkerUnion` with `AtomicMultiMarker`/`AtomicMarkerUnion`, which behave more like single markers than complex markers during marker simplification.

Example pyproject.toml from python-poetry/poetry#7689:

```
$ time poetry132 export -q
real    0m0.953s
user    0m0.853s
sys     0m0.040s

$ time poetry141 export -q
real    3m34.909s
user    3m34.617s
sys     0m0.230s

$ time poetry141_patched export -q
real    0m0.622s
user    0m0.538s
sys     0m0.020s
```

**Why not use a normal `SingleMarker` with `in` and `not in`?**

I assume that we are not standard compliant with our implementation of `in` and `not in`. From reading [PEP 508](https://peps.python.org/pep-0508/#specification), which does not give much detail about `in` and `not in`, and experimenting with `packaging`, I suspect it's just supposed to be a string operation:

```
>>> from packaging import markers
>>> m = markers.Marker("platform_machine in 'x86_64,amd64'")
>>> m.evaluate({'platform_machine': 'aarch64'})
False
>>> m.evaluate({'platform_machine': 'x86_64'})
True
>>> m.evaluate({'platform_machine': 'x86'})
True
```

Thus, `in` and `not in` will be kind of dangerous if there are values that are contained in other values.