### PR TITLE
Add build config settings to core

### DIFF
--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -280,7 +280,7 @@ class Factory:
                     groups=groups,
                     optional=optional,
                     develop=constraint.get("develop", False),
-                    config_settings=constraint.get("config_settings", {}),
+                    config_settings=constraint.get("config-settings", {}),
                     extras=constraint.get("extras", []),
                 )
             elif "file" in constraint:
@@ -323,7 +323,7 @@ class Factory:
                         optional=optional,
                         base=root_dir,
                         develop=constraint.get("develop", False),
-                        config_settings=constraint.get("config_settings", {}),
+                        config_settings=constraint.get("config-settings", {}),
                         extras=constraint.get("extras", []),
                     )
             elif "url" in constraint:

--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -280,6 +280,7 @@ class Factory:
                     groups=groups,
                     optional=optional,
                     develop=constraint.get("develop", False),
+                    config_settings=constraint.get("config_settings", {}),
                     extras=constraint.get("extras", []),
                 )
             elif "file" in constraint:
@@ -322,6 +323,7 @@ class Factory:
                         optional=optional,
                         base=root_dir,
                         develop=constraint.get("develop", False),
+                        config_settings=constraint.get("config_settings", {}),
                         extras=constraint.get("extras", []),
                     )
             elif "url" in constraint:

--- a/src/poetry/core/json/schemas/poetry-schema.json
+++ b/src/poetry/core/json/schemas/poetry-schema.json
@@ -439,6 +439,10 @@
         "develop": {
           "type": "boolean",
           "description": "Whether to install the dependency in development mode."
+        },
+        "config-settings": {
+          "type": "object",
+          "description": "Config-settings passed to the builder when installing."
         }
       }
     },

--- a/src/poetry/core/packages/directory_dependency.py
+++ b/src/poetry/core/packages/directory_dependency.py
@@ -50,7 +50,7 @@ class DirectoryDependency(PathDependency):
 
     @property
     def config_settings(self) -> Mapping[str, str | Sequence[str]] | None:
-        return self._develop
+        return self._config_settings
 
     def _validate(self) -> str:
         message = super()._validate()

--- a/src/poetry/core/packages/directory_dependency.py
+++ b/src/poetry/core/packages/directory_dependency.py
@@ -49,7 +49,7 @@ class DirectoryDependency(PathDependency):
         return self._develop
 
     @property
-    def config_settings(self) -> Mapping[str, str | Sequence[str]] | None = None:
+    def config_settings(self) -> Mapping[str, str | Sequence[str]] | None:
         return self._develop
 
     def _validate(self) -> str:

--- a/src/poetry/core/packages/directory_dependency.py
+++ b/src/poetry/core/packages/directory_dependency.py
@@ -12,7 +12,8 @@ from poetry.core.pyproject.toml import PyProjectTOML
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from pathlib import Path
-    from typing import Mapping, Sequence
+    from typing import Mapping
+    from typing import Sequence
 
 
 class DirectoryDependency(PathDependency):

--- a/src/poetry/core/packages/directory_dependency.py
+++ b/src/poetry/core/packages/directory_dependency.py
@@ -12,6 +12,7 @@ from poetry.core.pyproject.toml import PyProjectTOML
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from pathlib import Path
+    from typing import Mapping, Sequence
 
 
 class DirectoryDependency(PathDependency):
@@ -23,6 +24,7 @@ class DirectoryDependency(PathDependency):
         optional: bool = False,
         base: Path | None = None,
         develop: bool = False,
