### PR TITLE
Remove parametrize test for failed test

### DIFF
--- a/tests/version/test_requirements.py
+++ b/tests/version/test_requirements.py
@@ -134,7 +134,6 @@ def test_requirement(string: str, expected: dict[str, Any]) -> None:
     [
         ("foo!", "Unexpected character at column 4\n\nfoo!\n   ^\n"),
         ("foo (>=bar)", 'invalid version constraint ">=bar"'),
-        ("name @ file:.", "invalid URL"),
         ("name @ file:/.", "invalid URL"),
     ],
 )


### PR DESCRIPTION
In CPython3.12.6 urllib.parse.urlunsplit() was modified to preserve relative path in URL without netloc. poetry-core use this method to check the links in requirements. This patch remove that parametrize test.

Resolves: [python-poetry#9678](https://github.com/python-poetry/poetry/issues/9678)

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->


<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
