### PR TITLE
deprecate transitive_python_versions

### DIFF
--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -142,6 +142,11 @@ class Dependency(PackageSpecification):
 
     @property
     def transitive_python_versions(self) -> str:
+        warnings.warn(
+            "'transitive_python_versions' is deprecated and will be removed.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self._transitive_python_versions is None:
             return self._python_versions
 
@@ -149,6 +154,11 @@ class Dependency(PackageSpecification):
 
     @transitive_python_versions.setter
     def transitive_python_versions(self, value: str) -> None:
+        warnings.warn(
+            "'transitive_python_versions' is deprecated and will be removed.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._transitive_python_versions = value
         self._transitive_python_constraint = parse_constraint(value)
 

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from contextlib import AbstractContextManager
+from contextlib import nullcontext
+from typing import Any
+
 import pytest
 
 from packaging.utils import canonicalize_name
@@ -303,7 +307,8 @@ def test_with_constraint() -> None:
         'python_version >= "3.7" and python_version < "4.0"'
     )
     dependency.python_versions = "^3.6"
-    dependency.transitive_python_versions = "^3.7"
+    with pytest.warns(DeprecationWarning):
+        dependency.transitive_python_versions = "^3.7"
 
     new = dependency.with_constraint("^1.2.6")
 
@@ -403,7 +408,14 @@ def test_mutable_attributes_not_in_hash(attr_name: str, value: str) -> None:
     dependency = Dependency("foo", "^1.2.3")
     ref_hash = hash(dependency)
 
-    ref_value = getattr(dependency, attr_name)
-    setattr(dependency, attr_name, value)
+    if attr_name == "transitive_python_versions":
+        context: AbstractContextManager[Any] = pytest.warns(DeprecationWarning)
+    else:
+        context = nullcontext()
+
+    with context:
+        ref_value = getattr(dependency, attr_name)
+    with context:
+        setattr(dependency, attr_name, value)
     assert value != ref_value
     assert hash(dependency) == ref_hash


### PR DESCRIPTION
per https://github.com/python-poetry/poetry/pull/8542, `transitive_python_versions` is unused and confusing