+        config_settings: Mapping[str, str | Sequence[str]] | None = None,
         extras: Iterable[str] | None = None,
     ) -> None:
         super().__init__(
@@ -37,12 +39,17 @@ class DirectoryDependency(PathDependency):
         # Attributes must be immutable for clone() to be safe!
         # (For performance reasons, clone only creates a copy instead of a deep copy).
         self._develop = develop
+        self._config_settings = config_settings
 
         # cache this function to avoid multiple IO reads and parsing
         self.supports_poetry = functools.lru_cache(maxsize=1)(self._supports_poetry)
 
     @property
     def develop(self) -> bool:
+        return self._develop
+
+    @property
+    def config_settings(self) -> Mapping[str, str | Sequence[str]] | None = None:
         return self._develop
 
     def _validate(self) -> str:

--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -23,8 +23,10 @@ if TYPE_CHECKING:
     from collections.abc import Collection
     from collections.abc import Iterable
     from collections.abc import Iterator
-    from typing import Mapping, Union, Sequence
     from pathlib import Path
+    from typing import Mapping
+    from typing import Sequence
+    from typing import Union
 
     from packaging.utils import NormalizedName
 

--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import Mapping
     from typing import Sequence
-    from typing import Union
 
     from packaging.utils import NormalizedName
 
@@ -72,7 +71,7 @@ class Package(PackageSpecification):
         source_subdirectory: str | None = None,
         features: Iterable[str] | None = None,
         develop: bool = False,
-        config_settings: Mapping[str, Union[str, Sequence[str]]] | None = None,
+        config_settings: Mapping[str, str | Sequence[str]] | None = None,
         yanked: str | bool = False,
     ) -> None:
         """

--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from collections.abc import Collection
     from collections.abc import Iterable
     from collections.abc import Iterator
+    from typing import Mapping, Union, Sequence
     from pathlib import Path
 
     from packaging.utils import NormalizedName
@@ -69,6 +70,7 @@ class Package(PackageSpecification):
         source_subdirectory: str | None = None,
         features: Iterable[str] | None = None,
         develop: bool = False,
+        config_settings: Mapping[str, Union[str, Sequence[str]]] | None = None,
         yanked: str | bool = False,
     ) -> None:
         """
@@ -131,6 +133,8 @@ class Package(PackageSpecification):
         self.root_dir: Path | None = None
 
         self.develop = develop
+
+        self.config_settings = config_settings
 
         self._yanked = yanked
 

--- a/src/poetry/core/packages/vcs_dependency.py
+++ b/src/poetry/core/packages/vcs_dependency.py
@@ -27,6 +27,7 @@ class VCSDependency(Dependency):
         groups: Iterable[str] | None = None,
         optional: bool = False,
         develop: bool = False,
+        config_settings: Mapping[str, str | Sequence[str]] | None = None,
         extras: Iterable[str] | None = None,
     ) -> None:
         # Attributes must be immutable for clone() to be safe!
@@ -38,6 +39,7 @@ class VCSDependency(Dependency):
         self._rev = rev
         self._directory = directory
         self._develop = develop
+        self._config_settings = config_settings
 
         super().__init__(
             name,
@@ -81,6 +83,10 @@ class VCSDependency(Dependency):
 
     @property
     def develop(self) -> bool:
+        return self._develop
+
+    @property
+    def config_settings(self) -> Mapping[str, str | Sequence[str]] | None:
         return self._develop
 
     @property

--- a/src/poetry/core/packages/vcs_dependency.py
+++ b/src/poetry/core/packages/vcs_dependency.py
@@ -7,6 +7,7 @@ from poetry.core.packages.dependency import Dependency
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+    from typing import Mapping, Sequence
 
 
 class VCSDependency(Dependency):

--- a/src/poetry/core/packages/vcs_dependency.py
+++ b/src/poetry/core/packages/vcs_dependency.py
@@ -88,7 +88,7 @@ class VCSDependency(Dependency):
 
     @property
     def config_settings(self) -> Mapping[str, str | Sequence[str]] | None:
-        return self._develop
+        return self._config_settings
 
     @property
     def reference(self) -> str:

--- a/src/poetry/core/packages/vcs_dependency.py
+++ b/src/poetry/core/packages/vcs_dependency.py
@@ -7,7 +7,8 @@ from poetry.core.packages.dependency import Dependency
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-    from typing import Mapping, Sequence
+    from typing import Mapping
+    from typing import Sequence
 
 
 class VCSDependency(Dependency):


### PR DESCRIPTION
The build() function takes optional config-settings which can be useful for building gpu-specific packages, editable-mode settings for setuptools, or other build-tool specific configurations.   If used, should resolve a number of issues.   For example: https://github.com/python-poetry/poetry/issues/8909

(Sorry for the million commits, im editing this in a browser.)

See: https://build.pypa.io/en/stable/api.html.   Typing matches that.

If there's no objections, will finish adding tests, etc.