### PR TITLE
perf: cache results of `cnf`, `dnf` and `_merge_single_markers`

### DIFF
--- a/src/poetry/core/constraints/generic/constraint.py
+++ b/src/poetry/core/constraints/generic/constraint.py
@@ -123,9 +123,9 @@ class Constraint(BaseConstraint):
         return other.intersect(self)
 
     def union(self, other: BaseConstraint) -> BaseConstraint:
-        if isinstance(other, Constraint):
-            from poetry.core.constraints.generic.union_constraint import UnionConstraint
+        from poetry.core.constraints.generic.union_constraint import UnionConstraint
 
+        if isinstance(other, Constraint):
             if other == self:
                 return self
 
@@ -139,6 +139,10 @@ class Constraint(BaseConstraint):
                 return UnionConstraint(self, other)
 
             return AnyConstraint()
+
+        # to preserve order (functionally not necessary)
+        if isinstance(other, UnionConstraint):
+            return UnionConstraint(self).union(other)
 
         return other.union(self)
 

--- a/src/poetry/core/constraints/generic/multi_constraint.py
+++ b/src/poetry/core/constraints/generic/multi_constraint.py
@@ -128,11 +128,7 @@ class MultiConstraint(BaseConstraint):
         return self._constraints == other._constraints
 
     def __hash__(self) -> int:
-        h = hash("multi")
-        for constraint in self._constraints:
-            h ^= hash(constraint)
-
-        return h
+        return hash(("multi", *self._constraints))
 
     def __str__(self) -> str:
         constraints = [str(constraint) for constraint in self._constraints]

--- a/src/poetry/core/constraints/generic/multi_constraint.py
+++ b/src/poetry/core/constraints/generic/multi_constraint.py
@@ -125,7 +125,7 @@ class MultiConstraint(BaseConstraint):
         if not isinstance(other, MultiConstraint):
             return False
 
-        return set(self._constraints) == set(other._constraints)
+        return self._constraints == other._constraints
 
     def __hash__(self) -> int:
         h = hash("multi")

--- a/src/poetry/core/constraints/generic/union_constraint.py
+++ b/src/poetry/core/constraints/generic/union_constraint.py
@@ -134,13 +134,19 @@ class UnionConstraint(BaseConstraint):
             our_new_constraints: list[BaseConstraint] = []
             their_new_constraints: list[BaseConstraint] = []
             merged_new_constraints: list[BaseConstraint] = []
-            for our_constraint in self._constraints:
-                for their_constraint in other.constraints:
+            for their_constraint in other.constraints:
+                for our_constraint in self._constraints:
                     union = our_constraint.union(their_constraint)
                     if union.is_any():
                         return AnyConstraint()
                     if isinstance(union, Constraint):
-                        if union not in merged_new_constraints:
+                        if union == our_constraint:
+                            if union not in our_new_constraints:
+                                our_new_constraints.append(union)
+                        elif union == their_constraint:
+                            if union not in their_new_constraints:
+                                their_new_constraints.append(their_constraint)
+                        elif union not in merged_new_constraints:
                             merged_new_constraints.append(union)
                     else:
                         if our_constraint not in our_new_constraints:
@@ -169,7 +175,7 @@ class UnionConstraint(BaseConstraint):
         if not isinstance(other, UnionConstraint):
             return False
 
-        return set(self._constraints) == set(other._constraints)
+        return self._constraints == other._constraints
 
     def __hash__(self) -> int:
         h = hash("union")

--- a/src/poetry/core/constraints/generic/union_constraint.py
+++ b/src/poetry/core/constraints/generic/union_constraint.py
@@ -178,11 +178,7 @@ class UnionConstraint(BaseConstraint):
         return self._constraints == other._constraints
 
     def __hash__(self) -> int:
-        h = hash("union")
-        for constraint in self._constraints:
-            h ^= hash(constraint)
-
-        return h
+        return hash(("union", *self._constraints))
 
     def __str__(self) -> str:
         constraints = [str(constraint) for constraint in self._constraints]

--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -413,6 +413,15 @@ class SingleMarker(SingleMarkerLike[Union[BaseConstraint, VersionConstraint]]):
 
         return parse_marker(f"{self._name} {operator} '{self._value}'")
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SingleMarker):
+            return NotImplemented
+
+        return str(self) == str(other)
+
+    def __hash__(self) -> int:
+        return hash(str(self))
+
     def __str__(self) -> str:
         return f'{self._name} {self._operator} "{self._value}"'
 
