### PR TITLE
make `make vendor/lock` update packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ POETRY_BIN                      ?= $(shell which poetry)
 .PHONY: vendor/lock
 vendor/lock: $(VENDOR_LOCK)
 	# regenerate lock file
-	@pushd $(VENDOR_SRC) && $(POETRY_BIN) lock --no-update
+	@pushd $(VENDOR_SRC) && $(POETRY_BIN) lock
 
 .PHONY: vendor/sync
 vendor/sync:


### PR DESCRIPTION
Not sure what the intention of `--no-update` was here.  

For me it's just a minor annoyance that I always manually undo whenever I `make vendor/update`