### PR TITLE
release: bump version to 1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 
 
+## [1.9.1] - 2024-10-12
+
+### Added
+
+- Add `3.13` to the list of available Python versions ([#747](https://github.com/python-poetry/poetry-core/pull/747)).
+
+
 ## [1.9.0] - 2024-02-02
 
 ### Added
@@ -633,7 +640,8 @@ No changes.
 - Fixed support for stub-only packages ([#28](https://github.com/python-poetry/core/pull/28)).
 
 
-[Unreleased]: https://github.com/python-poetry/poetry-core/compare/1.9.0...main
+[Unreleased]: https://github.com/python-poetry/poetry-core/compare/1.9.1...main
+[1.9.1]: https://github.com/python-poetry/poetry-core/releases/tag/1.9.1
 [1.9.0]: https://github.com/python-poetry/poetry-core/releases/tag/1.9.0
 [1.8.1]: https://github.com/python-poetry/poetry-core/releases/tag/1.8.1
 [1.8.0]: https://github.com/python-poetry/poetry-core/releases/tag/1.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-core"
-version = "1.9.0"
+version = "1.9.1"
 description = "Poetry PEP 517 Build Backend"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 license = "MIT"
@@ -11,6 +11,8 @@ keywords = ["packaging", "dependency", "poetry"]
 classifiers = [
     "Topic :: Software Development :: Build Tools",
     "Topic :: Software Development :: Libraries :: Python Modules",
+    # Classifiers for Python 3.13 can be removed after Poetry 1.8.4 has been released.
+    "Programming Language :: Python :: 3.13",
 ]
 packages = [
     { include = "poetry", from = "src" },

--- a/src/poetry/core/__init__.py
+++ b/src/poetry/core/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 # this cannot presently be replaced with importlib.metadata.version as when building
 # itself, poetry-core is not available as an installed distribution.
-__version__ = "1.9.0"
+__version__ = "1.9.1"
 
 __vendor_site__ = (Path(__file__).parent / "_vendor").as_posix()
 


### PR DESCRIPTION
### Added

- Add `3.13` to the list of available Python versions ([#747](https://github.com/python-poetry/poetry-core/pull/747)).
