### PR TITLE
chore: enable downstream tests

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -2,10 +2,9 @@ name: Poetry Downstream Tests
 
 on:
   workflow_dispatch:
-# TODO: enable again after updating Poetry to use poetry-core 2.0.0
-#  pull_request: {}
-#  push:
-#    branches: [main]
+  pull_request: {}
+  push:
+    branches: [main]
 
 jobs:
   tests:


### PR DESCRIPTION
Now that python-poetry/poetry#9135 has been merged, the main branch is compatible again. Let's enable downstream tests so that we notice issues early.