### PR TITLE
Allow path dependency that is missing build-system

### DIFF
--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -406,8 +406,7 @@ class Dependency(PackageSpecification):
             if os.path.isdir(p) and (os.path.sep in name or name.startswith(".")):
                 if not is_python_project(Path(name)):
                     raise ValueError(
-                        f"Directory {name!r} is not installable. File 'setup.[py|cfg]' "
-                        "not found."
+                        f"Directory {name!r} is not installable. Not a Python project."
                     )
                 link = Link(path_to_url(p))
             elif is_archive_file(p):

--- a/src/poetry/core/packages/utils/utils.py
+++ b/src/poetry/core/packages/utils/utils.py
@@ -18,7 +18,6 @@ from urllib.request import url2pathname
 from poetry.core.constraints.version import Version
 from poetry.core.constraints.version import VersionRange
 from poetry.core.constraints.version import parse_marker_version_constraint
-from poetry.core.pyproject.toml import PyProjectTOML
 from poetry.core.version.markers import SingleMarker
 from poetry.core.version.markers import SingleMarkerLike
 from poetry.core.version.markers import dnf
@@ -129,12 +128,9 @@ def is_python_project(path: Path) -> bool:
     setup_cfg = path / "setup.cfg"
     setuptools_project = setup_py.exists() or setup_cfg.exists()
 
-    pyproject = PyProjectTOML(path / "pyproject.toml")
+    pyproject = (path / "pyproject.toml").exists()
 
-    supports_pep517 = setuptools_project or pyproject.exists()
-    supports_poetry = pyproject.is_poetry_project()
-
-    return supports_pep517 or supports_poetry
+    return pyproject or setuptools_project
 
 
 def is_archive_file(name: str) -> bool:

--- a/src/poetry/core/packages/utils/utils.py
+++ b/src/poetry/core/packages/utils/utils.py
@@ -131,7 +131,7 @@ def is_python_project(path: Path) -> bool:
 
     pyproject = PyProjectTOML(path / "pyproject.toml")
 
-    supports_pep517 = setuptools_project or pyproject.is_build_system_defined()
+    supports_pep517 = setuptools_project or pyproject.exists()
     supports_poetry = pyproject.is_poetry_project()
 
     return supports_pep517 or supports_poetry

--- a/src/poetry/core/pyproject/toml.py
+++ b/src/poetry/core/pyproject/toml.py
@@ -33,9 +33,6 @@ class PyProjectTOML:
 
         return self._data
 
-    def exists(self) -> bool:
-        return self.path.exists()
-
     @property
     def build_system(self) -> BuildSystem:
         if self._build_system is None:

--- a/src/poetry/core/pyproject/toml.py
+++ b/src/poetry/core/pyproject/toml.py
@@ -33,8 +33,8 @@ class PyProjectTOML:
 
         return self._data
 
-    def is_build_system_defined(self) -> bool:
-        return "build-system" in self.data
+    def exists(self) -> bool:
+        return self.path.exists()
 
     @property
     def build_system(self) -> BuildSystem:

--- a/tests/fixtures/project_minimal/pyproject.toml
+++ b/tests/fixtures/project_minimal/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "minimal"
+version = "1"

--- a/tests/packages/test_directory_dependency.py
+++ b/tests/packages/test_directory_dependency.py
@@ -67,11 +67,7 @@ def test_directory_dependency_is_not_a_python_project(
 
 
 def test_directory_dependency_minimal() -> None:
-    path = (
-        Path(__file__).parent.parent
-        / "fixtures"
-        / "project_minimal"
-    )
+    path = Path(__file__).parent.parent / "fixtures" / "project_minimal"
     dep = DirectoryDependency("demo", path)
     dep.validate(raise_error=True)
 

--- a/tests/packages/test_directory_dependency.py
+++ b/tests/packages/test_directory_dependency.py
@@ -66,6 +66,16 @@ def test_directory_dependency_is_not_a_python_project(
         dep.validate(raise_error=True)
 
 
+def test_directory_dependency_minimal() -> None:
+    path = (
+        Path(__file__).parent.parent
+        / "fixtures"
+        / "project_minimal"
+    )
+    dep = DirectoryDependency("demo", path)
+    dep.validate(raise_error=True)
+
+
 def _test_directory_dependency_pep_508(
     name: str, path: Path, pep_508_input: str, pep_508_output: str | None = None
 ) -> None:


### PR DESCRIPTION
Missing [build-system] table should be allowed.
Poetry handles this fine, except for this check.

> Tools should not require the existence of the [build-system] table.
https://packaging.python.org/en/latest/specifications/pyproject-toml/

---

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.