### PR TITLE
convert_script_files does not require script to exist

### DIFF
--- a/src/poetry/core/masonry/builders/builder.py
+++ b/src/poetry/core/masonry/builders/builder.py
@@ -364,16 +364,6 @@ class Builder:
 
                 abs_path = Path.joinpath(self._path, source)
 
-                if not abs_path.exists():
-                    raise RuntimeError(
-                        f"{abs_path} in script specification ({name}) is not found."
-                    )
-
-                if not abs_path.is_file():
-                    raise RuntimeError(
-                        f"{abs_path} in script specification ({name}) is not a file."
-                    )
-
                 script_files.append(abs_path)
 
         return script_files

--- a/tests/masonry/builders/test_builder.py
+++ b/tests/masonry/builders/test_builder.py
@@ -190,19 +190,6 @@ def test_metadata_with_url_dependencies() -> None:
     )
 
 
-def test_missing_script_files_throws_error() -> None:
-    builder = Builder(
-        Factory().create_poetry(
-            Path(__file__).parent / "fixtures" / "script_reference_file_missing"
-        )
-    )
-
-    with pytest.raises(RuntimeError) as err:
-        builder.convert_script_files()
-
-    assert "is not found." in str(err.value)
-
-
 def test_invalid_script_files_definition() -> None:
     with pytest.raises(RuntimeError) as err:
         Builder(


### PR DESCRIPTION
Scripts can be generated during build.  But poetry-core insists that scripts exist ahead of time.

fixes <https://github.com/python-poetry/poetry/issues/8856>

obviously this is giving up some validation: it is now possible to build a wheel that points at a non-existent script.  But
- I do not see an easy way of getting that back
- probably it is pretty obvious when that happens
- it already is possible to point at non-existent code in an entrypoint-style script, so in some sense this just puts things on an equal footing...