### PR TITLE
fix allows_any() with local versions

### DIFF
--- a/src/poetry/core/constraints/version/version.py
+++ b/src/poetry/core/constraints/version/version.py
@@ -93,19 +93,20 @@ class Version(PEP440Version, VersionRangeConstraint):
         )
 
     def allows_any(self, other: VersionConstraint) -> bool:
+        intersection = self.intersect(other)
+        return not intersection.is_empty()
+
+    def intersect(self, other: VersionConstraint) -> VersionConstraint:
         if isinstance(other, Version):
-            return self.allows(other)
+            if self.allows(other):
+                return other
 
-        return other.allows(self)
+            if other.allows(self):
+                return self
 
-    def intersect(self, other: VersionConstraint) -> Version | EmptyConstraint:
-        if other.allows(self):
-            return self
+            return EmptyConstraint()
 
-        if isinstance(other, Version) and self.allows(other):
-            return other
-
-        return EmptyConstraint()
+        return other.intersect(self)
 
     def union(self, other: VersionConstraint) -> VersionConstraint:
         from poetry.core.constraints.version.version_range import VersionRange

--- a/tests/constraints/version/test_version.py
+++ b/tests/constraints/version/test_version.py
@@ -375,9 +375,14 @@ def test_allows_all() -> None:
             True,
         ),
         (
+            Version.parse("1.2.3"),
+            VersionRange(Version.parse("1.2.3+local"), include_min=True),
+            True,
+        ),
+        (
             Version.parse("1.2.3+cpu"),
             Version.parse("1.2.3"),
-            False,
+            True,
         ),
         (
             Version.parse("1.2.3"),
@@ -437,6 +442,16 @@ def test_allows_any(
             Version.parse("1.2.3"),
             Version.parse("1.2.3+local"),
             Version.parse("1.2.3+local"),
+        ),
+        (
+            Version.parse("1.2.3"),
+            VersionRange(Version.parse("1.2.3+local"), include_min=True),
+            VersionRange(
+                Version.parse("1.2.3+local"),
+                Version.parse("1.2.4"),
+                include_min=True,
+                include_max=False,
+            ),
         ),
     ],
 )


### PR DESCRIPTION
Make `allows_any()` more like `intersect()`.  

It doesn't make sense that `1.2.3+cpu` and `1.2.3` have an intersection (at `1.2.3+cpu`), while `"1.2.3+cpu".allows_any("1.2.3")` is `False`.

(Possible alternative implementation is just to take the intersection and ask whether it is empty.  Conceptually that's clean, perhaps it's pointless to worry about the unnecessary construction of the `EmptyConstraint()` when the answer is "no").

see also https://github.com/python-poetry/poetry/issues/7876