### PR TITLE
Fixing platform_release pep440

### DIFF
--- a/src/poetry/core/constraints/generic/constraint.py
+++ b/src/poetry/core/constraints/generic/constraint.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import operator
 
-from typing import Any
 from typing import Callable
 from typing import ClassVar
 
@@ -11,20 +10,44 @@ from poetry.core.constraints.generic.base_constraint import BaseConstraint
 from poetry.core.constraints.generic.empty_constraint import EmptyConstraint
 
 
-OperatorType = Callable[[object, object], Any]
+OperatorType = Callable[[object, object], bool]
+
+
+def contains(a: object, b: object, /) -> bool:
+    return operator.contains(a, b)  # type: ignore[arg-type]
+
+
+def not_contains(a: object, b: object, /) -> bool:
+    return not contains(a, b)
 
 
 class Constraint(BaseConstraint):
     OP_EQ = operator.eq
     OP_NE = operator.ne
+    OP_IN = contains
+    OP_NC = not_contains
 
     _trans_op_str: ClassVar[dict[str, OperatorType]] = {
         "=": OP_EQ,
         "==": OP_EQ,
         "!=": OP_NE,
+        "in": OP_IN,
+        "not in": OP_NC,
     }
 
-    _trans_op_int: ClassVar[dict[OperatorType, str]] = {OP_EQ: "==", OP_NE: "!="}
+    _trans_op_int: ClassVar[dict[OperatorType, str]] = {
+        OP_EQ: "==",
+        OP_NE: "!=",
+        OP_IN: "in",
+        OP_NC: "not in",
+    }
+
+    _trans_op_inv: ClassVar[dict[str, str]] = {
+        "!=": "==",
+        "==": "!=",
+        "not in": "in",
+        "in": "not in",
+    }
 
     def __init__(self, value: str, operator: str = "==") -> None:
         if operator == "=":
@@ -49,14 +72,8 @@ class Constraint(BaseConstraint):
                 f' ("other" must be a constraint with operator "=="): {other}'
             )
 
-        is_equal_op = self._operator == "=="
-        is_non_equal_op = self._operator == "!="
-
-        if is_equal_op:
-            return self._value == other.value
-
-        if is_non_equal_op:
-            return self._value != other.value
+        if op := self._trans_op_str.get(self._operator):
+            return op(other.value, self._value)
 
         return False
 
@@ -67,6 +84,15 @@ class Constraint(BaseConstraint):
         if isinstance(other, Constraint):
             if other.operator == "==":
                 return self.allows(other)
+
+            if other.operator == "in" and self._operator == "in":
+                return self.value in other.value
+
+            if other.operator == "not in":
+                if self._operator == "not in":
+                    return other.value in self.value
+                if self._operator == "!=":
+                    return self.value not in other.value
 
             return self == other
 
@@ -82,36 +108,36 @@ class Constraint(BaseConstraint):
         from poetry.core.constraints.generic import MultiConstraint
         from poetry.core.constraints.generic import UnionConstraint
 
-        is_equal_op = self._operator == "=="
-        is_non_equal_op = self._operator == "!="
-
-        if is_equal_op:
+        if self._operator == "==":
             return other.allows(self)
 
         if isinstance(other, Constraint):
-            is_other_equal_op = other.operator == "=="
-            is_other_non_equal_op = other.operator == "!="
-
-            if is_other_equal_op:
+            if other.operator == "==":
                 return self.allows(other)
 
-            if is_equal_op and is_other_non_equal_op:
+            if other.operator == "!=" and self._operator == "==":
                 return self._value != other.value
 
-            return is_non_equal_op and is_other_non_equal_op
+            if other.operator == "not in" and self._operator == "in":
+                return other.value not in self.value
+
+            if other.operator == "in" and self._operator == "not in":
+                return self.value not in other.value
+
+            return True
 
         elif isinstance(other, MultiConstraint):
-            return is_non_equal_op
+            return self._operator == "!="
 
         elif isinstance(other, UnionConstraint):
