### PR TITLE
markers: allow `|` as value separator for markers with operators `in` and `not in`

### DIFF
--- a/src/poetry/core/packages/utils/utils.py
+++ b/src/poetry/core/packages/utils/utils.py
@@ -19,6 +19,7 @@ from poetry.core.constraints.version import Version
 from poetry.core.constraints.version import VersionRange
 from poetry.core.constraints.version import parse_marker_version_constraint
 from poetry.core.pyproject.toml import PyProjectTOML
+from poetry.core.version.markers import SingleMarker
 from poetry.core.version.markers import SingleMarkerLike
 from poetry.core.version.markers import dnf
 
@@ -374,7 +375,7 @@ def normalize_python_version_markers(  # NOSONAR
 
             elif op in ("in", "not in"):
                 versions = []
-                for v in re.split("[ ,]+", version):
+                for v in SingleMarker.VALUE_SEPARATOR_RE.split(version):
                     split = v.split(".")
                     if len(split) in (1, 2):
                         split.append("*")

--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -291,6 +291,7 @@ class SingleMarkerLike(BaseMarker, ABC, Generic[SingleMarkerConstraint]):
 
 class SingleMarker(SingleMarkerLike[Union[BaseConstraint, VersionConstraint]]):
     _CONSTRAINT_RE = re.compile(r"(?i)^(~=|!=|>=?|<=?|==?=?|in|not in)?\s*(.+)$")
+    VALUE_SEPARATOR_RE = re.compile("[ ,|]+")
     _VERSION_LIKE_MARKER_NAME = {
         "python_version",
         "python_full_version",
@@ -326,7 +327,7 @@ class SingleMarker(SingleMarkerLike[Union[BaseConstraint, VersionConstraint]]):
 
             if self._operator in {"in", "not in"}:
                 versions = []
-                for v in re.split("[ ,]+", self._value):
+                for v in self.VALUE_SEPARATOR_RE.split(self._value):
                     split = v.split(".")
                     if len(split) in (1, 2):
                         split.append("*")
@@ -346,7 +347,7 @@ class SingleMarker(SingleMarkerLike[Union[BaseConstraint, VersionConstraint]]):
             # into a union/multi-constraint of single constraint
             if self._operator in {"in", "not in"}:
                 op, glue = ("==", " || ") if self._operator == "in" else ("!=", ", ")
-                values = re.split("[ ,]+", self._value)
+                values = self.VALUE_SEPARATOR_RE.split(self._value)
                 constraint_string = glue.join(f"{op} {value}" for value in values)
 
         try:

--- a/tests/packages/test_main.py
+++ b/tests/packages/test_main.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from typing import cast
 
+import pytest
+
 from poetry.core.constraints.version import Version
 from poetry.core.packages.dependency import Dependency
 
@@ -108,33 +110,39 @@ def test_dependency_from_pep_508_complex() -> None:
     )
 
 
-def test_dependency_python_version_in() -> None:
-    name = "requests (==2.18.0); python_version in '3.3 3.4 3.5'"
+@pytest.mark.parametrize(
+    "marker_value",
+    [
+        "3.3 3.4 3.5",  # space
+        "3.3, 3.4, 3.5",  # comma
+        "3.3|3.4|3.5",  # pipe
+    ],
+)
+def test_dependency_python_version_in_(marker_value: str) -> None:
+    name = f"requests (==2.18.0); python_version in '{marker_value}'"
     dep = Dependency.create_from_pep_508(name)
 
     assert dep.name == "requests"
     assert str(dep.constraint) == "2.18.0"
     assert dep.python_versions == "3.3.* || 3.4.* || 3.5.*"
-    assert str(dep.marker) == 'python_version in "3.3 3.4 3.5"'
+    assert str(dep.marker) == f'python_version in "{marker_value}"'
 
 
-def test_dependency_python_version_in_comma() -> None:
-    name = "requests (==2.18.0); python_version in '3.3, 3.4, 3.5'"
+@pytest.mark.parametrize(
+    "marker_value",
+    [
+        "win32 darwin",  # space
+        "win32, darwin",  # comma
+        "win32|darwin",  # pipe
+    ],
+)
+def test_dependency_platform_in(marker_value: str) -> None:
+    name = f"requests (==2.18.0); sys_platform in '{marker_value}'"
     dep = Dependency.create_from_pep_508(name)
 
     assert dep.name == "requests"
     assert str(dep.constraint) == "2.18.0"
-    assert dep.python_versions == "3.3.* || 3.4.* || 3.5.*"
-    assert str(dep.marker) == 'python_version in "3.3, 3.4, 3.5"'
-
-
-def test_dependency_platform_in() -> None:
-    name = "requests (==2.18.0); sys_platform in 'win32 darwin'"
-    dep = Dependency.create_from_pep_508(name)
-
-    assert dep.name == "requests"
-    assert str(dep.constraint) == "2.18.0"
-    assert str(dep.marker) == 'sys_platform in "win32 darwin"'
+    assert str(dep.marker) == f'sys_platform in "{marker_value}"'
 
 
 def test_dependency_with_extra() -> None:


### PR DESCRIPTION
Apparently, `|` is also used (besides ` ` and `,`) to separate values in markers with `in` or `not in`: see https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg

Strictly speaking, `in` and `not in` are defined as string operations, so there even might be no separator at all. We could do this for generic constraints (with some effort) but probably not for version constraints. Since everyone uses some kind of a separator, I suppose adding separators after being spotted in the wild is the best we can do.

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
