### PR TITLE
Use `pyproject.toml` or SOURCE_DATE_EPOCH for generated file mtime

### DIFF
--- a/src/poetry/core/masonry/builders/sdist.py
+++ b/src/poetry/core/masonry/builders/sdist.py
@@ -371,13 +371,13 @@ class SdistBuilder(Builder):
         # same as how the pyproject.toml file is located in `find_files_to_add`
         pyproject = self._path / Path("pyproject.toml")
         try:
-            mtime = int(pyproject.stat(follow_symlinks=True).st_mtime)
+            mtime = int(pyproject.stat().st_mtime)
         except FileNotFoundError:
             logger.debug("pyproject.toml not found, using 0 for generated files mtime")
         except TypeError:
             logger.debug(
                 "mtime of pyproject.toml couldnt be coerced to an int, using 0, got"
-                f" mtime: {pyproject.stat(follow_symlinks=True).st_mtime}"
+                f" mtime: {pyproject.stat().st_mtime}"
             )
 
         return mtime

--- a/src/poetry/core/masonry/builders/sdist.py
+++ b/src/poetry/core/masonry/builders/sdist.py
@@ -352,26 +352,33 @@ class SdistBuilder(Builder):
         """
         Get mtime for generated files
 
-        * If the environment variable ``SOURCE_DATE_EPOCH`` is set as an integer, use that
+        * If the environment variable ``SOURCE_DATE_EPOCH`` is set as an integer,
+          use that
         * Otherwise, use the mtime of ``pyproject.toml``
         """
-        mtime = os.environ.get('SOURCE_DATE_EPOCH', None)
+        mtime = os.environ.get("SOURCE_DATE_EPOCH", None)  # type: int | str | None
         if mtime is not None:
             try:
-                logger.debug('Using SOURCE_DATE_EPOCH for generated file mtime')
+                logger.debug("Using SOURCE_DATE_EPOCH for generated file mtime")
                 return int(mtime)
             except TypeError:
-                logger.warning('SOURCE_DATE_EPOCH is not an integer, attempting to use mtime of pyproject.toml')
+                logger.warning(
+                    "SOURCE_DATE_EPOCH is not an integer, attempting to use mtime of"
+                    " pyproject.toml"
+                )
         mtime = 0
 
         # same as how the pyproject.toml file is located in `find_files_to_add`
-        pyproject = self._path / Path('pyproject.toml')
+        pyproject = self._path / Path("pyproject.toml")
         try:
             mtime = int(pyproject.stat(follow_symlinks=True).st_mtime)
         except FileNotFoundError:
-            logger.debug('pyproject.toml not found, using 0 for generated files mtime')
+            logger.debug("pyproject.toml not found, using 0 for generated files mtime")
         except TypeError:
-            logger.debug(f'mtime of pyproject.toml couldnt be coerced to an int, using 0, got mtime: {pyproject.stat(follow_symlinks=True).st_mtime}')
+            logger.debug(
+                "mtime of pyproject.toml couldnt be coerced to an int, using 0, got"
+                f" mtime: {pyproject.stat(follow_symlinks=True).st_mtime}"
+            )
 
         return mtime
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 import tempfile
 
@@ -108,3 +109,17 @@ def python(venv: Path) -> str:
 @pytest.fixture()
 def f() -> Factory:
     return Factory()
+
+@pytest.fixture(scope="function", params=[None, 1697539120])
+def env_source_date_epoch(request):
+    # store original value
+    env_orig = None
+    if request.param is not None:
+        env_orig = os.environ.get('SOURCE_DATE_EPOCH', None)
+        os.environ['SOURCE_DATE_EPOCH'] = str(request.param)
+
+    yield request.param
+
+    # restore
+    if env_orig is not None:
+        os.environ['SOURCE_DATE_EPOCH'] = env_orig

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ from poetry.core.utils._compat import WINDOWS
 if TYPE_CHECKING:
     from _pytest.config import Config
     from _pytest.config.argparsing import Parser
