### PR TITLE
release: bump version to 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,33 @@
 # Change Log
 
 
+## [1.8.0] - 2023-10-31
+
+### Added
+
+- Add `3.12` to the list of available Python versions ([#631](https://github.com/python-poetry/poetry-core/pull/631)).
+- Add support for creating packages dynamically in the build script ([#629](https://github.com/python-poetry/poetry-core/pull/629)).
+
+### Changed
+
+- Improve marker logic for `extra` markers ([#636](https://github.com/python-poetry/poetry-core/pull/636)).
+- Update list of supported licenses ([#635](https://github.com/python-poetry/poetry-core/pull/635),
+[#646](https://github.com/python-poetry/poetry-core/pull/646)).
+- Deprecate `Dependency.transitive_python_versions` ([#648](https://github.com/python-poetry/poetry-core/pull/648)).
+- Deprecate `Dependency.transitive_python_constraint` ([#649](https://github.com/python-poetry/poetry-core/pull/649)).
+
+### Fixed
+
+- Fix an issue where projects with extension modules were not installed in editable mode ([#633](https://github.com/python-poetry/poetry-core/pull/633)).
+- Fix an issue where the wrong or no `lib` folder was added to the wheel ([#634](https://github.com/python-poetry/poetry-core/pull/634)).
+
+### Vendoring
+
+- Replace [`jsonschema`](https://github.com/python-jsonschema/jsonschema) with [`fastjsonschema`](https://github.com/horejsek/python-fastjsonschema).
+- [`lark==1.1.8`](https://github.com/lark-parser/lark/releases/tag/1.1.8)
+- [`packaging==23.2`](https://github.com/pypa/packaging/blob/main/CHANGELOG.rst)
+
+
 ## [1.7.0] - 2023-08-20
 
 ### Added
@@ -567,7 +594,8 @@ No changes.
 - Fixed support for stub-only packages ([#28](https://github.com/python-poetry/core/pull/28)).
 
 
-[Unreleased]: https://github.com/python-poetry/poetry-core/compare/1.7.0...main
+[Unreleased]: https://github.com/python-poetry/poetry-core/compare/1.8.0...main
+[1.8.0]: https://github.com/python-poetry/poetry-core/releases/tag/1.8.0
 [1.7.0]: https://github.com/python-poetry/poetry-core/releases/tag/1.7.0
 [1.6.1]: https://github.com/python-poetry/poetry-core/releases/tag/1.6.1
 [1.6.0]: https://github.com/python-poetry/poetry-core/releases/tag/1.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-core"
-version = "1.7.0"
+version = "1.8.0"
 description = "Poetry PEP 517 Build Backend"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 license = "MIT"
@@ -10,7 +10,9 @@ repository = "https://github.com/python-poetry/poetry-core"
 keywords = ["packaging", "dependency", "poetry"]
 classifiers = [
     "Topic :: Software Development :: Build Tools",
-    "Topic :: Software Development :: Libraries :: Python Modules"
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    # Classifiers for Python 3.12 can be removed after Poetry 1.7.0 has been released.
+    "Programming Language :: Python :: 3.12",
 ]
 packages = [
     { include = "poetry", from = "src" },

--- a/src/poetry/core/__init__.py
+++ b/src/poetry/core/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 # this cannot presently be replaced with importlib.metadata.version as when building
 # itself, poetry-core is not available as an installed distribution.
-__version__ = "1.7.0"
+__version__ = "1.8.0"
 
 __vendor_site__ = (Path(__file__).parent / "_vendor").as_posix()
 


### PR DESCRIPTION
### Added

- Add `3.12` to the list of available Python versions ([#631](https://github.com/python-poetry/poetry-core/pull/631)).
- Add support for creating packages dynamically in the build script ([#629](https://github.com/python-poetry/poetry-core/pull/629)).

### Changed

- Improve marker logic for `extra` markers ([#636](https://github.com/python-poetry/poetry-core/pull/636)).
- Update list of supported licenses ([#635](https://github.com/python-poetry/poetry-core/pull/635), [#646](https://github.com/python-poetry/poetry-core/pull/646)).
- Deprecate `Dependency.transitive_python_versions` ([#648](https://github.com/python-poetry/poetry-core/pull/648)).
- Deprecate `Dependency.transitive_python_constraint` ([#649](https://github.com/python-poetry/poetry-core/pull/649)).

### Fixed

- Fix an issue where projects with extension modules were not installed in editable mode ([#633](https://github.com/python-poetry/poetry-core/pull/633)).
- Fix an issue where the wrong or no `lib` folder was added to the wheel ([#634](https://github.com/python-poetry/poetry-core/pull/634)).

### Vendoring

- Replace [`jsonschema`](https://github.com/python-jsonschema/jsonschema) with [`fastjsonschema`](https://github.com/horejsek/python-fastjsonschema).
- [`lark==1.1.8`](https://github.com/lark-parser/lark/releases/tag/1.1.8)
- [`packaging==23.2`](https://github.com/pypa/packaging/blob/main/CHANGELOG.rst)