### PR TITLE
deprecate `tool.poetry.dev-dependencies` in favor of `tool.poetry.group.dev.dependencies`

### DIFF
--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -56,6 +56,9 @@ class Factory:
 
             raise RuntimeError("The Poetry configuration is invalid:\n" + message)
 
+        for warning in check_result["warnings"]:
+            logger.warning(warning)
+
         # Load package
         # If name or version were missing in package mode, we would have already
         # raised an error, so we can safely assume they might only be missing
@@ -402,6 +405,13 @@ class Factory:
                     )
 
         result["errors"] += validation_errors
+
+        if "dev-dependencies" in config:
+            result["warnings"].append(
+                'The "poetry.dev-dependencies" section is deprecated'
+                " and will be removed in a future version."
+                ' Use "poetry.group.dev.dependencies" instead.'
+            )
 
         if strict:
             # If strict, check the file more thoroughly

--- a/tests/fixtures/complete.toml
+++ b/tests/fixtures/complete.toml
@@ -32,7 +32,7 @@ pendulum = { version = "^1.4", optional = true }
 [tool.poetry.extras]
 time = [ "pendulum" ]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^3.0"
 pytest-cov = "^2.4"
 

--- a/tests/fixtures/project_with_build_system_requires/pyproject.toml
+++ b/tests/fixtures/project_with_build_system_requires/pyproject.toml
@@ -19,4 +19,4 @@ script = "build.py"
 [tool.poetry.dependencies]
 python = "^3.7"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]

--- a/tests/fixtures/project_with_invalid_dev_deps/pyproject.toml
+++ b/tests/fixtures/project_with_invalid_dev_deps/pyproject.toml
@@ -9,5 +9,5 @@ license = "MIT"
 
 [tool.poetry.extras]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 mylib = { path = "../mylib", develop = true}

--- a/tests/fixtures/project_with_multi_constraints_dependency/pyproject.toml
+++ b/tests/fixtures/project_with_multi_constraints_dependency/pyproject.toml
@@ -16,4 +16,4 @@ pendulum = [
     { version = "^2.0", python = "^3.4" }
 ]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]

--- a/tests/json/test_poetry_schema.py
+++ b/tests/json/test_poetry_schema.py
@@ -15,7 +15,7 @@ def base_object() -> dict[str, Any]:
         "description": "Some description.",
         "authors": ["Your Name <you@example.com>"],
         "dependencies": {"python": "^3.6"},
-        "dev-dependencies": {},
+        "group": {"dev": {"dependencies": {}}},
     }
 
 
@@ -35,7 +35,6 @@ def multi_url_object() -> dict[str, Any]:
                 {"path": "../foo", "platform": "darwin"},
             ]
         },
-        "dev-dependencies": {},
     }
 
 
@@ -70,7 +69,7 @@ def test_invalid_mode() -> None:
 
 def test_path_dependencies(base_object: dict[str, Any]) -> None:
     base_object["dependencies"].update({"foo": {"path": "../foo"}})
-    base_object["dev-dependencies"].update({"foo": {"path": "../foo"}})
+    base_object["group"]["dev"]["dependencies"].update({"foo": {"path": "../foo"}})
 
     assert len(validate_object(base_object, "poetry-schema")) == 0
 

--- a/tests/masonry/builders/fixtures/case_sensitive_exclusions/pyproject.toml
+++ b/tests/masonry/builders/fixtures/case_sensitive_exclusions/pyproject.toml
@@ -37,7 +37,7 @@ cachy = { version = "^0.2.0", extras = ["msgpack"] }
 
 pendulum = { version = "^1.4", optional = true }
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "~3.4"
 
 [tool.poetry.extras]

