### PR TITLE
Remove leftover compat code

### DIFF
--- a/src/poetry/core/constraints/version/version_range.py
+++ b/src/poetry/core/constraints/version/version_range.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from contextlib import suppress
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 from poetry.core.constraints.version.empty_constraint import EmptyConstraint
@@ -12,7 +13,6 @@ from poetry.core.constraints.version.version_range_constraint import (
     VersionRangeConstraint,
 )
 from poetry.core.constraints.version.version_union import VersionUnion
-from poetry.core.utils._compat import cached_property
 
 
 if TYPE_CHECKING:

--- a/src/poetry/core/constraints/version/version_range_constraint.py
+++ b/src/poetry/core/constraints/version/version_range_constraint.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 from poetry.core.constraints.version.version_constraint import VersionConstraint
-from poetry.core.utils._compat import cached_property
 
 
 if TYPE_CHECKING:

--- a/src/poetry/core/constraints/version/version_union.py
+++ b/src/poetry/core/constraints/version/version_union.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import operator as op
 
+from functools import cached_property
 from functools import reduce
 from typing import TYPE_CHECKING
 
@@ -14,7 +15,6 @@ from poetry.core.constraints.version.version_constraint import (
 from poetry.core.constraints.version.version_range_constraint import (
     VersionRangeConstraint,
 )
-from poetry.core.utils._compat import cached_property
 
 
 if TYPE_CHECKING:

--- a/src/poetry/core/utils/_compat.py
+++ b/src/poetry/core/utils/_compat.py
@@ -5,18 +5,11 @@ import sys
 
 WINDOWS = sys.platform == "win32"
 
-if sys.version_info < (3, 8):
-    # no caching for python 3.7
-    cached_property = property
-else:
-    import functools
-
-    cached_property = functools.cached_property
 
 if sys.version_info < (3, 11):
     # compatibility for python <3.11
     import tomli as tomllib
 else:
-    import tomllib  # nopycln: import
+    import tomllib
 
 __all__ = ["tomllib"]


### PR DESCRIPTION
Removing some leftover compat code, which is no longer needed since we are now focused on 3.8+.
