### PR TITLE
Migrate anonymous Mapping[str, Any] to TypedDicts where their content is fully defined.

### DIFF
--- a/src/poetry/core/packages/project_package.py
+++ b/src/poetry/core/packages/project_package.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, TypedDict
 from typing import Any
 from typing import Mapping
 from typing import Sequence
@@ -17,6 +17,18 @@ if TYPE_CHECKING:
 
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.utils import create_nested_marker
+
+SupportedPackageFormats = Literal["sdist", "wheel"]
+
+class PackageSpec(TypedDict):
+    include: str
+    to: str
+    format: list[SupportedPackageFormats]
+
+
+class IncludeSpec(TypedDict):
+    path: str
+    format: list[SupportedPackageFormats]
 
 
 class ProjectPackage(Package):
@@ -40,9 +52,9 @@ class ProjectPackage(Package):
         # (For performance reasons, clone only creates a copy instead of a deep copy).
 
         self.build_config: Mapping[str, Any] = {}
-        self.packages: Sequence[Mapping[str, Any]] = []
-        self.include: Sequence[Mapping[str, Any]] = []
-        self.exclude: Sequence[Mapping[str, Any]] = []
+        self.packages: Sequence[PackageSpec] = []
+        self.include: Sequence[IncludeSpec] = []
+        self.exclude: Sequence[IncludeSpec] = []
         self.custom_urls: Mapping[str, str] = {}
 
         if self._python_versions == "*":

--- a/src/poetry/core/packages/project_package.py
+++ b/src/poetry/core/packages/project_package.py
@@ -18,7 +18,12 @@ if TYPE_CHECKING:
 from poetry.core.packages.package import Package
 from poetry.core.packages.utils.utils import create_nested_marker
 
+
 SupportedPackageFormats = Literal["sdist", "wheel"]
+
+
+BuildConfigSpec = TypedDict("BuildConfigSpec", {"script": str, "generate-setup-file": bool})
+
 
 class PackageSpec(TypedDict):
     include: str
@@ -51,7 +56,7 @@ class ProjectPackage(Package):
         # Attributes must be immutable for clone() to be safe!
         # (For performance reasons, clone only creates a copy instead of a deep copy).
 
-        self.build_config: Mapping[str, Any] = {}
+        self.build_config: BuildConfigSpec = {}
         self.packages: Sequence[PackageSpec] = []
         self.include: Sequence[IncludeSpec] = []
         self.exclude: Sequence[IncludeSpec] = []


### PR DESCRIPTION
When developing a plugin for Poetry, I found that despite the "include", "exclude" and "package" mapping content being fully defined in the documentation, no type hints were available to help me. Therefore I propose this minor change. It has no impact on current functionality, however with this IDEs like PyCharm and VSCode are aware of the structure of these dicts.

- [ ] Added **tests** for changed code. **NOT APPLICABLE**
- [ ] Updated **documentation** for changed code. **NOT APPLICABLE** (I think)

**Other similar changes may be useful elsewhere in the code**. I'll continue to explore the codebase and see what I can do.