### PR TITLE
Prevent matching bogus parent git directories

### DIFF
--- a/src/poetry/core/vcs/__init__.py
+++ b/src/poetry/core/vcs/__init__.py
@@ -17,13 +17,20 @@ def get_vcs(directory: Path) -> Git | None:
     try:
         from poetry.core.vcs.git import executable
 
-        git_dir = subprocess.check_output(
-            [executable(), "rev-parse", "--show-toplevel"],
-            stderr=subprocess.STDOUT,
-            text=True,
-        ).strip()
+        check_ignore = subprocess.run(
+            [executable(), "check-ignore", "."],
+        ).returncode
 
-        vcs = Git(Path(git_dir))
+        if check_ignore == 0:
+            vcs = None
+        else:
+            git_dir = subprocess.check_output(
+                [executable(), "rev-parse", "--show-toplevel"],
+                stderr=subprocess.STDOUT,
+                text=True,
+            ).strip()
+
+            vcs = Git(Path(git_dir))
 
     except (subprocess.CalledProcessError, OSError, RuntimeError):
         vcs = None


### PR DESCRIPTION
If our current directory is not tracked by git we should not try and search for the top-level directory of the working tree as any match will be a false positive.

Matching bogus parent working trees will result in poetry-core generating empty wheel/sdist files.

If our top level working git directory is:
```
/home/buildroot/buildroot/.git
```

With `/output` in this gitignore file:
```
/home/buildroot/buildroot/.gitignore
```

Then when building poetry-core from the following build directory:
```
/home/buildroot/buildroot/output/build/host-python-poetry-core-1.6.1
```

We will end up with an empty wheel file as all paths underneath this are ignored and incorrectly excluded by poetry-core:
```
/home/buildroot/buildroot/output
```

Fixes https://github.com/python-poetry/poetry/issues/5547