### PR TITLE
Add support for extras in markers

### DIFF
--- a/tests/fixtures/project_with_extra_in_markers/pyproject.toml
+++ b/tests/fixtures/project_with_extra_in_markers/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.poetry]
+name = "extra-package"
+version = "1.2.3"
+description = "Some description."
+authors = ["Your Name <you@example.com>"]
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = "^3.10"
+psycopg = [
+    { version = "^3.1.9" },
+    { version = "^3.1.9", optional = true , extras = ["binary"], markers = "extra == 'extra-binary'"},
+    { version = "^3.1.9", optional = true , extras = ["c"], markers = "extra in 'extra-c, extra-pool'"}
+]


### PR DESCRIPTION
Resolves: [python-poetry#834](https://github.com/python-poetry/poetry/issues/834)

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Description

Hello dear maintainers, it's my first contribution to Poetry so I hope I have done the things right.

As you may have seen in the issue mentioned above, there's a feature that's been requested but hasn't yet been implemented. Since I also need this feature, I decided to try to implement it myself and contribute to the project.

In the issue, it is requested that Poetry implements a feature that allows differing sets of dependency extras in the `tool.poetry.extras` section. I've chosen to make a slightly different implementation that the ones that were proposed because they had some problems in my opinion but this implementation also fix their problems.

In the `pyproject.toml`, it would look like that :

```toml
[tool.poetry.dependencies]
dependency = { version = "...", optional = true }

[tool.poetry.extras]
feature-a = ["dependency[feature-a]"]
feature-b = ["dependency[feature-b]"]
```

The extras that are located in the `tool.poetry.extras` section are additional extras that are added to the ones in `tool.poetry.dependencies` section. So, if there were an extra named `feature-c` in `dependency`, installing `my_project[feature-a]` would install `dependency[feature-a,feature-c]`.

## Why this implementation ?

In the [2 implementations proposed in the issue](https://github.com/python-poetry/poetry/issues/834#issue-402992710), I thought that there was some problems.

In the one with aliases, it would required many changes to make it work and the dependencies would have been less clear since we would not be able to read the true package names directly.

In the one with the superset that can be filtered, I thought that it would be a good idea at first but on second thought, it was not a really good idea since it would create backward-incompatible changes. Indeed, if we have a `pyproject.toml` like the one below, how should it be interpreted ?

```toml
[tool.poetry.dependencies]
dependency = { version = "...", optional = true, extras = ["feature-a", "feature-b"] }

[tool.poetry.extras]
no-feature = ["dependency"]
```

In the current implementation, it would download both features but if we implemented the new feature like a superset that can be filtered, it would have been more logical that it download neither of the features.

That's the reason why I implemented the feature like additional extras that can be added in the `tool.poetry.extras` section. It is backward-compatible because the feature only applies when we add square brackets at the end of an extra and since it was not possible before, it does not break anything.

In addition, it involves only very minor modifications because we just need to add additional dependencies when we found an extra in the `tool.poetry.extras` section.

Finally, it also solves [another problem that someone mentioned in the issue](https://github.com/python-poetry/poetry/issues/834#issuecomment-1184186068). Indeed, with this implementation, it is possible to have optional extras by writing something like this :

```toml
[tool.poetry.dependencies]
dependency = { version = "..." }

[tool.poetry.extras]
feature = ["dependency[feature]"]
```

With this configuration, it would install `dependency[feature]` only when installing `my_project[feature]` and it would install `dependency` when installing `my_project`.

If you are wondering why I choose to add additional extras and not to override extras, it's only because it could create inconsistencies. For example, with the following configuration, installing `my_project[feature-c]` would not install `dependency[feature-a, feature-b]` and since it is in the required section, it is not normal :

```toml
[tool.poetry.dependencies]
dependency = { version = "...", extras=["feature-a", "feature-b"] }

[tool.poetry.extras]
feature-c = ["dependency[feature-c]"]
```

## Conclusion

Thanks for reading this far and sorry for writing so much. I really wanted to expose my ideas and it took more space than expected.

Please let me know if there are any changes that could be made, and thank you for creating this fantastic software.