### PR TITLE
also deprecate transitive_python_constraint

### DIFF
--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -219,6 +219,11 @@ class Dependency(PackageSpecification):
 
     @property
     def transitive_python_constraint(self) -> VersionConstraint:
+        warnings.warn(
+            "'transitive_python_constraint' is deprecated and will be removed.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self._transitive_python_constraint is None:
             return self._python_constraint
 

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -321,7 +321,10 @@ def test_with_constraint() -> None:
     assert new.marker == dependency.marker
     assert new.transitive_marker == dependency.transitive_marker
     assert new.python_constraint == dependency.python_constraint
-    assert new.transitive_python_constraint == dependency.transitive_python_constraint
+    with pytest.warns(DeprecationWarning):
+        assert (
+            new.transitive_python_constraint == dependency.transitive_python_constraint
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
should go at the same time as `transitive_python_versions`, also unused and confusing 