-            return is_non_equal_op and any(
+            return self._operator == "!=" and any(
                 self.allows_any(c) for c in other.constraints
             )
 
         return other.is_any()
 
     def invert(self) -> Constraint:
-        return Constraint(self._value, "!=" if self._operator == "==" else "==")
+        return Constraint(self._value, self._trans_op_inv[self.operator])
 
     def difference(self, other: BaseConstraint) -> Constraint | EmptyConstraint:
         if other.allows(self):
@@ -126,16 +152,16 @@ class Constraint(BaseConstraint):
             if other == self:
                 return self
 
-            if self.operator == "!=" and other.operator == "==" and self.allows(other):
+            if self.allows_all(other):
                 return other
 
-            if other.operator == "!=" and self.operator == "==" and other.allows(self):
+            if other.allows_all(self):
                 return self
 
-            if other.operator == "!=" and self.operator == "!=":
-                return MultiConstraint(self, other)
+            if not self.allows_any(other) or not other.allows_any(self):
+                return EmptyConstraint()
 
-            return EmptyConstraint()
+            return MultiConstraint(self, other)
 
         return other.intersect(self)
 
@@ -146,16 +172,25 @@ class Constraint(BaseConstraint):
             if other == self:
                 return self
 
-            if self.operator == "!=" and other.operator == "==" and self.allows(other):
+            if self.allows_all(other):
                 return self
 
-            if other.operator == "!=" and self.operator == "==" and other.allows(self):
+            if other.allows_all(self):
                 return other
 
-            if other.operator == "==" and self.operator == "==":
-                return UnionConstraint(self, other)
+            ops = {self.operator, other.operator}
+            if (
+                (ops in ({"!="}, {"not in"}))
+                or (
+                    ops in ({"in", "!="}, {"in", "not in"})
+                    and (self.operator == "in" and self.value in other.value)
+                    or (other.operator == "in" and other.value in self.value)
+                )
+                or self.invert() == other
+            ):
+                return AnyConstraint()
 
-            return AnyConstraint()
+            return UnionConstraint(self, other)
 
         # to preserve order (functionally not necessary)
         if isinstance(other, UnionConstraint):
@@ -179,5 +214,7 @@ class Constraint(BaseConstraint):
         return hash((self._operator, self._value))
 
     def __str__(self) -> str:
+        if self._operator in {"in", "not in"}:
+            return f"'{self._value}' {self._operator}"
         op = self._operator if self._operator != "==" else ""
         return f"{op}{self._value}"

--- a/src/poetry/core/constraints/generic/parser.py
+++ b/src/poetry/core/constraints/generic/parser.py
@@ -16,6 +16,15 @@ if TYPE_CHECKING:
 
 
 BASIC_CONSTRAINT = re.compile(r"^(!?==?)?\s*([^\s]+?)\s*$")
+STR_CMP_CONSTRAINT = re.compile(
+    r"""(?ix)^ # case insensitive and verbose mode
+    (?P<quote>['"]) # Single or double quotes
+    (?P<value>.+?) # The value itself inside quotes
+    \1 # Closing single of double quote
+    \s* # Space
+    (?P<op>(not\sin|in)) # Literal match of 'in' or 'not in'
+    $"""
+)
 
 
 @functools.lru_cache(maxsize=None)
@@ -26,9 +35,7 @@ def parse_constraint(constraints: str) -> BaseConstraint:
     or_constraints = re.split(r"\s*\|\|?\s*", constraints.strip())
     or_groups = []
     for constraints in or_constraints:
-        and_constraints = re.split(
-            r"(?<!^)(?<![=>< ,]) *(?<!-)[, ](?!-) *(?!,|$)", constraints
-        )
+        and_constraints = re.split(r"\s*,\s*", constraints)
         constraint_objects = []
 
         if len(and_constraints) > 1:
@@ -53,9 +60,15 @@ def parse_constraint(constraints: str) -> BaseConstraint:
 
 
 def parse_single_constraint(constraint: str) -> Constraint:
+    # string comparator
+    if m := STR_CMP_CONSTRAINT.match(constraint):
+        op = m.group("op")
+        value = m.group("value").strip()
+        return Constraint(value, op)
+
     # Basic comparator
-    m = BASIC_CONSTRAINT.match(constraint)
-    if m:
+
+    if m := BASIC_CONSTRAINT.match(constraint):
         op = m.group(1)
         if op is None:
             op = "=="

--- a/src/poetry/core/constraints/version/parser.py
+++ b/src/poetry/core/constraints/version/parser.py
@@ -19,12 +19,16 @@ def parse_constraint(constraints: str) -> VersionConstraint:
     return _parse_constraint(constraints=constraints)
 
 
-def parse_marker_version_constraint(constraints: str) -> VersionConstraint:
-    return _parse_constraint(constraints=constraints, is_marker_constraint=True)
+def parse_marker_version_constraint(
+    constraints: str, *, pep440: bool = True
+) -> VersionConstraint:
+    return _parse_constraint(
+        constraints=constraints, is_marker_constraint=True, pep440=pep440
+    )
 
 
 def _parse_constraint(
-    constraints: str, *, is_marker_constraint: bool = False
+    constraints: str, *, is_marker_constraint: bool = False, pep440: bool = True
 ) -> VersionConstraint:
     if constraints == "*":
         from poetry.core.constraints.version.version_range import VersionRange
@@ -46,13 +50,17 @@ def _parse_constraint(
             for constraint in and_constraints:
                 constraint_objects.append(
                     parse_single_constraint(
-                        constraint, is_marker_constraint=is_marker_constraint
+                        constraint,
+                        is_marker_constraint=is_marker_constraint,
+                        pep440=pep440,
                     )
                 )
         else:
             constraint_objects.append(
                 parse_single_constraint(
-                    and_constraints[0], is_marker_constraint=is_marker_constraint
+                    and_constraints[0],
+                    is_marker_constraint=is_marker_constraint,
+                    pep440=pep440,
                 )
             )
 
@@ -74,9 +82,10 @@ def _parse_constraint(
 
 
 def parse_single_constraint(
-    constraint: str, *, is_marker_constraint: bool = False
+    constraint: str, *, is_marker_constraint: bool = False, pep440: bool = True
 ) -> VersionConstraint:
     from poetry.core.constraints.version.patterns import BASIC_CONSTRAINT
+    from poetry.core.constraints.version.patterns import BASIC_RELEASE_CONSTRAINT
     from poetry.core.constraints.version.patterns import CARET_CONSTRAINT
     from poetry.core.constraints.version.patterns import TILDE_CONSTRAINT
     from poetry.core.constraints.version.patterns import TILDE_PEP440_CONSTRAINT
@@ -183,6 +192,35 @@ def parse_single_constraint(
         if op == "!=":
             return VersionUnion(VersionRange(max=version), VersionRange(min=version))
 
+        return version
+
+    # These below should be reserved for comparing non python packages such as OS
+    # versions using `platform_release`
+    if not pep440 and (m := BASIC_RELEASE_CONSTRAINT.match(constraint)):
+        op = m.group("op")
+        release_string = m.group("release")
+        build = m.group("build")
+
+        try:
+            version = Version(
+                release=Version.parse(release_string).release,
+                local=build,
+            )
+        except InvalidVersion as e:
+            raise ParseConstraintError(
+                f"Could not parse version constraint: {constraint}"
+            ) from e
+
+        if op == "<":
+            return VersionRange(max=version)
+        if op == "<=":
+            return VersionRange(max=version, include_max=True)
+        if op == ">":
+            return VersionRange(min=version)
+        if op == ">=":
+            return VersionRange(min=version, include_min=True)
+        if op == "!=":
+            return VersionUnion(VersionRange(max=version), VersionRange(min=version))
         return version
 
     raise ParseConstraintError(f"Could not parse version constraint: {constraint}")

--- a/src/poetry/core/constraints/version/patterns.py
+++ b/src/poetry/core/constraints/version/patterns.py
@@ -26,3 +26,17 @@ BASIC_CONSTRAINT = re.compile(
     rf"^(?P<op><>|!=|>=?|<=?|==?)?\s*(?P<version>{VERSION_PATTERN}|dev)(?P<wildcard>\.\*)?$",
     re.VERBOSE | re.IGNORECASE,
 )
+
+RELEASE_PATTERN = r"""
+(?P<release>[0-9]+(?:\.[0-9]+)*)
+(?:(\+|-)(?P<build>
+    [0-9a-zA-Z-]+
+    (?:\.[0-9a-zA-Z-]+)*
+))?
+"""
+
+# pattern for non Python versions such as OS versions in `platform_release`
+BASIC_RELEASE_CONSTRAINT = re.compile(
+    rf"^(?P<op><>|!=|>=?|<=?|==?)?\s*(?P<version>{RELEASE_PATTERN})$",
+    re.VERBOSE | re.IGNORECASE,
+)

--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -233,15 +233,15 @@ class SingleMarkerLike(BaseMarker, ABC, Generic[SingleMarkerConstraint]):
         from poetry.core.constraints.generic import (
             parse_constraint as parse_generic_constraint,
         )
-        from poetry.core.constraints.version import (
-            parse_constraint as parse_version_constraint,
-        )
+        from poetry.core.constraints.version import parse_marker_version_constraint
 
         self._name = ALIASES.get(name, name)
         self._constraint = constraint
         self._parser: Callable[[str], BaseConstraint | VersionConstraint]
         if isinstance(constraint, VersionConstraint):
-            self._parser = parse_version_constraint
+            self._parser = functools.partial(
+                parse_marker_version_constraint, pep440=name != "platform_release"
+            )
         else:
             self._parser = parse_generic_constraint
 
@@ -386,7 +386,9 @@ class SingleMarker(SingleMarkerLike[Union[BaseConstraint, VersionConstraint]]):
             # or `"arm" not in platform_version`.
             pass
         elif name in self._VERSION_LIKE_MARKER_NAME:
-            parser = parse_marker_version_constraint
+            parser = functools.partial(
+                parse_marker_version_constraint, pep440=name != "platform_release"
+            )
 
             if self._operator in {"in", "not in"}:
                 versions = []

--- a/tests/constraints/generic/test_main.py
+++ b/tests/constraints/generic/test_main.py
@@ -18,6 +18,8 @@ from poetry.core.constraints.generic import parse_constraint
         ("==win32", Constraint("win32", "=")),
         ("!=win32", Constraint("win32", "!=")),
         ("!= win32", Constraint("win32", "!=")),
+        ("'tegra' not in", Constraint("tegra", "not in")),
+        ("'tegra' in", Constraint("tegra", "in")),
     ],
 )
 def test_parse_constraint(input: str, constraint: AnyConstraint | Constraint) -> None:
@@ -39,6 +41,13 @@ def test_parse_constraint(input: str, constraint: AnyConstraint | Constraint) ->
                 Constraint("linux2", "!="),
             ),
         ),
