### PR TITLE
make `Package.all_classifiers` unique even if `classfiers` in pyproject.toml has python_classifiers

### DIFF
--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -348,7 +348,7 @@ class Package(PackageSpecification):
         # it like this so that 3.10 is sorted after 3.9.
         sorted_classifiers = []
         python_classifiers_inserted = False
-        for classifier in sorted(set(classifiers)):
+        for classifier in sorted(set(classifiers) - set(python_classifiers)):
             if (
                 not python_classifiers_inserted
                 and classifier > python_classifier_prefix

--- a/tests/fixtures/project_with_duplicated_classifiers/pyproject.toml
+++ b/tests/fixtures/project_with_duplicated_classifiers/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.poetry]
+name = "project_with_duplicated_classifiers"
+version = "1.2.3"
+description = "This is a description"
+authors = ["Your Name <you@example.com>"]
+license = "MIT"
+
+classifiers = [
+    # Duplicated classifiers
+    "Topic :: Software Development :: Build Tools",
+    "Topic :: Software Development :: Build Tools",
+    # The following classifiers are automatically generated
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+]
+
+[tool.poetry.dependencies]
+python = "^3.8"

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -478,3 +478,19 @@ def test_create_dependency_marker_variants(
     assert dep.python_versions == exp_python
     assert dep.python_constraint == parse_constraint(exp_python)
     assert str(dep.marker) == exp_marker
+
+
+def test_all_classifiers_unique_even_if_classifiers_is_duplicated() -> None:
+    poetry = Factory().create_poetry(
+        fixtures_dir / "project_with_duplicated_classifiers"
+    )
+    package = poetry.package
+    assert package.all_classifiers == [
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Topic :: Software Development :: Build Tools",
+    ]


### PR DESCRIPTION
Resolves: https://github.com/python-poetry/poetry/issues/7857

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
     - Did not need  to update documentation
<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
