### PR TITLE
Introduce non-package-mode

### DIFF
--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -396,13 +396,12 @@ class Factory:
         # which is quite vague, so we try to give a more precise error message
         generic_error = "data cannot be validated by any definition"
         if generic_error in validation_errors:
-            mode = config.get("mode", "package")
-            if mode not in {"package", "non-package"}:
+            package_mode = config.get("package-mode", True)
+            if not isinstance(package_mode, bool):
                 validation_errors[validation_errors.index(generic_error)] = (
-                    f'Invalid mode "{mode}"'
-                    ' (allowed values are "package" and "non-package").'
+                    f"Invalid value for package-mode: {package_mode}"
                 )
-            elif mode == "package":
+            elif package_mode:
                 required = {"name", "version", "description", "authors"}
                 if missing := required.difference(config):
                     validation_errors[validation_errors.index(generic_error)] = (

--- a/src/poetry/core/json/schemas/poetry-schema.json
+++ b/src/poetry/core/json/schemas/poetry-schema.json
@@ -3,13 +3,36 @@
   "name": "Package",
   "type": "object",
   "additionalProperties": true,
-  "required": [
-    "name",
-    "version",
-    "description",
-    "authors"
+  "anyOf": [
+    {
+      "required": [
+        "mode"
+      ],
+      "properties": {
+        "mode": {
+          "enum": [
+            "non-package"
+          ]
+        }
+      }
+    },
+    {
+      "required": [
+        "name",
+        "version",
+        "description",
+        "authors"
+      ]
+    }
   ],
   "properties": {
+    "mode": {
+      "enum": [
+        "package",
+        "non-package"
+      ],
+      "description": "Defines the operating mode of Poetry."
+    },
     "name": {
       "type": "string",
       "description": "Package name."

--- a/src/poetry/core/json/schemas/poetry-schema.json
+++ b/src/poetry/core/json/schemas/poetry-schema.json
@@ -6,12 +6,12 @@
   "anyOf": [
     {
       "required": [
-        "mode"
+        "package-mode"
       ],
       "properties": {
-        "mode": {
+        "package-mode": {
           "enum": [
-            "non-package"
+            false
           ]
         }
       }
@@ -26,12 +26,10 @@
     }
   ],
   "properties": {
-    "mode": {
-      "enum": [
-        "package",
-        "non-package"
-      ],
-      "description": "Defines the operating mode of Poetry."
+    "package-mode": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether Poetry is operated in package mode or non-package mode."
     },
     "name": {
       "type": "string",

--- a/src/poetry/core/masonry/builders/builder.py
+++ b/src/poetry/core/masonry/builders/builder.py
@@ -41,6 +41,11 @@ class Builder:
     ) -> None:
         from poetry.core.masonry.metadata import Metadata
 
+        if not poetry.is_package_mode:
+            raise RuntimeError(
+                "Building a package is not possible in non-package mode."
+            )
+
         self._poetry = poetry
         self._package = poetry.package
         self._path: Path = poetry.pyproject_path.parent

--- a/src/poetry/core/poetry.py
+++ b/src/poetry/core/poetry.py
@@ -37,6 +37,12 @@ class Poetry:
         return self._package
 
     @property
+    def is_package_mode(self) -> bool:
+        mode = self._local_config.get("mode", "package")
+        assert isinstance(mode, str)
+        return mode == "package"
+
+    @property
     def local_config(self) -> dict[str, Any]:
         return self._local_config
 

--- a/src/poetry/core/poetry.py
+++ b/src/poetry/core/poetry.py
@@ -38,9 +38,9 @@ class Poetry:
 
     @property
     def is_package_mode(self) -> bool:
-        mode = self._local_config.get("mode", "package")
-        assert isinstance(mode, str)
-        return mode == "package"
+        package_mode = self._local_config["package-mode"]
+        assert isinstance(package_mode, bool)
+        return package_mode
 
     @property
     def local_config(self) -> dict[str, Any]:

--- a/tests/fixtures/invalid_mode/pyproject.toml
+++ b/tests/fixtures/invalid_mode/pyproject.toml
@@ -1,2 +1,2 @@
 [tool.poetry]
-mode = "invalid"
+package-mode = "invalid"

--- a/tests/fixtures/invalid_mode/pyproject.toml
+++ b/tests/fixtures/invalid_mode/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.poetry]
+mode = "invalid"

--- a/tests/fixtures/non_package_mode/pyproject.toml
+++ b/tests/fixtures/non_package_mode/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.poetry]
+mode = "non-package"
+
+[tool.poetry.dependencies]
+python = "^3.8"
+cleo = "^0.6"
+pendulum = { git = "https://github.com/sdispater/pendulum.git", branch = "2.0" }

--- a/tests/fixtures/non_package_mode/pyproject.toml
+++ b/tests/fixtures/non_package_mode/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-mode = "non-package"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/tests/json/test_poetry_schema.py
+++ b/tests/json/test_poetry_schema.py
@@ -39,6 +39,35 @@ def multi_url_object() -> dict[str, Any]:
     }
 
 
+@pytest.mark.parametrize("explicit", [True, False])
+@pytest.mark.parametrize(
+    "missing_required", ["", "name", "version", "description", "authors"]
+)
+def test_package_mode(
+    base_object: dict[str, Any], explicit: bool, missing_required: str
+) -> None:
+    if explicit:
+        base_object["mode"] = "package"
+    if missing_required:
+        del base_object[missing_required]
+        assert len(validate_object(base_object, "poetry-schema")) == 1
+    else:
+        assert len(validate_object(base_object, "poetry-schema")) == 0
+
+
+def test_non_package_mode_no_metadata() -> None:
+    assert len(validate_object({"mode": "non-package"}, "poetry-schema")) == 0
+
+
+def test_non_package_mode_with_metadata(base_object: dict[str, Any]) -> None:
+    base_object["mode"] = "non-package"
+    assert len(validate_object(base_object, "poetry-schema")) == 0
+
+
+def test_invalid_mode() -> None:
+    assert len(validate_object({"mode": "foo"}, "poetry-schema")) == 1
+
+
 def test_path_dependencies(base_object: dict[str, Any]) -> None:
     base_object["dependencies"].update({"foo": {"path": "../foo"}})
     base_object["dev-dependencies"].update({"foo": {"path": "../foo"}})

--- a/tests/json/test_poetry_schema.py
+++ b/tests/json/test_poetry_schema.py
@@ -47,7 +47,7 @@ def test_package_mode(
     base_object: dict[str, Any], explicit: bool, missing_required: str
 ) -> None:
     if explicit:
-        base_object["mode"] = "package"
+        base_object["package-mode"] = True
     if missing_required:
         del base_object[missing_required]
         assert len(validate_object(base_object, "poetry-schema")) == 1
@@ -56,16 +56,16 @@ def test_package_mode(
 
 
 def test_non_package_mode_no_metadata() -> None:
-    assert len(validate_object({"mode": "non-package"}, "poetry-schema")) == 0
+    assert len(validate_object({"package-mode": False}, "poetry-schema")) == 0
 
 
 def test_non_package_mode_with_metadata(base_object: dict[str, Any]) -> None:
-    base_object["mode"] = "non-package"
+    base_object["package-mode"] = False
     assert len(validate_object(base_object, "poetry-schema")) == 0
 
 
 def test_invalid_mode() -> None:
-    assert len(validate_object({"mode": "foo"}, "poetry-schema")) == 1
+    assert len(validate_object({"package-mode": "foo"}, "poetry-schema")) == 1
 
 
 def test_path_dependencies(base_object: dict[str, Any]) -> None:

--- a/tests/masonry/builders/test_builder.py
+++ b/tests/masonry/builders/test_builder.py
@@ -16,6 +16,17 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
+def test_building_not_possible_in_non_package_mode() -> None:
+    with pytest.raises(RuntimeError) as err:
+        Builder(
+            Factory().create_poetry(
+                Path(__file__).parent.parent.parent / "fixtures" / "non_package_mode"
+            )
+        )
+
+    assert str(err.value) == "Building a package is not possible in non-package mode."
+
+
 def test_builder_find_excluded_files(mocker: MockerFixture) -> None:
     p = mocker.patch("poetry.core.vcs.git.Git.get_ignored_files")
     p.return_value = []
@@ -190,7 +201,7 @@ def test_missing_script_files_throws_error() -> None:
     with pytest.raises(RuntimeError) as err:
         builder.convert_script_files()
 
-    assert "is not found." in err.value.args[0]
+    assert "is not found." in str(err.value)
 
 
 def test_invalid_script_files_definition() -> None:
@@ -203,8 +214,8 @@ def test_invalid_script_files_definition() -> None:
             )
         )
 
-    assert "configuration is invalid" in err.value.args[0]
-    assert "scripts.invalid_definition" in err.value.args[0]
+    assert "configuration is invalid" in str(err.value)
+    assert "scripts.invalid_definition" in str(err.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/masonry/test_builder.py
+++ b/tests/masonry/test_builder.py
@@ -46,6 +46,17 @@ def test_builder_factory_raises_error_when_format_is_not_valid() -> None:
 
 
 @pytest.mark.parametrize("format", ["sdist", "wheel", "all"])
+def test_builder_raises_error_in_non_package_mode(tmp_path: Path, format: str) -> None:
+    poetry = Factory().create_poetry(
+        Path(__file__).parent.parent / "fixtures" / "non_package_mode"
+    )
+    with pytest.raises(RuntimeError) as err:
+        Builder(poetry).build(format, target_dir=tmp_path)
+
+    assert str(err.value) == "Building a package is not possible in non-package mode."
+
+
+@pytest.mark.parametrize("format", ["sdist", "wheel", "all"])
 def test_builder_creates_places_built_files_in_specified_directory(
     tmp_path: Path, format: str
 ) -> None:

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -375,7 +375,7 @@ def test_create_poetry_fails_on_invalid_mode() -> None:
 
     expected = """\
 The Poetry configuration is invalid:
-  - Invalid mode "invalid" (allowed values are "package" and "non-package").
+  - Invalid value for package-mode: invalid
 """
     assert str(e.value) == expected
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -31,6 +31,8 @@ fixtures_dir = Path(__file__).parent / "fixtures"
 def test_create_poetry() -> None:
     poetry = Factory().create_poetry(fixtures_dir / "sample_project")
 
+    assert poetry.is_package_mode
+
     package = poetry.package
 
     assert package.name == "my-package"
@@ -237,6 +239,12 @@ def test_create_poetry_with_multi_constraints_dependency() -> None:
     assert len(package.requires) == 2
 
 
+def test_create_poetry_non_package_mode() -> None:
+    poetry = Factory().create_poetry(fixtures_dir / "non_package_mode")
+
+    assert not poetry.is_package_mode
+
+
 def test_validate() -> None:
     complete = fixtures_dir / "complete.toml"
     with complete.open("rb") as f:
@@ -269,8 +277,8 @@ def test_validate_without_strict_fails_only_non_strict() -> None:
     assert Factory.validate(content) == {
         "errors": [
             (
-                "data must contain ['authors', 'description', 'name', 'version'] "
-                "properties"
+                "The fields ['authors', 'description', 'name', 'version']"
+                " are required in package mode."
             ),
         ],
         "warnings": [],
@@ -288,8 +296,8 @@ def test_validate_strict_fails_strict_and_non_strict() -> None:
     assert Factory.validate(content, strict=True) == {
         "errors": [
             (
-                "data must contain ['authors', 'description', 'name', 'version']"
-                " properties"
+                "The fields ['authors', 'description', 'name', 'version']"
+                " are required in package mode."
             ),
             (
                 'Cannot find dependency "missing_extra" for extra "some-extras" in '
@@ -354,7 +362,20 @@ def test_create_poetry_fails_on_invalid_configuration() -> None:
 
     expected = """\
 The Poetry configuration is invalid:
-  - data must contain ['description'] properties
+  - The fields ['description'] are required in package mode.
+"""
+    assert str(e.value) == expected
+
+
+def test_create_poetry_fails_on_invalid_mode() -> None:
+    with pytest.raises(RuntimeError) as e:
+        Factory().create_poetry(
+            Path(__file__).parent / "fixtures" / "invalid_mode" / "pyproject.toml"
+        )
+
+    expected = """\
+The Poetry configuration is invalid:
+  - Invalid mode "invalid" (allowed values are "package" and "non-package").
 """
     assert str(e.value) == expected
 


### PR DESCRIPTION
Precondition for python-poetry/poetry#8650

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
- add a new attribute ~`mode`~ `package-mode` in `tool.poetry`
- ~`mode` can be either `package` (default) or `non-package`~
- `package-mode` can be either `true` (default) or `false`
- in non-package mode metadata like `name` and `version` is not required
- building is not possible in non-package mode