### PR TITLE
Optionally use resolved references in to_pep_508

### DIFF
--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -258,6 +258,10 @@ class Dependency(PackageSpecification):
 
         return requirement
 
+    @property
+    def base_pep_508_name_resolved(self) -> str:
+        return self.base_pep_508_name
+
     def allows_prereleases(self) -> bool:
         return self._allows_prereleases
 
@@ -282,8 +286,8 @@ class Dependency(PackageSpecification):
     def to_pep_508(self, with_extras: bool = True, *, resolved: bool = False) -> str:
         from poetry.core.packages.utils.utils import convert_markers
 
-        if resolved and hasattr(self, "base_pep_508_name_resolved"):
-            requirement: str = self.base_pep_508_name_resolved
+        if resolved:
+            requirement = self.base_pep_508_name_resolved
         else:
             requirement = self.base_pep_508_name
 

--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -279,10 +279,13 @@ class Dependency(PackageSpecification):
     def is_url(self) -> bool:
         return False
 
-    def to_pep_508(self, with_extras: bool = True) -> str:
+    def to_pep_508(self, with_extras: bool = True, resolved: bool = False) -> str:
         from poetry.core.packages.utils.utils import convert_markers
 
-        requirement = self.base_pep_508_name
+        if resolved and hasattr(self, "base_pep_508_name_resolved"):
+            requirement: str = self.base_pep_508_name_resolved
+        else:
+            requirement = self.base_pep_508_name
 
         markers = []
         has_extras = False

--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -279,7 +279,7 @@ class Dependency(PackageSpecification):
     def is_url(self) -> bool:
         return False
 
-    def to_pep_508(self, with_extras: bool = True, resolved: bool = False) -> str:
+    def to_pep_508(self, with_extras: bool = True, *, resolved: bool = False) -> str:
         from poetry.core.packages.utils.utils import convert_markers
 
         if resolved and hasattr(self, "base_pep_508_name_resolved"):

--- a/src/poetry/core/packages/vcs_dependency.py
+++ b/src/poetry/core/packages/vcs_dependency.py
@@ -101,8 +101,7 @@ class VCSDependency(Dependency):
 
         return f"{what} {version}"
 
-    @property
-    def base_pep_508_name(self) -> str:
+    def _base_pep_508_name(self, resolved: bool = False) -> str:
         from poetry.core.vcs import git
 
         requirement = self.pretty_name
@@ -117,12 +116,24 @@ class VCSDependency(Dependency):
         else:
             requirement += f" @ {self._vcs}+ssh://{parsed_url.format()}"
 
-        if self.reference:
+        if resolved and self.source_resolved_reference:
+            requirement += f"@{self.source_resolved_reference}"
+        elif self.reference:
             requirement += f"@{self.reference}"
 
         if self._directory:
             requirement += f"#subdirectory={self._directory}"
 
+        return requirement
+
+    @property
+    def base_pep_508_name(self) -> str:
+        requirement = self._base_pep_508_name()
+        return requirement
+
+    @property
+    def base_pep_508_name_resolved(self) -> str:
+        requirement = self._base_pep_508_name(resolved=True)
         return requirement
 
     def is_vcs(self) -> bool:

--- a/src/poetry/core/packages/vcs_dependency.py
+++ b/src/poetry/core/packages/vcs_dependency.py
@@ -101,7 +101,7 @@ class VCSDependency(Dependency):
 
         return f"{what} {version}"
 
