### PR TITLE
Get Build Platlib Dir From Build Env

### DIFF
--- a/src/poetry/core/masonry/builders/wheel.py
+++ b/src/poetry/core/masonry/builders/wheel.py
@@ -235,7 +235,7 @@ print(sysconfig.get_platform(), sys.implementation.cache_tag, sep='-')
                 plat_specifier = output.strip()
             except subprocess.CalledProcessError as e:
                 raise RuntimeError(
-                    "Failed to get platform-cache_tag for python interpreter"
+                    "Failed to get build_platlib_dir for python interpreter"
                     f" '{self.executable.as_posix()}':\n{e.output}"
                 )
         else:

--- a/src/poetry/core/masonry/builders/wheel.py
+++ b/src/poetry/core/masonry/builders/wheel.py
@@ -232,12 +232,12 @@ print(sysconfig.get_platform(), sys.implementation.cache_tag, sep='-')
                     text=True,
                     encoding="utf-8",
                 )
-                plat_specifier = output.strip()
             except subprocess.CalledProcessError as e:
                 raise RuntimeError(
                     "Failed to get build_platlib_dir for python interpreter"
                     f" '{self.executable.as_posix()}':\n{e.output}"
                 )
+            plat_specifier = output.strip()
         else:
             plat_specifier = "-".join(
                 (sysconfig.get_platform(), sys.implementation.cache_tag)

--- a/src/poetry/core/masonry/builders/wheel.py
+++ b/src/poetry/core/masonry/builders/wheel.py
@@ -209,13 +209,40 @@ class WheelBuilder(Builder):
                         self._add_file(wheel, pkg, rel_path)
 
     def _get_build_purelib_dir(self) -> Path:
-        return self._path / "build/lib"
+        return self._path / "build" / "lib"
 
     def _get_build_platlib_dir(self) -> Path:
         # Roughly equivalent to the naming convention in used by distutils, see:
         # distutils.command.build.build.finalize_options
-        plat_specifier = f"{sysconfig.get_platform()}-{sys.implementation.cache_tag}"
-        return self._path / f"build/lib.{plat_specifier}"
+        if self._package.build_script and self.executable != Path(sys.executable):
+            # poetry-core is not run in the build environment
+            # -> this is probably not a PEP 517 build but a poetry build
+            try:
+                output = subprocess.check_output(
+                    [
+                        self.executable.as_posix(),
+                        "-c",
+                        """
+import sysconfig
+import sys
+print(sysconfig.get_platform(), sys.implementation.cache_tag, sep='-')
+""",
+                    ],
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    encoding="utf-8",
+                )
+                plat_specifier = output.strip()
+            except subprocess.CalledProcessError as e:
+                raise RuntimeError(
+                    "Failed to get platform-cache_tag for python interpreter"
+                    f" '{self.executable.as_posix()}':\n{e.output}"
+                )
+        else:
+            plat_specifier = "-".join(
+                (sysconfig.get_platform(), sys.implementation.cache_tag)
+            )
+        return self._path / "build" / ("lib." + plat_specifier)
 
     def _get_build_lib_dir(self) -> Path | None:
         # Either the purelib or platlib path will have been used when building

--- a/src/poetry/core/masonry/builders/wheel.py
+++ b/src/poetry/core/masonry/builders/wheel.py
@@ -214,7 +214,7 @@ class WheelBuilder(Builder):
     def _get_build_platlib_dir(self) -> Path:
         # Roughly equivalent to the naming convention in used by distutils, see:
         # distutils.command.build.build.finalize_options
-        if self._package.build_script and self.executable != Path(sys.executable):
+        if self.executable != Path(sys.executable):
             # poetry-core is not run in the build environment
             # -> this is probably not a PEP 517 build but a poetry build
             try:

--- a/src/poetry/core/masonry/builders/wheel.py
+++ b/src/poetry/core/masonry/builders/wheel.py
@@ -242,7 +242,7 @@ print(sysconfig.get_platform(), sys.implementation.cache_tag, sep='-')
             plat_specifier = "-".join(
                 (sysconfig.get_platform(), sys.implementation.cache_tag)
             )
-        return self._path / "build" / ("lib." + plat_specifier)
+        return self._path / "build" / f"lib.{plat_specifier}"
 
     def _get_build_lib_dir(self) -> Path | None:
         # Either the purelib or platlib path will have been used when building


### PR DESCRIPTION
When poetry-core is not run in the build environment, the build platlib directory, in particular the cache_tag string, is now derived from the build environment via a subprocess call, similar to _get_sys_tags(). Previously build platlib was always derived from the poetry-core environment, resulting in a build error if the Python version differed between the poetry-core and build environments.

Resolves: python-poetry/poetry#9344

No new tests added. Changes tested by existing build_with_build_py_only test.
No change to documentation required.