--- a/tests/masonry/builders/fixtures/comma_file/pyproject.toml
+++ b/tests/masonry/builders/fixtures/comma_file/pyproject.toml
@@ -8,5 +8,5 @@ authors = [
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 

--- a/tests/masonry/builders/fixtures/complete/pyproject.toml
+++ b/tests/masonry/builders/fixtures/complete/pyproject.toml
@@ -39,7 +39,7 @@ version = "^1.4"
 markers = 'python_version ~= "2.7" and sys_platform == "win32" or python_version in "3.4 3.5"'
 optional = true
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "~3.4"
 
 [tool.poetry.extras]

--- a/tests/masonry/builders/fixtures/default_src_with_excluded_data/pyproject.toml
+++ b/tests/masonry/builders/fixtures/default_src_with_excluded_data/pyproject.toml
@@ -28,7 +28,7 @@ cachy = { version = "^0.2.0", extras = ["msgpack"] }
 
 pendulum = { version = "^1.4", optional = true }
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "~3.4"
 
 [tool.poetry.extras]

--- a/tests/masonry/builders/fixtures/default_with_excluded_data/pyproject.toml
+++ b/tests/masonry/builders/fixtures/default_with_excluded_data/pyproject.toml
@@ -28,7 +28,7 @@ cachy = { version = "^0.2.0", extras = ["msgpack"] }
 
 pendulum = { version = "^1.4", optional = true }
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "~3.4"
 
 [tool.poetry.extras]

--- a/tests/masonry/builders/fixtures/default_with_excluded_data_toml/pyproject.toml
+++ b/tests/masonry/builders/fixtures/default_with_excluded_data_toml/pyproject.toml
@@ -30,7 +30,7 @@ cachy = { version = "^0.2.0", extras = ["msgpack"] }
 
 pendulum = { version = "^1.4", optional = true }
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "~3.4"
 
 [tool.poetry.extras]

--- a/tests/masonry/builders/fixtures/disable_setup_py/pyproject.toml
+++ b/tests/masonry/builders/fixtures/disable_setup_py/pyproject.toml
@@ -29,7 +29,7 @@ python = "~2.7 || ^3.6"
 
 [tool.poetry.extras]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [tool.poetry.scripts]
 my-script = "my_package:main"

--- a/tests/masonry/builders/fixtures/exclude_nested_data_toml/pyproject.toml
+++ b/tests/masonry/builders/fixtures/exclude_nested_data_toml/pyproject.toml
@@ -31,7 +31,7 @@ cachy = { version = "^0.2.0", extras = ["msgpack"] }
 
 pendulum = { version = "^1.4", optional = true }
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "~3.4"
 
 [tool.poetry.extras]

--- a/tests/masonry/builders/fixtures/excluded_subpackage/pyproject.toml
+++ b/tests/masonry/builders/fixtures/excluded_subpackage/pyproject.toml
@@ -10,7 +10,7 @@ exclude = [
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^3.0"
 
 [build-system]

--- a/tests/masonry/builders/fixtures/include_excluded_code/pyproject.toml
+++ b/tests/masonry/builders/fixtures/include_excluded_code/pyproject.toml
@@ -13,7 +13,7 @@ include = ['lib/my_package/generated.py']
 [tool.poetry.dependencies]
 python = "^3.8"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/masonry/builders/fixtures/invalid_case_sensitive_exclusions/pyproject.toml
+++ b/tests/masonry/builders/fixtures/invalid_case_sensitive_exclusions/pyproject.toml
@@ -32,7 +32,7 @@ cachy = { version = "^0.2.0", extras = ["msgpack"] }
 
 pendulum = { version = "^1.4", optional = true }
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "~3.4"
 
 [tool.poetry.extras]

--- a/tests/masonry/builders/fixtures/licenses_and_copying/pyproject.toml
+++ b/tests/masonry/builders/fixtures/licenses_and_copying/pyproject.toml
@@ -34,7 +34,7 @@ version = "^1.4"
 markers= 'python_version ~= "2.7" and sys_platform == "win32" or python_version in "3.4 3.5"'
 optional = true
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "~3.4"
 
 [tool.poetry.extras]

--- a/tests/masonry/builders/fixtures/script_callable_legacy_string/pyproject.toml
+++ b/tests/masonry/builders/fixtures/script_callable_legacy_string/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.rst"
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [tool.poetry.extras]
 

--- a/tests/masonry/builders/fixtures/script_reference_console/pyproject.toml
+++ b/tests/masonry/builders/fixtures/script_reference_console/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.rst"
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [tool.poetry.extras]
 time = []

--- a/tests/masonry/builders/fixtures/script_reference_file/pyproject.toml
+++ b/tests/masonry/builders/fixtures/script_reference_file/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.rst"
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [tool.poetry.extras]
 

--- a/tests/masonry/builders/fixtures/script_reference_file_invalid_definition/pyproject.toml
+++ b/tests/masonry/builders/fixtures/script_reference_file_invalid_definition/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.rst"
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [tool.poetry.extras]
 

--- a/tests/masonry/builders/fixtures/script_reference_file_missing/pyproject.toml
+++ b/tests/masonry/builders/fixtures/script_reference_file_missing/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.rst"
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 
 [tool.poetry.extras]
 

--- a/tests/masonry/builders/fixtures/with-include/pyproject.toml
+++ b/tests/masonry/builders/fixtures/with-include/pyproject.toml
@@ -46,7 +46,7 @@ cachy = { version = "^0.2.0", extras = ["msgpack"] }
 
 pendulum = { version = "^1.4", optional = true }
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "~3.4"
 
 [tool.poetry.extras]

--- a/tests/masonry/builders/fixtures/with_bad_path_dev_dep/pyproject.toml
+++ b/tests/masonry/builders/fixtures/with_bad_path_dev_dep/pyproject.toml
@@ -7,5 +7,5 @@ authors = ["Awesome Hacker <awesome@hacker.io>"]
 [tool.poetry.dependencies]
 python = "^3.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 bogus = { path = "../only/in/dev", develop = true }

--- a/tests/masonry/builders/fixtures/with_include_inline_table/pyproject.toml
+++ b/tests/masonry/builders/fixtures/with_include_inline_table/pyproject.toml
@@ -37,7 +37,7 @@ cachy = { version = "^0.2.0", extras = ["msgpack"] }
 
 pendulum = { version = "^1.4", optional = true }
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "~3.4"
 
 [tool.poetry.extras]

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -411,10 +411,17 @@ def test_create_poetry_with_invalid_dev_dependencies(caplog: LogCaptureFixture) 
     assert any("dev" in r.groups for r in poetry.package.all_requires)
 
 
-def test_create_poetry_with_groups_and_legacy_dev() -> None:
+def test_create_poetry_with_groups_and_legacy_dev(caplog: LogCaptureFixture) -> None:
+    assert not caplog.records
+
     poetry = Factory().create_poetry(
         fixtures_dir / "project_with_groups_and_legacy_dev"
     )
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.levelname == "WARNING"
+    assert '"poetry.dev-dependencies" section is deprecated' in record.message
 
     package = poetry.package
     dependencies = package.all_requires


### PR DESCRIPTION
Requires: python-poetry/poetry#9661

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
