### PR TITLE
avoid duplicate extras in lockfiles

### DIFF
--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -177,7 +177,7 @@ class Factory:
         extras = config.get("extras", {})
         for extra_name, requirements in extras.items():
             extra_name = canonicalize_name(extra_name)
-            package.extras[extra_name] = []
+            package.extras[extra_name] = set()
 
             # Checking for dependency
             for req in requirements:
@@ -186,7 +186,7 @@ class Factory:
                 for dep in package.requires:
                     if dep.name == req.name:
                         dep.in_extras.append(extra_name)
-                        package.extras[extra_name].append(dep)
+                        package.extras[extra_name].add(dep)
 
         if "build" in config:
             build = config["build"]

--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -107,7 +107,7 @@ class Package(PackageSpecification):
         self._license: License | None = None
         self.readmes: tuple[Path, ...] = ()
 
-        self.extras: dict[NormalizedName, list[Dependency]] = {}
+        self.extras: dict[NormalizedName, set[Dependency]] = {}
 
         self._dependency_groups: dict[str, DependencyGroup] = {}
 

--- a/tests/masonry/builders/test_sdist.py
+++ b/tests/masonry/builders/test_sdist.py
@@ -75,7 +75,7 @@ def test_convert_dependencies() -> None:
     assert result == (main, extras)
 
     package = ProjectPackage("foo", "1.2.3")
-    package.extras = {canonicalize_name("bar"): [Dependency("A", "*")]}
+    package.extras = {canonicalize_name("bar"): {Dependency("A", "*")}}
 
     result = SdistBuilder.convert_dependencies(
         package,
@@ -95,7 +95,7 @@ def test_convert_dependencies() -> None:
     d = Dependency("D", "3.4.5", optional=True)
     d.python_versions = "~2.7 || ^3.4"
 
-    package.extras = {canonicalize_name("baz"): [Dependency("D", "*")]}
+    package.extras = {canonicalize_name("baz"): {Dependency("D", "*")}}
 
     result = SdistBuilder.convert_dependencies(
         package,


### PR DESCRIPTION
there are duplicate extras in poetry.lock files.

I'm not entirely sure what are the circumstances that trigger this but it shows up in
- one of the fixtures in the companion pull request in `poetry` proper
- poetry's own lockfile (see the `tests-no-zope` extras on `attrs`)

Because I don't know exactly how to trigger this, I don't know how to add an explicit testcase for it.  But as I say there's a `poetry` testcase that currently demonstrates the faulty behaviour and which is fixed by this; and post-fix it's kinda self-testing - of course a set can't contain duplicates as a list could

I expect that the entanglement between the `poetry` and `poetry-core` pipelines will make it challenging to figure out how to merge this