+    from _pytest.fixtures import SubRequest
 
 
 def pytest_addoption(parser: Parser) -> None:
@@ -110,16 +111,17 @@ def python(venv: Path) -> str:
 def f() -> Factory:
     return Factory()
 
+
 @pytest.fixture(scope="function", params=[None, 1697539120])
-def env_source_date_epoch(request):
+def env_source_date_epoch(request: SubRequest) -> Iterator[int | None]:
     # store original value
     env_orig = None
     if request.param is not None:
-        env_orig = os.environ.get('SOURCE_DATE_EPOCH', None)
-        os.environ['SOURCE_DATE_EPOCH'] = str(request.param)
+        env_orig = os.environ.get("SOURCE_DATE_EPOCH", None)
+        os.environ["SOURCE_DATE_EPOCH"] = str(request.param)
 
     yield request.param
 
     # restore
     if env_orig is not None:
-        os.environ['SOURCE_DATE_EPOCH'] = env_orig
+        os.environ["SOURCE_DATE_EPOCH"] = env_orig

--- a/tests/masonry/builders/test_sdist.py
+++ b/tests/masonry/builders/test_sdist.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Iterator
-from typing import Optional
 
 import pytest
 
@@ -438,7 +437,9 @@ def test_with_src_module_dir() -> None:
         assert "package_src-0.1/src/package_src/module.py" in tar.getnames()
 
 
-def test_default_with_excluded_data(mocker: MockerFixture, env_source_date_epoch: Optional[int]) -> None:
+def test_default_with_excluded_data(
+    mocker: MockerFixture, env_source_date_epoch: int | None
+) -> None:
     class MockGit:
         def get_ignored_files(self, folder: Path | None = None) -> list[str]:
             # Patch git module to return specific excluded files
@@ -498,11 +499,13 @@ def test_default_with_excluded_data(mocker: MockerFixture, env_source_date_epoch
         # if the SOURCE_DATE_EPOCH env variable is set, use it for mtimes
         if env_source_date_epoch is None:
             # if unset, should be pyproject.toml's mtime
-            generated_mtime = int(tar.getmember('my_package-1.2.3/pyproject.toml').mtime)
+            generated_mtime = int(
+                tar.getmember("my_package-1.2.3/pyproject.toml").mtime
+            )
         else:
             # should be the env variable, which should be set
             generated_mtime = env_source_date_epoch
-            assert os.environ['SOURCE_DATE_EPOCH'] == str(generated_mtime)
+            assert os.environ["SOURCE_DATE_EPOCH"] == str(generated_mtime)
 
         # all last modified times should be set to a valid timestamp
         for tarinfo in tar.getmembers():
@@ -510,7 +513,8 @@ def test_default_with_excluded_data(mocker: MockerFixture, env_source_date_epoch
                 "my_package-1.2.3/setup.py",
                 "my_package-1.2.3/PKG-INFO",
             ]:
-                # generated files have timestamp set to pyproject.toml's mtime or SOURCE_DATE_EPOCH
+                # generated files have timestamp set to pyproject.toml's mtime
+                # or SOURCE_DATE_EPOCH
                 assert tarinfo.mtime == generated_mtime
                 continue
             assert tarinfo.mtime > 0


### PR DESCRIPTION
Resolves (or rather, revisits): poetry-core#142

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
> As far as I can find, there is no documentation for setting modified time in generated files.
- [x] Reviewed contributing docs, ran mypy, pre-commit checks, pytest.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

Was wondering why there were a bunch of files with time == 0 on my disk, found this previous PR that set mtime to 0 for generated files for deterministic builds: https://github.com/python-poetry/poetry-core/pull/142 and also this comment at the end that suggested that pulling the time from `pyproject.toml` would be a good way to be deterministic while also having a sensible timestamp: https://github.com/python-poetry/poetry-core/pull/142#issuecomment-822413583 and went ahead and did that, also adding this suggestion to use `SOURCE_DATE_EPOCH` if set https://github.com/python-poetry/poetry-core/pull/142#pullrequestreview-617327332

