### PR TITLE
deprecate `poetry.core.masonry.builder` (not a core functionality, only used in `poetry build`)

### DIFF
--- a/src/poetry/core/masonry/builder.py
+++ b/src/poetry/core/masonry/builder.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import warnings
+
 from typing import TYPE_CHECKING
 
 
@@ -7,6 +9,14 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from poetry.core.poetry import Poetry
+
+
+warnings.warn(
+    "poetry.core.masonry.builder is deprecated. Its functionality has been moved"
+    "from poetry-core to poetry (poetry.console.commands.build).",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 class Builder:

--- a/tests/masonry/test_builder.py
+++ b/tests/masonry/test_builder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import shutil
+import warnings
 
 from contextlib import contextmanager
 from pathlib import Path
@@ -10,7 +11,11 @@ from typing import Iterator
 import pytest
 
 from poetry.core.factory import Factory
-from poetry.core.masonry.builder import Builder
+
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    from poetry.core.masonry.builder import Builder
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
according to https://github.com/python-poetry/poetry-core/pull/680#issuecomment-1879031775

Companion: python-poetry/poetry#8877

Closes: #680
Closes: #679