+        (
+            "'tegra' not in,'rpi-v8' not in",
+            MultiConstraint(
+                Constraint("tegra", "not in"),
+                Constraint("rpi-v8", "not in"),
+            ),
+        ),
     ],
 )
 def test_parse_constraint_multi(input: str, constraint: MultiConstraint) -> None:
@@ -52,6 +61,10 @@ def test_parse_constraint_multi(input: str, constraint: MultiConstraint) -> None
         (
             "win32 || !=linux2",
             UnionConstraint(Constraint("win32"), Constraint("linux2", "!=")),
+        ),
+        (
+            "'tegra' in || 'rpi-v8' in",
+            UnionConstraint(Constraint("tegra", "in"), Constraint("rpi-v8", "in")),
         ),
     ],
 )

--- a/tests/constraints/version/test_parse_constraint.py
+++ b/tests/constraints/version/test_parse_constraint.py
@@ -7,6 +7,8 @@ from poetry.core.constraints.version import VersionConstraint
 from poetry.core.constraints.version import VersionRange
 from poetry.core.constraints.version import VersionUnion
 from poetry.core.constraints.version import parse_constraint
+from poetry.core.constraints.version import parse_marker_version_constraint
+from poetry.core.constraints.version.exceptions import ParseConstraintError
 from poetry.core.version.pep440 import ReleaseTag
 
 
