### PR TITLE
[README] Clarify note about unneeded dependencies of Poetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ build-backend = "poetry.core.masonry.api"
 ```
 
 Once this is present, a PEP 517 frontend like `pip` can build and install your project from source without the need
-for Poetry or any of its dependencies.
+for Poetry or any of its dependencies (besides `poetry-core`).
 
 ```shell
 # install to current environment


### PR DESCRIPTION
`poetry-core` [is a dependency of Poetry](https://github.com/python-poetry/poetry/blob/eb80d10846f7336b0b2a66ce2964e72dffee9a1c/pyproject.toml#L35), of course.

This change should avoid confusion arising from the former wording.