### PR TITLE
Correcting README information regarding `poetry-core` reading lock files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,5 @@ dependencies are not required when the objective is to simply build either a sou
 project.
 
 In order to improve the above situation, `poetry-core` was created. Shared functionality pertaining to PEP 517 build
-backends, including reading lock file, `pyproject.toml` and building wheel/sdist, were implemented in this package. This
+backends, `pyproject.toml` and building wheel/sdist, were implemented in this package. This
 makes PEP 517 builds extremely fast for Poetry managed packages.

--- a/README.md
+++ b/README.md
@@ -41,5 +41,5 @@ dependencies are not required when the objective is to simply build either a sou
 project.
 
 In order to improve the above situation, `poetry-core` was created. Shared functionality pertaining to PEP 517 build
-backends, `pyproject.toml` and building wheel/sdist, were implemented in this package. This
+backends, including reading `pyproject.toml` and building wheel/sdist, were implemented in this package. This
 makes PEP 517 builds extremely fast for Poetry managed packages.


### PR DESCRIPTION
Resolves: An issue raised in the comments of [python-poetry#7419](https://github.com/python-poetry/poetry/issues/7419)<!-- add issue number/link here -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
As discussed in https://github.com/python-poetry/poetry/issues/7419, poetry-core mentions in its `README.md` that it can read lock files. However, this is not the case, and as per the issue, it seems to be a "known and expected behavior." This PR corrects the information in the `README.md`.