### PR TITLE
Deprecated string defined scripts in favor of reference. Enabled gui scripts.

### DIFF
--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -448,7 +448,9 @@ class Factory:
 
                 for name, script in scripts.items():
                     if isinstance(script, str):
-                        result["warnings"].append('String defined scripts are deprecated in favor of reference definition')
+                        result["warnings"].append(
+                            "String defined scripts are deprecated in favor of reference definition"
+                        )
 
                     if not isinstance(script, dict):
                         continue

--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -441,11 +441,15 @@ class Factory:
                             )
 
             # Checking for scripts with extras
+            # Checking for string scripts
             if "scripts" in config:
                 scripts = config["scripts"]
                 config_extras = config.get("extras", {})
 
                 for name, script in scripts.items():
+                    if isinstance(script, str):
+                        result["warnings"].append('String defined scripts are deprecated in favor of reference definition')
+
                     if not isinstance(script, dict):
                         continue
 

--- a/src/poetry/core/json/schemas/poetry-schema.json
+++ b/src/poetry/core/json/schemas/poetry-schema.json
@@ -621,7 +621,8 @@
           "type": "string",
           "enum": [
             "file",
-            "console"
+            "console",
+            "gui"
           ]
         },
         "extras": {
@@ -644,7 +645,7 @@
       "properties": {
         "callable": {
           "$ref": "#/definitions/script-legacy",
-          "description": "The entry point of the script. Deprecated in favour of reference."
+          "description": "The entry point of the script. Deprecated in favor of reference."
         },
         "extras": {
           "type": "array",

--- a/src/poetry/core/masonry/builders/builder.py
+++ b/src/poetry/core/masonry/builders/builder.py
@@ -299,13 +299,16 @@ class Builder:
         for name, specification in self._poetry.local_config.get("scripts", {}).items():
             if isinstance(specification, str):
                 warnings.warn(
-                    'String defined scripts are deprecated in favor of reference definition',
+                    "String defined scripts are deprecated in favor of reference definition",
                     DeprecationWarning,
                     stacklevel=1,
                 )
                 specification = {"reference": specification, "type": "console"}
 
-            if specification.get("type") != "console" and specification.get("type") != "gui":
+            if (
+                specification.get("type") != "console"
+                and specification.get("type") != "gui"
+            ):
                 continue
 
             extras = specification.get("extras", [])

--- a/src/poetry/core/masonry/builders/builder.py
+++ b/src/poetry/core/masonry/builders/builder.py
@@ -298,10 +298,14 @@ class Builder:
         # Scripts -> Entry points
         for name, specification in self._poetry.local_config.get("scripts", {}).items():
             if isinstance(specification, str):
-                # TODO: deprecate this in favour or reference
+                warnings.warn(
+                    'String defined scripts are deprecated in favor of reference definition',
+                    DeprecationWarning,
+                    stacklevel=1,
+                )
                 specification = {"reference": specification, "type": "console"}
 
-            if specification.get("type") != "console":
+            if specification.get("type") != "console" and specification.get("type") != "gui":
                 continue
 
             extras = specification.get("extras", [])
@@ -318,8 +322,12 @@ class Builder:
             extras = f"[{', '.join(extras)}]" if extras else ""
             reference = specification.get("reference")
 
-            if reference:
+            if not reference:
+                continue
+            if specification.get("type") == "console":
                 result["console_scripts"].append(f"{name} = {reference}{extras}")
+            if specification.get("type") == "gui":
+                result["gui_scripts"].append(f"{name} = {reference}{extras}")
 
         # Plugins -> entry points
         plugins = self._poetry.local_config.get("plugins", {})

--- a/tests/fixtures/complete.toml
+++ b/tests/fixtures/complete.toml
@@ -37,7 +37,7 @@ pytest = "^3.0"
 pytest-cov = "^2.4"
 
 [tool.poetry.scripts]
-my-script = 'my_package:main'
+my-script = { reference = "my_package:main", type = "console" }
 sample_pyscript = { reference = "script-files/sample_script.py", type= "file" }
 sample_shscript = { reference = "script-files/sample_script.sh", type= "file" }
 

--- a/tests/fixtures/pep_517_backend/pyproject.toml
+++ b/tests/fixtures/pep_517_backend/pyproject.toml
@@ -34,4 +34,4 @@ pytest = "7.1.3"
 preview = true
 
 [tool.poetry.scripts]
-my-script = "my_package:main"
+my-script = { reference = "my_package:main", type = "console"}

--- a/tests/fixtures/sample_project/pyproject.toml
+++ b/tests/fixtures/sample_project/pyproject.toml
@@ -64,7 +64,7 @@ pytest = "~3.4"
 
 
 [tool.poetry.scripts]
-my-script = "my_package:main"
+my-script = { reference = "my_package:main", type = "console"}
 
 
 [tool.poetry.plugins."blogtool.parsers"]

--- a/tests/masonry/builders/fixtures/case_sensitive_exclusions/pyproject.toml
+++ b/tests/masonry/builders/fixtures/case_sensitive_exclusions/pyproject.toml
@@ -44,6 +44,6 @@ pytest = "~3.4"
 time = ["pendulum"]
 
 [tool.poetry.scripts]
-my-script = "my_package:main"
-my-2nd-script = "my_package:main2"
+my-script = { reference = "my_package:main", type = "console" }
+my-2nd-script = { reference = "my_package:main2", type = "console" }
 extra-script = {reference = "my_package.extra:main", extras = ["time"], type = "console"}

--- a/tests/masonry/builders/fixtures/complete/pyproject.toml
+++ b/tests/masonry/builders/fixtures/complete/pyproject.toml
@@ -46,8 +46,8 @@ pytest = "~3.4"
 time = ["pendulum"]
 
 [tool.poetry.scripts]
-my-script = "my_package:main"
-my-2nd-script = "my_package:main2"
+my-script = { reference = "my_package:main", type = "console" }
+my-2nd-script = { reference = "my_package:main2", type = "console" }
 file-script = { reference = "bin/script.sh", type = "file" }
 extra-script = { reference = "my_package.extra:main", extras = ["time"], type = "console" }
 

--- a/tests/masonry/builders/fixtures/default_src_with_excluded_data/pyproject.toml
+++ b/tests/masonry/builders/fixtures/default_src_with_excluded_data/pyproject.toml
@@ -35,5 +35,5 @@ pytest = "~3.4"
 time = ["pendulum"]
 
 [tool.poetry.scripts]
-my-script = "my_package:main"
-my-2nd-script = "my_package:main2"
+my-script = { reference = "my_package:main", type="console"}
+my-2nd-script = { reference = "my_package:main2", type="console"}

--- a/tests/masonry/builders/fixtures/default_with_excluded_data/pyproject.toml
+++ b/tests/masonry/builders/fixtures/default_with_excluded_data/pyproject.toml
@@ -35,5 +35,5 @@ pytest = "~3.4"
 time = ["pendulum"]
 
 [tool.poetry.scripts]
-my-script = "my_package:main"
-my-2nd-script = "my_package:main2"
+my-script = {reference = "my_package:main", type = "console"}
+my-2nd-script = {reference = "my_package:main2", type = "console"}

--- a/tests/masonry/builders/fixtures/default_with_excluded_data_toml/pyproject.toml
+++ b/tests/masonry/builders/fixtures/default_with_excluded_data_toml/pyproject.toml
@@ -37,5 +37,5 @@ pytest = "~3.4"
 time = ["pendulum"]
 
 [tool.poetry.scripts]
-my-script = "my_package:main"
-my-2nd-script = "my_package:main2"
+my-script = { reference = "my_package:main", type = "console" }
+my-2nd-script = { reference = "my_package:main2", type = "console" }

--- a/tests/masonry/builders/fixtures/disable_setup_py/pyproject.toml
+++ b/tests/masonry/builders/fixtures/disable_setup_py/pyproject.toml
@@ -32,4 +32,4 @@ python = "~2.7 || ^3.6"
 [tool.poetry.dev-dependencies]
 
 [tool.poetry.scripts]
-my-script = "my_package:main"
+my-script = { reference = "my_package:main", type = "console" }

--- a/tests/masonry/builders/fixtures/exclude_nested_data_toml/pyproject.toml
+++ b/tests/masonry/builders/fixtures/exclude_nested_data_toml/pyproject.toml
@@ -38,5 +38,5 @@ pytest = "~3.4"
 time = ["pendulum"]
 
 [tool.poetry.scripts]
-my-script = "my_package:main"
-my-2nd-script = "my_package:main2"
+my-script = {reference = "my_package:main", type="console"}
+my-2nd-script = {reference = "my_package:main2", type="console"}

--- a/tests/masonry/builders/fixtures/invalid_case_sensitive_exclusions/pyproject.toml
+++ b/tests/masonry/builders/fixtures/invalid_case_sensitive_exclusions/pyproject.toml
@@ -39,6 +39,6 @@ pytest = "~3.4"
 time = ["pendulum"]
 
 [tool.poetry.scripts]
-my-script = "my_package:main"
-my-2nd-script = "my_package:main2"
+my-script = { reference = "my_package:main", type = "console"}
+my-2nd-script = { reference = "my_package:main2", type = "console"}
 extra-script = {reference = "my_package.extra:main", extras = ["time"], type = "console"}

--- a/tests/masonry/builders/fixtures/licenses_and_copying/pyproject.toml
+++ b/tests/masonry/builders/fixtures/licenses_and_copying/pyproject.toml
@@ -41,8 +41,8 @@ pytest = "~3.4"
 time = ["pendulum"]
 
 [tool.poetry.scripts]
-my-script = "my_package:main"
-my-2nd-script = "my_package:main2"
+my-script = { reference = "my_package:main", type = "console" }
+my-2nd-script = { reference = "my_package:main2", type = "console" }
 
 [tool.poetry.urls]
 "Issue Tracker" = "https://github.com/python-poetry/poetry/issues"

--- a/tests/masonry/builders/fixtures/with-include/pyproject.toml
+++ b/tests/masonry/builders/fixtures/with-include/pyproject.toml
@@ -53,5 +53,5 @@ pytest = "~3.4"
 time = ["pendulum"]
 
 [tool.poetry.scripts]
-my-script = "my_package:main"
-my-2nd-script = "my_package:main2"
+my-script = { reference = "my_package:main", type="console" }
+my-2nd-script = { reference = "my_package:main2", type="console" }

--- a/tests/masonry/builders/fixtures/with_include_inline_table/pyproject.toml
+++ b/tests/masonry/builders/fixtures/with_include_inline_table/pyproject.toml
@@ -44,5 +44,5 @@ pytest = "~3.4"
 time = ["pendulum"]
 
 [tool.poetry.scripts]
-my-script = "my_package:main"
-my-2nd-script = "my_package:main2"
+my-script = { reference = "my_package:main", type = "console"}
+my-2nd-script = { reference = "my_package:main2", type = "console"}

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -332,9 +332,7 @@ def test_validate_strict_fails_strict_and_non_strict() -> None:
                 " https://packaging.python.org/en/latest/specifications/entry-points/#data-model"
                 " for details."
             ),
-            (
-                'String defined scripts are deprecated in favor of reference definition'
-            ),
+            ("String defined scripts are deprecated in favor of reference definition"),
         ],
     }
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -332,6 +332,9 @@ def test_validate_strict_fails_strict_and_non_strict() -> None:
                 " https://packaging.python.org/en/latest/specifications/entry-points/#data-model"
                 " for details."
             ),
+            (
+                'String defined scripts are deprecated in favor of reference definition'
+            ),
         ],
     }
 


### PR DESCRIPTION
Resolves: 
Deprecating string scripts
python-poetry-core [TODO](https://github.com/python-poetry/poetry-core/blob/06d72bc0f1f05086a1cc0e760075c519af33db5b/src/poetry/core/masonry/builders/builder.py#L301)
Continuation to my [PR](https://github.com/python-poetry/poetry/pull/9549#issue-2407767175) on python-poetry/poetry

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code. Updated previous Test
- [x] Updated **documentation** for changed code.

As for the deprecation work changes tests toml's to reference scripts, except the ones that shouldn't of course.
Documentation updated on [PR](https://github.com/python-poetry/poetry/pull/9549#issue-2407767175)

**Warning**

On tests the deprecation raises a warning on [test_builder_convert_entry_points](https://github.com/python-poetry/poetry-core/blob/06d72bc0f1f05086a1cc0e760075c519af33db5b/tests/masonry/builders/test_builder.py#L243C1-L243C39) that i don't know how to solve

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