@@ -645,7 +654,7 @@ class MultiMarker(BaseMarker):
         if not isinstance(other, MultiMarker):
             return False
 
-        return set(self._markers) == set(other.markers)
+        return self._markers == other.markers
 
     def __hash__(self) -> int:
         h = hash("multi")
@@ -825,7 +834,7 @@ class MarkerUnion(BaseMarker):
         if not isinstance(other, MarkerUnion):
             return False
 
-        return set(self._markers) == set(other.markers)
+        return self._markers == other.markers
 
     def __hash__(self) -> int:
         h = hash("union")
@@ -898,6 +907,7 @@ def _compact_markers(
     return union(*sub_markers)
 
 
+@functools.lru_cache(maxsize=None)
 def cnf(marker: BaseMarker) -> BaseMarker:
     """Transforms the marker into CNF (conjunctive normal form)."""
     if isinstance(marker, MarkerUnion):
@@ -915,6 +925,7 @@ def cnf(marker: BaseMarker) -> BaseMarker:
     return marker
 
 
+@functools.lru_cache(maxsize=None)
 def dnf(marker: BaseMarker) -> BaseMarker:
     """Transforms the marker into DNF (disjunctive normal form)."""
     if isinstance(marker, MultiMarker):
@@ -957,6 +968,7 @@ def union(*markers: BaseMarker) -> BaseMarker:
     return min(disjunction, conjunction, unnormalized, key=lambda x: x.complexity)
 
 
+@functools.lru_cache(maxsize=None)
 def _merge_single_markers(
     marker1: SingleMarkerLike[SingleMarkerConstraint],
     marker2: SingleMarkerLike[SingleMarkerConstraint],

--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -152,7 +152,7 @@ class AnyMarker(BaseMarker):
         return "<AnyMarker>"
 
     def __hash__(self) -> int:
-        return hash(("<any>", "<any>"))
+        return hash("any")
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, BaseMarker):
@@ -193,7 +193,7 @@ class EmptyMarker(BaseMarker):
         return "<EmptyMarker>"
 
     def __hash__(self) -> int:
-        return hash(("<empty>", "<empty>"))
+        return hash("empty")
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, BaseMarker):
@@ -231,6 +231,10 @@ class SingleMarkerLike(BaseMarker, ABC, Generic[SingleMarkerConstraint]):
     @property
     def constraint(self) -> SingleMarkerConstraint:
         return self._constraint
+
+    @property
+    def _key(self) -> tuple[object, ...]:
+        return self._name, self._constraint
 
     def validate(self, environment: dict[str, Any] | None) -> bool:
         if environment is None:
@@ -284,10 +288,10 @@ class SingleMarkerLike(BaseMarker, ABC, Generic[SingleMarkerConstraint]):
         if not isinstance(other, SingleMarkerLike):
             return NotImplemented
 
-        return self._name == other.name and self._constraint == other.constraint
+        return self._key == other._key
 
     def __hash__(self) -> int:
-        return hash((self._name, self._constraint))
+        return hash(self._key)
 
 
 class SingleMarker(SingleMarkerLike[Union[BaseConstraint, VersionConstraint]]):
@@ -368,6 +372,10 @@ class SingleMarker(SingleMarkerLike[Union[BaseConstraint, VersionConstraint]]):
     def value(self) -> str:
         return self._value
 
+    @property
+    def _key(self) -> tuple[object, ...]:
+        return self._name, self._operator, self._value
+
     def invert(self) -> BaseMarker:
         if self._operator in ("===", "=="):
             operator = "!="
@@ -417,10 +425,10 @@ class SingleMarker(SingleMarkerLike[Union[BaseConstraint, VersionConstraint]]):
         if not isinstance(other, SingleMarker):
             return NotImplemented
 
-        return str(self) == str(other)
+        return self._key == other._key
 
     def __hash__(self) -> int:
-        return hash(str(self))
+        return hash(self._key)
 
     def __str__(self) -> str:
         return f'{self._name} {self._operator} "{self._value}"'
