### PR TITLE
make `allow-prereleases` a tri-state setting to really forbid pre-releases if the setting is `false` and keep default behavior to allow pre-releases only if necessary

### DIFF
--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -414,7 +414,7 @@ class Factory:
             python_versions = constraint.get("python")
             platform = constraint.get("platform")
             markers = constraint.get("markers")
-            allows_prereleases = constraint.get("allow-prereleases", False)
+            allows_prereleases = constraint.get("allow-prereleases")
 
             dependency: Dependency
             if "git" in constraint:

--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -41,7 +41,7 @@ class Dependency(PackageSpecification):
         constraint: str | VersionConstraint,
         optional: bool = False,
         groups: Iterable[str] | None = None,
-        allows_prereleases: bool = False,
+        allows_prereleases: bool | None = None,
         extras: Iterable[str] | None = None,
         source_type: str | None = None,
         source_url: str | None = None,
@@ -233,7 +233,14 @@ class Dependency(PackageSpecification):
     def base_pep_508_name_resolved(self) -> str:
         return self.base_pep_508_name
 
-    def allows_prereleases(self) -> bool:
+    def allows_prereleases(self) -> bool | None:
+        """
+        None (default): only use pre-release versions
+                        if no stable version satisfies the constraint
+        False: do not allow pre-release versions
+               even if this means there is no solution
+        True: do not distinguish between stable and pre-release versions
+        """
         return self._allows_prereleases
 
     def is_optional(self) -> bool:

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -24,7 +24,7 @@ from poetry.core.version.requirements import InvalidRequirementError
         "^1.0.0-1",
     ],
 )
-@pytest.mark.parametrize("allows_prereleases", [False, True])
+@pytest.mark.parametrize("allows_prereleases", [None, False, True])
 def test_allows_prerelease(constraint: str, allows_prereleases: bool) -> None:
     dependency = Dependency("A", constraint, allows_prereleases=allows_prereleases)
     assert dependency.allows_prereleases() == allows_prereleases

--- a/tests/packages/test_dependency_group.py
+++ b/tests/packages/test_dependency_group.py
@@ -15,7 +15,7 @@ def create_dependency(
     constraint: str = "*",
     *,
     extras: tuple[str, ...] = (),
-    allows_prereleases: bool = False,
+    allows_prereleases: bool | None = None,
     develop: bool = False,
     source_name: str | None = None,
     marker: str | None = None,
@@ -146,6 +146,11 @@ def test_remove_dependency_removes_from_both_lists() -> None:
             [Dependency.create_from_pep_508("foo>=1")],
             [create_dependency("foo", allows_prereleases=True)],
             [create_dependency("foo", ">=1", allows_prereleases=True)],
+        ),
+        (
+            [Dependency.create_from_pep_508("foo>=1")],
+            [create_dependency("foo", allows_prereleases=False)],
+            [create_dependency("foo", ">=1", allows_prereleases=False)],
         ),
         # directory dependency - develop
         (

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -221,7 +221,7 @@ def test_create_poetry(new_format: str) -> None:
     requests = dependencies["requests"]
     assert requests.pretty_constraint == (">=2.18,<3.0" if new_format else "^2.18")
     assert not requests.is_vcs()
-    assert not requests.allows_prereleases()
+    assert requests.allows_prereleases() is None
     assert requests.is_optional()
     assert requests.extras == frozenset({"security"})
 
@@ -928,6 +928,22 @@ def test_create_dependency_marker_variants(
     assert dep.python_versions == exp_python
     assert dep.python_constraint == parse_constraint(exp_python)
     assert str(dep.marker) == exp_marker
+
+
+@pytest.mark.parametrize(
+    ("constraint", "expected"),
+    [
+        ("1", None),
+        ({"version": "1"}, None),
+        ({"version": "1", "allow-prereleases": False}, False),
+        ({"version": "1", "allow-prereleases": True}, True),
+    ],
+)
+def test_create_dependency_allow_prereleases(
+    constraint: str | dict[str, str], expected: bool | None
+) -> None:
+    dep = Factory.create_dependency("foo", constraint)
+    assert dep.allows_prereleases() is expected
 
 
 def test_all_classifiers_unique_even_if_classifiers_is_duplicated() -> None:


### PR DESCRIPTION
Values of `allow-prereleases`:
* not set (default): only use pre-release versions if no stable version satisfies the constraint
* `false`: do not allow pre-release versions even if this means there is no solution
* `true`: do not distinguish between stable and pre-release versions

This PR only allows `None` as a value / makes sure that the value of the property is `None` if not set (instead of `False`). The behavior is implemented downstream in https://github.com/python-poetry/poetry/pull/9798.