### PR TITLE
Rename `Builder` to `BaseBuilder`

### DIFF
--- a/src/poetry/core/masonry/builders/builder.py
+++ b/src/poetry/core/masonry/builders/builder.py
@@ -30,7 +30,7 @@ Summary: {summary}
 logger = logging.getLogger(__name__)
 
 
-class Builder:
+class BaseBuilder:
     format: str | None = None
 
     def __init__(

--- a/src/poetry/core/masonry/builders/sdist.py
+++ b/src/poetry/core/masonry/builders/sdist.py
@@ -15,7 +15,7 @@ from posixpath import join as pjoin
 from pprint import pformat
 from typing import TYPE_CHECKING
 
-from poetry.core.masonry.builders.builder import Builder
+from poetry.core.masonry.builders.builder import BaseBuilder
 from poetry.core.masonry.builders.builder import BuildIncludeFile
 from poetry.core.masonry.utils.helpers import distribution_name
 
@@ -54,7 +54,7 @@ setup(**setup_kwargs)
 logger = logging.getLogger(__name__)
 
 
-class SdistBuilder(Builder):
+class SdistBuilder(BaseBuilder):
     format = "sdist"
 
     def build(

--- a/src/poetry/core/masonry/builders/wheel.py
+++ b/src/poetry/core/masonry/builders/wheel.py
@@ -23,7 +23,7 @@ import packaging.tags
 
 from poetry.core import __version__
 from poetry.core.constraints.version import parse_constraint
-from poetry.core.masonry.builders.builder import Builder
+from poetry.core.masonry.builders.builder import BaseBuilder
 from poetry.core.masonry.builders.sdist import SdistBuilder
 from poetry.core.masonry.utils.helpers import distribution_name
 from poetry.core.masonry.utils.helpers import normalize_file_permissions
@@ -48,7 +48,7 @@ Tag: {tag}
 logger = logging.getLogger(__name__)
 
 
-class WheelBuilder(Builder):
+class WheelBuilder(BaseBuilder):
     format = "wheel"
 
     def __init__(

--- a/tests/masonry/builders/test_builder.py
+++ b/tests/masonry/builders/test_builder.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from poetry.core.factory import Factory
-from poetry.core.masonry.builders.builder import Builder
+from poetry.core.masonry.builders.builder import BaseBuilder
 
 
 if TYPE_CHECKING:
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 def test_building_not_possible_in_non_package_mode() -> None:
     with pytest.raises(RuntimeError) as err:
-        Builder(
+        BaseBuilder(
             Factory().create_poetry(
                 Path(__file__).parent.parent.parent / "fixtures" / "non_package_mode"
             )
@@ -31,7 +31,7 @@ def test_builder_find_excluded_files(mocker: MockerFixture) -> None:
     p = mocker.patch("poetry.core.vcs.git.Git.get_ignored_files")
     p.return_value = []
 
-    builder = Builder(
+    builder = BaseBuilder(
         Factory().create_poetry(Path(__file__).parent / "fixtures" / "complete")
     )
 
@@ -46,7 +46,7 @@ def test_builder_find_case_sensitive_excluded_files(mocker: MockerFixture) -> No
     p = mocker.patch("poetry.core.vcs.git.Git.get_ignored_files")
     p.return_value = []
 
-    builder = Builder(
+    builder = BaseBuilder(
         Factory().create_poetry(
             Path(__file__).parent / "fixtures" / "case_sensitive_exclusions"
         )
@@ -73,7 +73,7 @@ def test_builder_find_invalid_case_sensitive_excluded_files(
     p = mocker.patch("poetry.core.vcs.git.Git.get_ignored_files")
     p.return_value = []
 
-    builder = Builder(
+    builder = BaseBuilder(
         Factory().create_poetry(
             Path(__file__).parent / "fixtures" / "invalid_case_sensitive_exclusions"
         )
@@ -83,7 +83,7 @@ def test_builder_find_invalid_case_sensitive_excluded_files(
 
 
 def test_get_metadata_content() -> None:
-    builder = Builder(
+    builder = BaseBuilder(
         Factory().create_poetry(Path(__file__).parent / "fixtures" / "complete")
     )
 
@@ -140,7 +140,7 @@ def test_get_metadata_content() -> None:
 
 
 def test_metadata_pretty_name() -> None:
-    builder = Builder(
+    builder = BaseBuilder(
         Factory().create_poetry(Path(__file__).parent / "fixtures" / "Pretty.Name")
     )
 
@@ -150,7 +150,7 @@ def test_metadata_pretty_name() -> None:
 
 
 def test_metadata_homepage_default() -> None:
-    builder = Builder(
+    builder = BaseBuilder(
         Factory().create_poetry(Path(__file__).parent / "fixtures" / "simple_version")
     )
 
@@ -160,7 +160,7 @@ def test_metadata_homepage_default() -> None:
 
 
 def test_metadata_with_vcs_dependencies() -> None:
-    builder = Builder(
+    builder = BaseBuilder(
         Factory().create_poetry(
             Path(__file__).parent / "fixtures" / "with_vcs_dependency"
         )
@@ -174,7 +174,7 @@ def test_metadata_with_vcs_dependencies() -> None:
 
 
 def test_metadata_with_url_dependencies() -> None:
-    builder = Builder(
+    builder = BaseBuilder(
         Factory().create_poetry(
             Path(__file__).parent / "fixtures" / "with_url_dependency"
         )
@@ -192,7 +192,7 @@ def test_metadata_with_url_dependencies() -> None:
 
 
 def test_missing_script_files_throws_error() -> None:
-    builder = Builder(
+    builder = BaseBuilder(
         Factory().create_poetry(
             Path(__file__).parent / "fixtures" / "script_reference_file_missing"
         )
@@ -206,7 +206,7 @@ def test_missing_script_files_throws_error() -> None:
 
 def test_invalid_script_files_definition() -> None:
     with pytest.raises(RuntimeError) as err:
-        Builder(
+        BaseBuilder(
             Factory().create_poetry(
                 Path(__file__).parent
                 / "fixtures"
@@ -226,7 +226,7 @@ def test_invalid_script_files_definition() -> None:
 )
 def test_entrypoint_scripts_legacy_warns(fixture: str) -> None:
     with pytest.warns(DeprecationWarning):
-        Builder(
+        BaseBuilder(
             Factory().create_poetry(Path(__file__).parent / "fixtures" / fixture)
         ).convert_entry_points()
 
@@ -266,7 +266,7 @@ def test_entrypoint_scripts_legacy_warns(fixture: str) -> None:
 def test_builder_convert_entry_points(
     fixture: str, result: dict[str, list[str]]
 ) -> None:
-    entry_points = Builder(
+    entry_points = BaseBuilder(
         Factory().create_poetry(Path(__file__).parent / "fixtures" / fixture)
     ).convert_entry_points()
     assert entry_points == result
@@ -295,13 +295,15 @@ def test_builder_convert_entry_points(
 )
 def test_builder_convert_script_files(fixture: str, result: list[Path]) -> None:
     project_root = Path(__file__).parent / "fixtures" / fixture
-    script_files = Builder(Factory().create_poetry(project_root)).convert_script_files()
+    script_files = BaseBuilder(
+        Factory().create_poetry(project_root)
+    ).convert_script_files()
     assert [p.relative_to(project_root) for p in script_files] == result
 
 
 def test_metadata_with_readme_files() -> None:
     test_path = Path(__file__).parent.parent.parent / "fixtures" / "with_readme_files"
-    builder = Builder(Factory().create_poetry(test_path))
+    builder = BaseBuilder(Factory().create_poetry(test_path))
 
     metadata = Parser().parsestr(builder.get_metadata_content())
 
@@ -316,7 +318,7 @@ def test_metadata_with_wildcard_dependency_constraint() -> None:
     test_path = (
         Path(__file__).parent / "fixtures" / "with_wildcard_dependency_constraint"
     )
-    builder = Builder(Factory().create_poetry(test_path))
+    builder = BaseBuilder(Factory().create_poetry(test_path))
 
     metadata = Parser().parsestr(builder.get_metadata_content())
 

--- a/tests/masonry/builders/test_sdist.py
+++ b/tests/masonry/builders/test_sdist.py
@@ -150,7 +150,7 @@ def test_make_setup() -> None:
 
 def test_make_pkg_info(mocker: MockerFixture) -> None:
     get_metadata_content = mocker.patch(
-        "poetry.core.masonry.builders.builder.Builder.get_metadata_content"
+        "poetry.core.masonry.builders.builder.BaseBuilder.get_metadata_content"
     )
     poetry = Factory().create_poetry(project("complete"))
 


### PR DESCRIPTION
A small change of class name. While working on #679 It was confusing to have `poetry.core.masonry.builders.builder` and `poetry.core.masonry.builder` have the same name for 2 different classes. 
