### PR TITLE
Fix for handling of version ranges

### DIFF
--- a/src/poetry/core/constraints/version/version_range_constraint.py
+++ b/src/poetry/core/constraints/version/version_range_constraint.py
@@ -60,7 +60,7 @@ class VersionRangeConstraint(VersionConstraint):
         # The exclusive ordered comparison <V MUST NOT allow a pre-release
         # of the specified version unless the specified version is itself a pre-release.
         # https://peps.python.org/pep-0440/#exclusive-ordered-comparison
-        return self.max.first_devrelease()
+        return self.max.before_first_devrelease()
 
     def allows_lower(self, other: VersionRangeConstraint) -> bool:
         _this, _other = self.allowed_min, other.allowed_min

--- a/src/poetry/core/version/pep440/version.py
+++ b/src/poetry/core/version/pep440/version.py
@@ -297,6 +297,15 @@ class PEP440Version:
             pre=ReleaseTag(RELEASE_PHASE_ID_ALPHA),
         )
 
+    def before_first_devrelease(self: T) -> T:
+        return self.__class__(
+            epoch=self.epoch,
+            release=self.release,
+            pre=self.pre,
+            post=self.post,
+            dev=_NEG_INF_TAG,
+        )
+
     def first_devrelease(self: T) -> T:
         return self.__class__(
             epoch=self.epoch,


### PR DESCRIPTION
don't include first prerelease in the allowed max for an exclusive range.

Fixes https://github.com/python-poetry/poetry/issues/8475, https://github.com/python-poetry/poetry/issues/8405, https://github.com/python-poetry/poetry/issues/8202 

(actually 8202 seems to have been resolved by changes in the available dependencies on pypi and so I can't reproduce it now: but I'm pretty sure these will all be the same)

Absurdly I can't find a simple testcase that takes two versions or version ranges and compares or intersects them or something to demonstrate the point.  So I confess that I don't fully understand what was going wrong before this fix.

However I do understand that those issues are 
- something to do with wildcard constraints (eg `=2.*`) which poetry interprets as having a lower bound that is the first dev-release (eg `2.dev0`)
- and something to do with how they interact with regular but adjacent constraints like `<2`

so I've made this fix somewhat on gut: `<2` certainly shouldn't allow `2.dev0` and so it's weird that `allowed_max` would return that value.

What can I say?  I'm confused, but this looks like a good fix and it does resolve those issues...