### PR TITLE
performance: fix a performance regression introduced in #402

### DIFF
--- a/src/poetry/core/constraints/version/version_range.py
+++ b/src/poetry/core/constraints/version/version_range.py
@@ -12,6 +12,7 @@ from poetry.core.constraints.version.version_range_constraint import (
     VersionRangeConstraint,
 )
 from poetry.core.constraints.version.version_union import VersionUnion
+from poetry.core.utils._compat import cached_property
 
 
 if TYPE_CHECKING:
@@ -356,14 +357,16 @@ class VersionRange(VersionRangeConstraint):
     def flatten(self) -> list[VersionRangeConstraint]:
         return [self]
 
+    @cached_property
     def _single_wildcard_range_string(self) -> str:
-        if not self.is_single_wildcard_range():
+        if not self.is_single_wildcard_range:
             raise ValueError("Not a valid wildcard range")
 
         assert self.min is not None
         assert self.max is not None
         return f"=={_single_wildcard_range_string(self.min, self.max)}"
 
+    @cached_property
     def is_single_wildcard_range(self) -> bool:
         # e.g.
         # - "1.*" equals ">=1.0.dev0, <2" (equivalent to ">=1.0.dev0, <2.0.dev0")
@@ -436,7 +439,7 @@ class VersionRange(VersionRangeConstraint):
 
     def __str__(self) -> str:
         with suppress(ValueError):
-            return self._single_wildcard_range_string()
+            return self._single_wildcard_range_string
 
         text = ""
 

--- a/src/poetry/core/constraints/version/version_range_constraint.py
+++ b/src/poetry/core/constraints/version/version_range_constraint.py
@@ -4,6 +4,7 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING
 
 from poetry.core.constraints.version.version_constraint import VersionConstraint
+from poetry.core.utils._compat import cached_property
 
 
 if TYPE_CHECKING:
@@ -33,9 +34,6 @@ class VersionRangeConstraint(VersionConstraint):
 
     @property
     def allowed_min(self) -> Version | None:
-        if self.min is None:
-            return None
-
         # That is a bit inaccurate because
         # 1) The exclusive ordered comparison >V MUST NOT allow a post-release
         #    of the given version unless V itself is a post release.
@@ -47,7 +45,7 @@ class VersionRangeConstraint(VersionConstraint):
         # the callers of allowed_min.
         return self.min
 
-    @property
+    @cached_property
     def allowed_max(self) -> Version | None:
         if self.max is None:
             return None

--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -239,8 +239,8 @@ class Dependency(PackageSpecification):
         constraint = self.constraint
         if isinstance(constraint, VersionUnion):
             if (
-                constraint.excludes_single_version()
-                or constraint.excludes_single_wildcard_range()
+                constraint.excludes_single_version
+                or constraint.excludes_single_wildcard_range
             ):
                 # This branch is a short-circuit logic for special cases and
                 # avoids having to split and parse constraint again. This has

--- a/src/poetry/core/utils/_compat.py
+++ b/src/poetry/core/utils/_compat.py
@@ -5,6 +5,14 @@ import sys
 
 WINDOWS = sys.platform == "win32"
 
+if sys.version_info < (3, 8):
+    # no caching for python 3.7
+    cached_property = property
+else:
+    import functools
+
+    cached_property = functools.cached_property
+
 if sys.version_info < (3, 11):
     # compatibility for python <3.11
     import tomli as tomllib

--- a/tests/constraints/version/test_version_range.py
+++ b/tests/constraints/version/test_version_range.py
@@ -672,7 +672,7 @@ def test_is_single_wildcard_range_include_min_include_max(
     version_range = VersionRange(
         Version.parse("1.2.dev0"), Version.parse("1.3"), include_min, include_max
     )
-    assert version_range.is_single_wildcard_range() is expected
+    assert version_range.is_single_wildcard_range is expected
 
 
 @pytest.mark.parametrize(
@@ -721,7 +721,7 @@ def test_is_single_wildcard_range(
         Version.parse(max) if max else None,
         include_min=True,
     )
-    assert version_range.is_single_wildcard_range() is expected
+    assert version_range.is_single_wildcard_range is expected
 
 
 @pytest.mark.parametrize(

--- a/tests/constraints/version/test_version_union.py
+++ b/tests/constraints/version/test_version_union.py
@@ -83,7 +83,7 @@ from poetry.core.constraints.version import parse_constraint
 def test_excludes_single_wildcard_range_basics(
     ranges: list[VersionRange], expected: bool
 ) -> None:
-    assert VersionUnion(*ranges).excludes_single_wildcard_range() is expected
+    assert VersionUnion(*ranges).excludes_single_wildcard_range is expected
 
 
 @pytest.mark.parametrize(
@@ -126,7 +126,7 @@ def test_excludes_single_wildcard_range(max: str, min: str, expected: bool) -> N
         VersionRange(max=Version.parse(max)),
         VersionRange(Version.parse(min), include_min=True),
     )
-    assert version_union.excludes_single_wildcard_range() is expected
+    assert version_union.excludes_single_wildcard_range is expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes a perfomance regression introduced in #402 by applying `cached_property` to certain properties

`cached_property` is available since Python 3.8. There is a package named `backports.cached-property`, which makes the decorator available in Python 3.7. However, I don't want to add a new vendored dependency since we will drop Python 3.7 support anyway in the near future. We could introduce a restricted dependency on `backports.cached-property` like in poetry or just accept the performance regression for Python 3.7. I have chosen the latter but do not have strong feelings about it.

In the following table you can see the `cumtime` of relevant calls (in seconds) from profiling different variants for a sample project

variant|excludes_single_version()|VersionUnion.allows()|VersionRangeConstraint.allowed_min
---|---|---|---
poetry master|2.2|0.3|-
poetry master with poetry-core master|15.3|12.4|7.7
poetry master with this PR|1.0|0.65|0.1
