### PR TITLE
release: bump version to 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 
 
+## [1.8.1] - 2023-10-31
+
+### Fixed
+
+- Fix an issue where git URLs starting with `git+` could not be parsed anymore ([#657](https://github.com/python-poetry/poetry-core/pull/657)).
+
+
 ## [1.8.0] - 2023-10-31
 
 ### Added
@@ -594,7 +601,8 @@ No changes.
 - Fixed support for stub-only packages ([#28](https://github.com/python-poetry/core/pull/28)).
 
 
-[Unreleased]: https://github.com/python-poetry/poetry-core/compare/1.8.0...main
+[Unreleased]: https://github.com/python-poetry/poetry-core/compare/1.8.1...main
+[1.8.1]: https://github.com/python-poetry/poetry-core/releases/tag/1.8.1
 [1.8.0]: https://github.com/python-poetry/poetry-core/releases/tag/1.8.0
 [1.7.0]: https://github.com/python-poetry/poetry-core/releases/tag/1.7.0
 [1.6.1]: https://github.com/python-poetry/poetry-core/releases/tag/1.6.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-core"
-version = "1.8.0"
+version = "1.8.1"
 description = "Poetry PEP 517 Build Backend"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 license = "MIT"

--- a/src/poetry/core/__init__.py
+++ b/src/poetry/core/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 # this cannot presently be replaced with importlib.metadata.version as when building
 # itself, poetry-core is not available as an installed distribution.
-__version__ = "1.8.0"
+__version__ = "1.8.1"
 
 __vendor_site__ = (Path(__file__).parent / "_vendor").as_posix()
 


### PR DESCRIPTION
### Fixed

- Fix an issue where git URLs starting with `git+` could not be parsed anymore ([#657](https://github.com/python-poetry/poetry-core/pull/657)).
