### PR TITLE
tests: fix test failures on upcoming `gcc-14`

### DIFF
--- a/tests/masonry/builders/fixtures/extended/extended/extended.c
+++ b/tests/masonry/builders/fixtures/extended/extended/extended.c
@@ -10,7 +10,7 @@ static PyMethodDef module_methods[] = {
     {
         "hello",
         (PyCFunction) hello,
-        NULL,
+        0,
         PyDoc_STR("Say hello.")
     },
     {NULL}

--- a/tests/masonry/builders/fixtures/extended_with_no_setup/extended/extended.c
+++ b/tests/masonry/builders/fixtures/extended_with_no_setup/extended/extended.c
@@ -10,7 +10,7 @@ static PyMethodDef module_methods[] = {
     {
         "hello",
         (PyCFunction) hello,
-        NULL,
+        0,
         PyDoc_STR("Say hello.")
     },
     {NULL}

--- a/tests/masonry/builders/fixtures/src_extended/src/extended/extended.c
+++ b/tests/masonry/builders/fixtures/src_extended/src/extended/extended.c
@@ -10,7 +10,7 @@ static PyMethodDef module_methods[] = {
     {
         "hello",
         (PyCFunction) hello,
-        NULL,
+        0,
         PyDoc_STR("Say hello.")
     },
     {NULL}


### PR DESCRIPTION
Upcoming `gcc-14` enabled a few warnings into errors, like `-Wint-conversion`. This caused `shadow` build to fail as:

    src/extended/extended.c:13:9: error:
      initialization of ‘int’ from ‘void *’ makes integer from pointer
        without a cast [-Wint-conversion]
       13 |         NULL,
          |         ^~~~

The change fixes `int ml_flags;` to take `int` instead of pointer.

Resolves: python-poetry#<!-- add issue number/link here -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