@@ -503,10 +511,10 @@ def _flatten_markers(
 
 class MultiMarker(BaseMarker):
     def __init__(self, *markers: BaseMarker) -> None:
-        self._markers = _flatten_markers(markers, MultiMarker)
+        self._markers = tuple(_flatten_markers(markers, MultiMarker))
 
     @property
-    def markers(self) -> list[BaseMarker]:
+    def markers(self) -> tuple[BaseMarker, ...]:
         return self._markers
 
     @property
@@ -657,11 +665,7 @@ class MultiMarker(BaseMarker):
         return self._markers == other.markers
 
     def __hash__(self) -> int:
-        h = hash("multi")
-        for m in self._markers:
-            h ^= hash(m)
-
-        return h
+        return hash(("multi", *self._markers))
 
     def __str__(self) -> str:
         elements = []
@@ -676,10 +680,10 @@ class MultiMarker(BaseMarker):
 
 class MarkerUnion(BaseMarker):
     def __init__(self, *markers: BaseMarker) -> None:
-        self._markers = _flatten_markers(markers, MarkerUnion)
+        self._markers = tuple(_flatten_markers(markers, MarkerUnion))
 
     @property
-    def markers(self) -> list[BaseMarker]:
+    def markers(self) -> tuple[BaseMarker, ...]:
         return self._markers
 
     @property
@@ -743,12 +747,6 @@ class MarkerUnion(BaseMarker):
             return new_markers[0]
 
         return MarkerUnion(*new_markers)
-
-    def append(self, marker: BaseMarker) -> None:
-        if marker in self._markers:
-            return
-
-        self._markers.append(marker)
 
     def intersect(self, other: BaseMarker) -> BaseMarker:
         return intersection(self, other)
@@ -837,11 +835,7 @@ class MarkerUnion(BaseMarker):
         return self._markers == other.markers
 
     def __hash__(self) -> int:
-        h = hash("union")
-        for m in self._markers:
-            h ^= hash(m)
-
-        return h
+        return hash(("union", *self._markers))
 
     def __str__(self) -> str:
         return " or ".join(str(m) for m in self._markers)

--- a/tests/constraints/generic/test_constraint.py
+++ b/tests/constraints/generic/test_constraint.py
@@ -159,7 +159,10 @@ def test_invert(constraint: BaseConstraint, inverted: BaseConstraint) -> None:
         (
             Constraint("win32", "!="),
             Constraint("linux", "!="),
-            MultiConstraint(Constraint("win32", "!="), Constraint("linux", "!=")),
+            (
+                MultiConstraint(Constraint("win32", "!="), Constraint("linux", "!=")),
+                MultiConstraint(Constraint("linux", "!="), Constraint("win32", "!=")),
+            ),
         ),
         (
             Constraint("win32", "!="),
@@ -222,10 +225,17 @@ def test_invert(constraint: BaseConstraint, inverted: BaseConstraint) -> None:
         (
             MultiConstraint(Constraint("win32", "!="), Constraint("linux", "!=")),
             MultiConstraint(Constraint("win32", "!="), Constraint("darwin", "!=")),
-            MultiConstraint(
-                Constraint("win32", "!="),
-                Constraint("linux", "!="),
-                Constraint("darwin", "!="),
+            (
+                MultiConstraint(
+                    Constraint("win32", "!="),
+                    Constraint("linux", "!="),
+                    Constraint("darwin", "!="),
+                ),
+                MultiConstraint(
+                    Constraint("win32", "!="),
+                    Constraint("darwin", "!="),
+                    Constraint("linux", "!="),
+                ),
             ),
         ),
     ],
@@ -233,10 +243,12 @@ def test_invert(constraint: BaseConstraint, inverted: BaseConstraint) -> None:
 def test_intersect(
     constraint1: BaseConstraint,
     constraint2: BaseConstraint,
-    expected: BaseConstraint,
+    expected: BaseConstraint | tuple[BaseConstraint, BaseConstraint],
 ) -> None:
-    assert constraint1.intersect(constraint2) == expected
-    assert constraint2.intersect(constraint1) == expected
+    if not isinstance(expected, tuple):
+        expected = (expected, expected)
+    assert constraint1.intersect(constraint2) == expected[0]
+    assert constraint2.intersect(constraint1) == expected[1]
 
 
 @pytest.mark.parametrize(
@@ -295,7 +307,10 @@ def test_intersect(
         (
             Constraint("win32"),
             Constraint("linux"),
-            UnionConstraint(Constraint("win32"), Constraint("linux")),
+            (
+                UnionConstraint(Constraint("win32"), Constraint("linux")),
+                UnionConstraint(Constraint("linux"), Constraint("win32")),
+            ),
         ),
         (
             Constraint("win32"),
@@ -324,8 +339,13 @@ def test_intersect(
         (
             Constraint("win32"),
             UnionConstraint(Constraint("linux"), Constraint("linux2")),
-            UnionConstraint(
-                Constraint("win32"), Constraint("linux"), Constraint("linux2")
+            (
+                UnionConstraint(
+                    Constraint("win32"), Constraint("linux"), Constraint("linux2")
+                ),
+                UnionConstraint(
+                    Constraint("linux"), Constraint("linux2"), Constraint("win32")
+                ),
             ),
         ),
         (
@@ -366,8 +386,13 @@ def test_intersect(
         (
             UnionConstraint(Constraint("win32"), Constraint("linux")),
             UnionConstraint(Constraint("win32"), Constraint("darwin")),
-            UnionConstraint(
-                Constraint("win32"), Constraint("linux"), Constraint("darwin")
+            (
+                UnionConstraint(
+                    Constraint("win32"), Constraint("linux"), Constraint("darwin")
+                ),
+                UnionConstraint(
+                    Constraint("win32"), Constraint("darwin"), Constraint("linux")
+                ),
             ),
         ),
         (
@@ -377,11 +402,19 @@ def test_intersect(
             UnionConstraint(
                 Constraint("win32"), Constraint("cygwin"), Constraint("darwin")
             ),
-            UnionConstraint(
-                Constraint("win32"),
-                Constraint("linux"),
-                Constraint("darwin"),
-                Constraint("cygwin"),
+            (
+                UnionConstraint(
+                    Constraint("win32"),
+                    Constraint("linux"),
+                    Constraint("darwin"),
+                    Constraint("cygwin"),
+                ),
+                UnionConstraint(
+                    Constraint("win32"),
+                    Constraint("cygwin"),
+                    Constraint("darwin"),
+                    Constraint("linux"),
+                ),
             ),
         ),
         (
@@ -412,10 +445,12 @@ def test_intersect(
 def test_union(
     constraint1: BaseConstraint,
     constraint2: BaseConstraint,
-    expected: BaseConstraint,
+    expected: BaseConstraint | tuple[BaseConstraint, BaseConstraint],
 ) -> None:
-    assert constraint1.union(constraint2) == expected
-    assert constraint2.union(constraint1) == expected
+    if not isinstance(expected, tuple):
+        expected = (expected, expected)
+    assert constraint1.union(constraint2) == expected[0]
+    assert constraint2.union(constraint1) == expected[1]
 
 
 def test_difference() -> None:

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -376,10 +376,10 @@ def test_multi_marker() -> None:
     m = parse_marker('sys_platform == "darwin" and implementation_name == "cpython"')
 
     assert isinstance(m, MultiMarker)
-    assert m.markers == [
+    assert m.markers == (
         parse_marker('sys_platform == "darwin"'),
         parse_marker('implementation_name == "cpython"'),
-    ]
+    )
 
 
 def test_multi_marker_is_empty_is_contradictory() -> None:
@@ -652,10 +652,10 @@ def test_marker_union() -> None:
     m = parse_marker('sys_platform == "darwin" or implementation_name == "cpython"')
 
     assert isinstance(m, MarkerUnion)
-    assert m.markers == [
+    assert m.markers == (
         parse_marker('sys_platform == "darwin"'),
         parse_marker('implementation_name == "cpython"'),
-    ]
+    )
 
 
 def test_marker_union_deduplicate() -> None:

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -1314,8 +1314,8 @@ def test_union_should_drop_markers_if_their_complement_is_present(
                 ),
                 MarkerUnion(
                     SingleMarker("python_version", "<3.7"),
-                    SingleMarker("sys_platform", "!=linux"),
                     SingleMarker("python_version", ">=3.9"),
+                    SingleMarker("sys_platform", "!=linux"),
                 ),
             ),
         ),


### PR DESCRIPTION
Picking up the suggestion in https://github.com/python-poetry/poetry/pull/7257#issuecomment-1604514982

In order to cache `cnf` and `dnf`, we can no longer consider composite markers and constraints with the same sub elements but a different order to be equal because order is relevant when building an intersection or union. Neglecting order leads to different results if the result of an "equal" marker with a different order has already been cached. This can even result in a RecursionError, as the test suite demonstrates.

Performance measurements see https://github.com/python-poetry/poetry/pull/7257#issuecomment-1605501632