@@ -595,3 +597,14 @@ def test_parse_constraint_with_white_space_padding(
     padding = " " * (4 if with_whitespace_padding else 0)
     constraint = padding.join(["", *constraint_parts, ""])
     assert parse_constraint(constraint) == expected
+
+
+def test_parse_marker_constraint_does_not_allow_invalid_version() -> None:
+    with pytest.raises(ParseConstraintError):
+        parse_marker_version_constraint("4.9.253-tegra")
+
+
+def test_parse_marker_constraint_does_allow_invalid_version_if_requested() -> None:
+    assert parse_marker_version_constraint(
+        "4.9.253-tegra", pep440=False
+    ) == Version.from_parts(4, 9, 253, local="tegra")

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -62,6 +62,11 @@ EMPTY = "<empty>"
         'extra == "a" or extra != "b"',
         'extra != "a" or extra == "b"',
         'extra != "a" or extra != "b"',
+        # String comparison markers
+        '"tegra" in platform_release',
+        '"tegra" not in platform_release',
+        '"tegra" in platform_release or "rpi-v8" in platform_release',
+        '"tegra" not in platform_release and "rpi-v8" not in platform_release',
     ],
 )
 def test_parse_marker(marker: str) -> None:
@@ -110,6 +115,10 @@ def test_parse_marker(marker: str) -> None:
             "platform_machine",
             "!=aarch64, !=loongarch64",
         ),
