### PR TITLE
Stop using private pytest API

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,8 @@ from poetry.core.utils._compat import WINDOWS
 
 
 if TYPE_CHECKING:
-    from _pytest.config import Config
-    from _pytest.config.argparsing import Parser
+    from pytest import Config
+    from pytest import Parser
 
 
 def pytest_addoption(parser: Parser) -> None:

--- a/tests/integration/test_pep517.py
+++ b/tests/integration/test_pep517.py
@@ -15,7 +15,7 @@ from tests.testutils import temporary_project_directory
 
 
 if TYPE_CHECKING:
-    from _pytest.fixtures import FixtureRequest
+    from pytest import FixtureRequest
 
 pytestmark = pytest.mark.integration
 

--- a/tests/masonry/builders/test_wheel.py
+++ b/tests/masonry/builders/test_wheel.py
@@ -20,7 +20,7 @@ from tests.masonry.builders.test_sdist import project
 
 
 if TYPE_CHECKING:
-    from _pytest.monkeypatch import MonkeyPatch
+    from pytest import MonkeyPatch
     from pytest_mock import MockerFixture
 
 fixtures_dir = Path(__file__).parent / "fixtures"

--- a/tests/masonry/test_api.py
+++ b/tests/masonry/test_api.py
@@ -18,7 +18,7 @@ from tests.testutils import validate_wheel_contents
 
 
 if TYPE_CHECKING:
-    from _pytest.logging import LogCaptureFixture
+    from pytest import LogCaptureFixture
 
 
 @contextmanager

--- a/tests/packages/test_directory_dependency.py
+++ b/tests/packages/test_directory_dependency.py
@@ -11,7 +11,7 @@ from poetry.core.packages.directory_dependency import DirectoryDependency
 
 
 if TYPE_CHECKING:
-    from _pytest.logging import LogCaptureFixture
+    from pytest import LogCaptureFixture
     from pytest_mock import MockerFixture
 
 

--- a/tests/packages/test_file_dependency.py
+++ b/tests/packages/test_file_dependency.py
@@ -12,7 +12,7 @@ from poetry.core.version.markers import SingleMarker
 
 
 if TYPE_CHECKING:
-    from _pytest.logging import LogCaptureFixture
+    from pytest import LogCaptureFixture
     from pytest_mock import MockerFixture
 
     from poetry.core.version.markers import BaseMarker

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -18,7 +18,7 @@ from poetry.core.version.markers import SingleMarker
 
 
 if TYPE_CHECKING:
-    from _pytest.logging import LogCaptureFixture
+    from pytest import LogCaptureFixture
 
     from poetry.core.packages.dependency import Dependency
     from poetry.core.packages.directory_dependency import DirectoryDependency


### PR DESCRIPTION
Pytest has been exporting those types as public for a few years now.