-    def _base_pep_508_name(self, resolved: bool = False) -> str:
+    def _base_pep_508_name(self, *, resolved: bool = False) -> str:
         from poetry.core.vcs import git
 
         requirement = self.pretty_name

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -137,6 +137,7 @@ def test_to_pep_508_with_patch_python_version(
     expected = f"Django (>=1.23,<2.0) ; {marker}"
 
     assert dependency.to_pep_508() == expected
+    assert dependency.to_pep_508(resolved=True) == expected
     assert str(dependency.marker) == marker
 
 

--- a/tests/packages/test_vcs_dependency.py
+++ b/tests/packages/test_vcs_dependency.py
@@ -22,6 +22,10 @@ from poetry.core.packages.vcs_dependency import VCSDependency
             "poetry[bar,foo] @ git+https://github.com/python-poetry/poetry.git",
         ),
         (
+            {"extras": ["foo", "bar"], "branch": "main"},
+            "poetry[bar,foo] @ git+https://github.com/python-poetry/poetry.git@main",
+        ),
+        (
             {"branch": "main"},
             "poetry @ git+https://github.com/python-poetry/poetry.git@main",
         ),
@@ -65,6 +69,10 @@ def test_to_pep_508(kwargs: dict[str, Any], expected: str) -> None:
         (
             {"extras": ["foo", "bar"]},
             "poetry[bar,foo] @ git+https://github.com/python-poetry/poetry.git",
+        ),
+        (
+            {"extras": ["foo", "bar"], "branch": "main", "resolved_rev": "aaaa"},
+            "poetry[bar,foo] @ git+https://github.com/python-poetry/poetry.git@aaaa",
         ),
         (
             {"branch": "main", "resolved_rev": "aaaa"},

--- a/tests/packages/test_vcs_dependency.py
+++ b/tests/packages/test_vcs_dependency.py
@@ -54,6 +54,51 @@ def test_to_pep_508(kwargs: dict[str, Any], expected: str) -> None:
     assert dependency.to_pep_508() == expected
 
 
+@pytest.mark.parametrize(
+    "kwargs, expected",
+    [
+        ({}, "poetry @ git+https://github.com/python-poetry/poetry.git"),
+        (
+            {"extras": ["foo"]},
+            "poetry[foo] @ git+https://github.com/python-poetry/poetry.git",
+        ),
+        (
+            {"extras": ["foo", "bar"]},
+            "poetry[bar,foo] @ git+https://github.com/python-poetry/poetry.git",
+        ),
+        (
+            {"branch": "main", "resolved_rev": "aaaa"},
+            "poetry @ git+https://github.com/python-poetry/poetry.git@aaaa",
+        ),
+        (
+            {"tag": "1.0", "resolved_rev": "aaaa"},
+            "poetry @ git+https://github.com/python-poetry/poetry.git@aaaa",
+        ),
+        (
+            {"rev": "12345", "resolved_rev": "aaaa"},
+            "poetry @ git+https://github.com/python-poetry/poetry.git@aaaa",
+        ),
+        (
+            {"directory": "sub"},
+            "poetry @ git+https://github.com/python-poetry/poetry.git#subdirectory=sub",
+        ),
+        (
+            {"branch": "main", "directory": "sub", "resolved_rev": "aaaa"},
+            (
+                "poetry @ git+https://github.com/python-poetry/poetry.git"
+                "@aaaa#subdirectory=sub"
+            ),
+        ),
+    ],
+)
+def test_to_pep_508_resolved(kwargs: dict[str, Any], expected: str) -> None:
+    dependency = VCSDependency(
+        "poetry", "git", "https://github.com/python-poetry/poetry.git", **kwargs
+    )
+
+    assert dependency.to_pep_508(resolved=True) == expected
+
+
 def test_to_pep_508_ssh() -> None:
     dependency = VCSDependency("poetry", "git", "git@github.com:sdispater/poetry.git")
 


### PR DESCRIPTION
Related-to: https://github.com/python-poetry/poetry-plugin-export/issues/35

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

Well this pull request doesn't actually solve the issue linked above. But it is necessary to be able to solve it.

I've modified the `to_pep_508` function to return resolved references if called with the optional argument `resolved=True`. The default of this argument is `False` in order to not make any backward incompatible changes that might adversely affect other code also making use of the `to_pep_508` function.

I have no idea how to update the documentation since by inspecting this library I found no documentation for any of the internal python functions.
