### PR TITLE
constraints: allow whitespace padding in caret constraints (for consistency) and consolidate `parse_constraint` tests

### DIFF
--- a/src/poetry/core/constraints/version/parser.py
+++ b/src/poetry/core/constraints/version/parser.py
@@ -38,7 +38,7 @@ def _parse_constraint(
         # standard-compliant it seems to occur in some packages)
         constraints = constraints.rstrip(",").rstrip()
         and_constraints = re.split(
-            "(?<!^)(?<![~=>< ,]) *(?<!-)[, ](?!-) *(?!,|$)", constraints
+            r"(?<!^)(?<![\^~=>< ,]) *(?<!-)[, ](?!-) *(?!,|$)", constraints
         )
         constraint_objects = []
 

--- a/src/poetry/core/constraints/version/patterns.py
+++ b/src/poetry/core/constraints/version/patterns.py
@@ -8,7 +8,7 @@ from packaging.version import VERSION_PATTERN
 COMPLETE_VERSION = re.compile(VERSION_PATTERN, re.VERBOSE | re.IGNORECASE)
 
 CARET_CONSTRAINT = re.compile(
-    rf"^\^(?P<version>{VERSION_PATTERN})$", re.VERBOSE | re.IGNORECASE
+    rf"^\^\s*(?P<version>{VERSION_PATTERN})$", re.VERBOSE | re.IGNORECASE
 )
 TILDE_CONSTRAINT = re.compile(
     rf"^~(?!=)\s*(?P<version>{VERSION_PATTERN})$", re.VERBOSE | re.IGNORECASE


### PR DESCRIPTION
Tests regarding whitespace padding were spread over several tests, although there already has been a dedicated test: `test_parse_constraint_with_white_space_padding`. However, this test did not only test whitespace padding but additional stuff that is already tested in the other tests (or at least fits better there).

This PR, removes duplicated tests and moves tests from `test_parse_constraint_with_white_space_padding` to other tests and vice versa to sharpen the objective of each test. Further, it improves `test_parse_constraint_with_white_space_padding` by systematically applying whitespace padding not only at the beginning and at the end of a constraint, but everywhere it is possible.

Thereby, it was noticed that padding was allowed for all types of constraints but caret constraints. This PR fixes this inconsistency.