+        ('"tegra" not in platform_release', "platform_release", "'tegra' not in"),
+        ('"rpi-v8" in platform_release', "platform_release", "'rpi-v8' in"),
+        ('"arm" not in platform_version', "platform_version", "'arm' not in"),
+        ('"arm" in platform_version', "platform_version", "'arm' in"),
     ],
 )
 def test_parse_single_marker(
@@ -1300,6 +1309,8 @@ def test_union_of_multi_with_a_containing_single() -> None:
             'python_full_version ~= "3.6.3"',
             'python_full_version < "3.6.3" or python_full_version >= "3.7.0"',
         ),
+        ('"tegra" in platform_release', '"tegra" not in platform_release'),
+        ('"tegra" not in platform_release', '"tegra" in platform_release'),
     ],
 )
 def test_invert(marker: str, inverse: str) -> None:

--- a/tests/version/test_requirements.py
+++ b/tests/version/test_requirements.py
@@ -109,6 +109,18 @@ def assert_requirement(
                 ),
             },
         ),
+        (
+            (
+                'foo (>=1.2.3) ; "tegra" not in platform_release and python_version >= "3.10"'
+            ),
+            {
+                "name": "foo",
+                "constraint": ">=1.2.3",
+                "marker": (
+                    '"tegra" not in platform_release and python_version >= "3.10"'
+                ),
+            },
+        ),
     ],
 )
 def test_requirement(string: str, expected: dict[str, Any]) -> None:


### PR DESCRIPTION
Resolves: python-poetry/poetry#7418
Resolves: python-poetry/poetry#9434

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

Can add more tests if requested. Any feedback welcome as well, attempted to fix with smallest changes and no side effects.

Examples of conditions this should fix

- `'tegra' in platform_release`
- `'platform_release <= 5.10.123-tegra`
- `'arm' in platform_version`


When parsing versions, I added an additional semver-ish regex that will catch patterns that match certain `platform_release` versions that aren't quite pep440 or semver. Examples are either WSL2 builds, raspi builds or nvidia edge device builds

- `5.15.146.1-microsoft-standard-WSL2`
- `6.6.20+rpt-rpi-v8`
- `5.10.120-tegra`