### PR TITLE
constraints: fix `allows`, `allows_any` and `allows_all` for generic constraints and increase test coverage

### DIFF
--- a/src/poetry/core/constraints/generic/multi_constraint.py
+++ b/src/poetry/core/constraints/generic/multi_constraint.py
@@ -29,44 +29,27 @@ class MultiConstraint(BaseConstraint):
         return all(constraint.allows(other) for constraint in self._constraints)
 
     def allows_all(self, other: BaseConstraint) -> bool:
-        if other.is_any():
-            return False
+        if isinstance(other, MultiConstraint):
+            return all(c in other.constraints for c in self._constraints)
 
-        if other.is_empty():
-            return True
-
-        if not isinstance(other, MultiConstraint):
-            return self.allows(other)
-
-        our_constraints = iter(self._constraints)
-        their_constraints = iter(other.constraints)
-        our_constraint = next(our_constraints, None)
-        their_constraint = next(their_constraints, None)
-
-        while our_constraint and their_constraint:
-            if our_constraint.allows_all(their_constraint):
-                their_constraint = next(their_constraints, None)
-            else:
-                our_constraint = next(our_constraints, None)
-
-        return their_constraint is None
+        return all(c.allows_all(other) for c in self._constraints)
 
     def allows_any(self, other: BaseConstraint) -> bool:
-        if other.is_any():
-            return True
-
-        if other.is_empty():
-            return True
+        from poetry.core.constraints.generic import UnionConstraint
 
         if isinstance(other, Constraint):
-            return self.allows(other)
+            if other.operator == "==":
+                return self.allows(other)
 
-        if isinstance(other, MultiConstraint):
+            return other.operator == "!="
+
+        if isinstance(other, UnionConstraint):
             return any(
-                c1.allows(c2) for c1 in self.constraints for c2 in other.constraints
+                all(c1.allows_any(c2) for c1 in self.constraints)
+                for c2 in other.constraints
             )
 
-        return False
+        return isinstance(other, MultiConstraint) or other.is_any()
 
     def invert(self) -> UnionConstraint:
         from poetry.core.constraints.generic import UnionConstraint

--- a/tests/constraints/generic/test_multi_constraint.py
+++ b/tests/constraints/generic/test_multi_constraint.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
+import pytest
+
+from poetry.core.constraints.generic import AnyConstraint
+from poetry.core.constraints.generic import BaseConstraint
 from poetry.core.constraints.generic import Constraint
+from poetry.core.constraints.generic import EmptyConstraint
 from poetry.core.constraints.generic import MultiConstraint
+from poetry.core.constraints.generic import UnionConstraint
 
 
 def test_allows() -> None:
@@ -12,25 +18,83 @@ def test_allows() -> None:
     assert c.allows(Constraint("darwin"))
 
 
-def test_allows_any() -> None:
+@pytest.mark.parametrize(
+    ("constraint", "expected_any", "expected_all"),
+    [
+        (EmptyConstraint(), False, True),
+        (AnyConstraint(), True, False),
+        (Constraint("win32"), False, False),
+        (Constraint("linux"), False, False),
+        (Constraint("darwin"), True, True),
+        (Constraint("win32", "!="), True, False),
+        (Constraint("linux", "!="), True, False),
+        (Constraint("darwin", "!="), True, False),
+        (
+            UnionConstraint(Constraint("win32"), Constraint("linux")),
+            False,
+            False,
+        ),
+        (
+            UnionConstraint(
+                Constraint("win32"), Constraint("linux"), Constraint("darwin")
+            ),
+            True,
+            False,
+        ),
+        (
+            UnionConstraint(Constraint("darwin"), Constraint("linux")),
+            True,
+            False,
+        ),
+        (
+            UnionConstraint(Constraint("darwin"), Constraint("osx")),
+            True,
+            True,
+        ),
+        (
+            UnionConstraint(Constraint("win32", "!="), Constraint("linux", "!=")),
+            True,
+            False,
+        ),
+        (
+            UnionConstraint(Constraint("darwin", "!="), Constraint("linux", "!=")),
+            True,
+            False,
+        ),
+        (
+            UnionConstraint(Constraint("darwin", "!="), Constraint("osx", "!=")),
+            True,
+            False,
+        ),
+        (
+            MultiConstraint(Constraint("win32", "!="), Constraint("linux", "!=")),
+            True,
+            True,
+        ),
+        (
+            MultiConstraint(
+                Constraint("win32", "!="),
+                Constraint("linux", "!="),
+                Constraint("darwin", "!="),
+            ),
+            True,
+            True,
+        ),
+        (
+            MultiConstraint(Constraint("darwin", "!="), Constraint("linux", "!=")),
+            True,
+            False,
+        ),
+        (
+            MultiConstraint(Constraint("darwin", "!="), Constraint("osx", "!=")),
+            True,
+            False,
+        ),
+    ],
+)
+def test_allows_any_and_allows_all(
+    constraint: BaseConstraint, expected_any: bool, expected_all: bool
+) -> None:
     c = MultiConstraint(Constraint("win32", "!="), Constraint("linux", "!="))
