### PR TITLE
Cleanup pyproject

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1085,4 +1085,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "e639d315256558561a1c31a5e554a36e14470200885b3d2c44f503dece17212a"
+content-hash = "3330a4f99db4b96dd10bfbba5b3d695ff4ad25ea6237c9f06a102a4af9f4116b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1085,4 +1085,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "3330a4f99db4b96dd10bfbba5b3d695ff4ad25ea6237c9f06a102a4af9f4116b"
+content-hash = "a35979d7ec4637241aaa45fac3373d4669e112f6e79958bd930160c2f0e0da22"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ importlib-metadata = {version = ">=1.7.0", python = "<3.8"}
 pre-commit = ">=2.15.0"
 tox = ">=3.0"
 vendoring = {version = ">=1.0", python = "^3.8"}
-pyrsistent = ">=0.18.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = ">=7.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,34 +3,21 @@ name = "poetry-core"
 version = "1.6.0"
 description = "Poetry PEP 517 Build Backend"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
-
 license = "MIT"
-
 readme = "README.md"
-
 homepage = "https://github.com/python-poetry/poetry-core"
 repository = "https://github.com/python-poetry/poetry-core"
-
 keywords = ["packaging", "dependency", "poetry"]
-
 classifiers = [
     "Topic :: Software Development :: Build Tools",
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
-
 packages = [
     { include = "poetry", from = "src" },
 ]
 include = [
     { path = "tests", format = "sdist" },
 ]
-exclude = [
-    "**/*.pyc",
-    "**/*.pyi",
-]
-
-[tool.poetry.build]
-generate-setup-file = false
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/python-poetry/poetry/issues"
@@ -41,18 +28,22 @@ python = "^3.7"
 # required for compatibility
 importlib-metadata = {version = ">=1.7.0", python = "<3.8"}
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pre-commit = ">=2.15.0"
-pyrsistent = ">=0.18.0"
-pytest = ">=7.1.2"
-pytest-cov = ">=3.0.0"
-pytest-mock = ">=3.5"
 tox = ">=3.0"
 vendoring = {version = ">=1.0", python = "^3.8"}
+pyrsistent = ">=0.18.0"
+
+[tool.poetry.group.test.dependencies]
+pytest = ">=7.1.2"
+pytest-cov = ">=3.0.0"
+pytest-mock = ">=3.10"
 build = ">=0.10.0"
-mypy = ">=1.0"
 setuptools = ">=60"
 tomli-w = "^1.0.0"
+
+[tool.poetry.group.typing.dependencies]
+mypy = ">=1.0"
 types-jsonschema = ">=4.4.4"
 types-setuptools = ">=57.4.14"
 
@@ -102,9 +93,7 @@ required-imports = ["from __future__ import annotations"]
 
 
 [tool.black]
-line-length = 88
 preview = true
-include = '\.pyi?$'
 extend-exclude = "src/poetry/core/_vendor/*"
 
 


### PR DESCRIPTION
Resolves: python-poetry/poetry#7929

- Moved dev dependencies to groups
- Removed `pyrsistent` from dev dependencies (it's vendored anyway)
- Removed `exclude` directive (.pyi files are required for tests, .pyc are ignored by git)
- Removed `generate-setup-file = false` as it is now a default setting
- Removed redundant include directive from `black` config
