### PR TITLE
metadata version 2.3

### DIFF
--- a/src/poetry/core/masonry/builders/builder.py
+++ b/src/poetry/core/masonry/builders/builder.py
@@ -21,7 +21,7 @@ AUTHOR_REGEX = re.compile(
 )
 
 METADATA_BASE = """\
-Metadata-Version: 2.1
+Metadata-Version: 2.3
 Name: {name}
 Version: {version}
 Summary: {summary}

--- a/src/poetry/core/masonry/metadata.py
+++ b/src/poetry/core/masonry/metadata.py
@@ -6,11 +6,13 @@ from poetry.core.utils.helpers import readme_content_type
 
 
 if TYPE_CHECKING:
+    from packaging.utils import NormalizedName
+
     from poetry.core.packages.package import Package
 
 
 class Metadata:
-    metadata_version = "2.1"
+    metadata_version = "2.3"
     # version 1.0
     name: str | None = None
     version: str
@@ -41,7 +43,7 @@ class Metadata:
 
     # Version 2.1
     description_content_type: str | None = None
-    provides_extra: list[str] = []  # noqa: RUF012
+    provides_extra: list[NormalizedName] = []  # noqa: RUF012
 
     @classmethod
     def from_package(cls, package: Package) -> Metadata:

--- a/tests/masonry/builders/test_builder.py
+++ b/tests/masonry/builders/test_builder.py
@@ -92,7 +92,7 @@ def test_get_metadata_content() -> None:
     p = Parser()
     parsed = p.parsestr(metadata)
 
-    assert parsed["Metadata-Version"] == "2.1"
+    assert parsed["Metadata-Version"] == "2.3"
     assert parsed["Name"] == "my-package"
     assert parsed["Version"] == "1.2.3"
     assert parsed["Summary"] == "Some description."

--- a/tests/masonry/builders/test_complete.py
+++ b/tests/masonry/builders/test_complete.py
@@ -181,7 +181,7 @@ Tag: py3-none-any
         assert (
             wheel_data
             == """\
-Metadata-Version: 2.1
+Metadata-Version: 2.3
 Name: my-package
 Version: 1.2.3
 Summary: Some description.

--- a/tests/masonry/test_api.py
+++ b/tests/masonry/test_api.py
@@ -151,7 +151,7 @@ Root-Is-Purelib: true
 Tag: py3-none-any
 """
     metadata = """\
-Metadata-Version: 2.1
+Metadata-Version: 2.3
 Name: my-package
 Version: 1.2.3
 Summary: Some description.


### PR DESCRIPTION
mirror of https://github.com/python-poetry/poetry/pull/9078

- PEP643 was version 2.2, it introduced "Dynamic".  By declaring metadata 2.2, poetry is promising that its metadata is static
- PEP685 was version 2.3, it describes normalization of extras - which poetry has done for some time