-
-    assert c.allows_any(Constraint("darwin"))
-    assert c.allows_any(Constraint("darwin", "!="))
-    assert not c.allows_any(Constraint("win32"))
-    assert c.allows_any(c)
-    assert c.allows_any(
-        MultiConstraint(Constraint("win32", "!="), Constraint("darwin", "!="))
-    )
-
-
-def test_allows_all() -> None:
-    c = MultiConstraint(Constraint("win32", "!="), Constraint("linux", "!="))
-
-    assert c.allows_all(Constraint("darwin"))
-    assert c.allows_all(Constraint("darwin", "!="))
-    assert not c.allows_all(Constraint("win32"))
-    assert c.allows_all(c)
-    assert not c.allows_all(
-        MultiConstraint(Constraint("win32", "!="), Constraint("darwin", "!="))
-    )
+    assert c.allows_any(constraint) == expected_any
+    assert c.allows_all(constraint) == expected_all

--- a/tests/constraints/generic/test_union_constraint.py
+++ b/tests/constraints/generic/test_union_constraint.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+import pytest
+
+from poetry.core.constraints.generic import AnyConstraint
+from poetry.core.constraints.generic import BaseConstraint
 from poetry.core.constraints.generic import Constraint
+from poetry.core.constraints.generic import EmptyConstraint
+from poetry.core.constraints.generic import MultiConstraint
 from poetry.core.constraints.generic import UnionConstraint
 
 
@@ -12,21 +18,83 @@ def test_allows() -> None:
     assert not c.allows(Constraint("darwin"))
 
 
-def test_allows_any() -> None:
+@pytest.mark.parametrize(
+    ("constraint", "expected_any", "expected_all"),
+    [
+        (EmptyConstraint(), False, True),
+        (AnyConstraint(), True, False),
+        (Constraint("win32"), True, True),
+        (Constraint("linux"), True, True),
+        (Constraint("darwin"), False, False),
+        (Constraint("win32", "!="), True, False),
+        (Constraint("linux", "!="), True, False),
+        (Constraint("darwin", "!="), True, False),
+        (
+            UnionConstraint(Constraint("win32"), Constraint("linux")),
+            True,
+            True,
+        ),
+        (
+            UnionConstraint(
+                Constraint("win32"), Constraint("linux"), Constraint("darwin")
+            ),
+            True,
+            False,
+        ),
+        (
+            UnionConstraint(Constraint("darwin"), Constraint("linux")),
+            True,
+            False,
+        ),
+        (
+            UnionConstraint(Constraint("darwin"), Constraint("osx")),
+            False,
+            False,
+        ),
+        (
+            UnionConstraint(Constraint("win32", "!="), Constraint("linux", "!=")),
+            True,
+            False,
+        ),
+        (
+            UnionConstraint(Constraint("darwin", "!="), Constraint("linux", "!=")),
+            True,
+            False,
+        ),
+        (
+            UnionConstraint(Constraint("darwin", "!="), Constraint("osx", "!=")),
+            True,
+            False,
+        ),
+        (
+            MultiConstraint(Constraint("win32", "!="), Constraint("linux", "!=")),
+            False,
+            False,
+        ),
+        (
+            MultiConstraint(
+                Constraint("win32", "!="),
+                Constraint("linux", "!="),
+                Constraint("darwin", "!="),
+            ),
+            False,
+            False,
+        ),
+        (
+            MultiConstraint(Constraint("darwin", "!="), Constraint("linux", "!=")),
+            True,
+            False,
+        ),
+        (
+            MultiConstraint(Constraint("darwin", "!="), Constraint("osx", "!=")),
+            True,
+            False,
+        ),
+    ],
+)
+def test_allows_any_and_allows_all(
+    constraint: BaseConstraint, expected_any: bool, expected_all: bool
+) -> None:
     c = UnionConstraint(Constraint("win32"), Constraint("linux"))
-
-    assert c.allows_any(c)
-    assert c.allows_any(UnionConstraint(Constraint("win32"), Constraint("darwin")))
-    assert not c.allows_any(UnionConstraint(Constraint("linux2"), Constraint("darwin")))
-    assert c.allows_any(Constraint("win32"))
-    assert not c.allows_any(Constraint("darwin"))
-
-
-def test_allows_all() -> None:
-    c = UnionConstraint(Constraint("win32"), Constraint("linux"))
-
-    assert c.allows_all(c)
-    assert not c.allows_all(UnionConstraint(Constraint("win32"), Constraint("darwin")))
-    assert not c.allows_all(UnionConstraint(Constraint("linux2"), Constraint("darwin")))
-    assert c.allows_all(Constraint("win32"))
-    assert not c.allows_all(Constraint("darwin"))
+    assert c.allows_any(constraint) == expected_any
+    assert c.allows_all(constraint) == expected_all


### PR DESCRIPTION
While reviewing #722, I noticed some bugs in the existing implementation of `allows`, `allows_any` and `allows_all` for generic constraints combined with a low test coverage.

Further, I had some difficulties to tell what's the expected behavior of `allows` compared to `allows_any` and `allows_all`. When looking into version constraints for comparison, we can see that `allows` expects a version as argument while `allows_any` and `allows_all` expect arbitrary version constraints. The equivalent of a version is a generic constraint with an `==` operator (there is no explicit class as for version constraints). Therefore, I changed `allows` to raise an error when passing another argument than a constraint with an `==` operator to make the interface more clear.

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
