### PR TITLE
vcs: fix parsing of basic auth http(s) credentials

### DIFF
--- a/src/poetry/core/vcs/git.py
+++ b/src/poetry/core/vcs/git.py
@@ -18,6 +18,16 @@ PATH = r"[%\w~.\-\+/\\\$]+"
 NAME = r"[%\w~.\-]+"
 REV = r"[^@#]+?"
 SUBDIR = r"[\w\-/\\]+"
+PATTERN_SUFFIX = (
+    r"(?:"
+    rf"#(?:egg=.+?&subdirectory=|subdirectory=)(?P<subdirectory>{SUBDIR})"
+    r"|"
+    r"#egg=?.+"
+    r"|"
+    rf"[@#](?P<rev>{REV})(?:[&#](?:(?:egg=.+?&subdirectory=|subdirectory=)(?P<rev_subdirectory>{SUBDIR})|egg=.+?))?"
+    r")?"
+    r"$"
+)
 
 PATTERNS = [
     re.compile(
@@ -28,14 +38,7 @@ PATTERNS = [
         rf"(:(?P<port>{PORT}))?"
         rf"(?P<pathname>[:/\\]({PATH}[/\\])?"
         rf"((?P<name>{NAME}?)(\.git|[/\\])?)?)"
-        r"(?:"
-        rf"#(?:egg=.+?&subdirectory=|subdirectory=)(?P<subdirectory>{SUBDIR})"
-        r"|"
-        r"#egg=?.+"
-        r"|"
-        rf"[@#](?P<rev>{REV})(?:[&#](?:(?:egg=.+?&subdirectory=|subdirectory=)(?P<rev_subdirectory>{SUBDIR})|egg=.+?))?"
-        r")?"
-        r"$"
+        rf"{PATTERN_SUFFIX}"
     ),
     re.compile(
         r"(git\+)?"
@@ -45,14 +48,7 @@ PATTERNS = [
         rf"(:(?P<port>{PORT}))?"
         rf"(?P<pathname>({PATH})"
         rf"(?P<name>{NAME})(\.git|/)?)"
-        r"(?:"
-        rf"#(?:egg=.+?&subdirectory=|subdirectory=)(?P<subdirectory>{SUBDIR})"
-        r"|"
-        r"#egg=?.+"
-        r"|"
-        rf"[@#](?P<rev>{REV})(?:[&#](?:(?:egg=.+?&subdirectory=|subdirectory=)(?P<rev_subdirectory>{SUBDIR})|egg=.+?))?"
-        r")?"
-        r"$"
+        rf"{PATTERN_SUFFIX}"
     ),
     re.compile(
         rf"^(?:(?P<user>{USER})@)?"
@@ -60,14 +56,7 @@ PATTERNS = [
         rf"(:(?P<port>{PORT}))?"
         rf"(?P<pathname>([:/]{PATH}/)"
         rf"(?P<name>{NAME})(\.git|/)?)"
-        r"(?:"
-        rf"#(?:egg=.+?&subdirectory=|subdirectory=)(?P<subdirectory>{SUBDIR})"
-        r"|"
-        r"#egg=?.+"
-        r"|"
-        rf"[@#](?P<rev>{REV})(?:[&#](?:(?:egg=.+?&subdirectory=|subdirectory=)(?P<rev_subdirectory>{SUBDIR})|egg=.+?))?"
-        r")?"
-        r"$"
+        rf"{PATTERN_SUFFIX}"
     ),
     re.compile(
         rf"((?P<user>{USER})@)?"
@@ -75,14 +64,7 @@ PATTERNS = [
         r"[:/]{{1,2}}"
         rf"(?P<pathname>({PATH})"
         rf"(?P<name>{NAME})(\.git|/)?)"
-        r"(?:"
-        rf"#(?:egg=.+?&subdirectory=|subdirectory=)(?P<subdirectory>{SUBDIR})"
-        r"|"
-        r"#egg=?.+"
-        r"|"
-        rf"[@#](?P<rev>{REV})(?:[&#](?:(?:egg=.+?&subdirectory=|subdirectory=)(?P<rev_subdirectory>{SUBDIR})|egg=.+?))?"
-        r")?"
-        r"$"
+        rf"{PATTERN_SUFFIX}"
     ),
 ]
 

--- a/src/poetry/core/vcs/git.py
+++ b/src/poetry/core/vcs/git.py
@@ -11,7 +11,10 @@ from poetry.core.utils._compat import WINDOWS
 
 
 PROTOCOL = r"\w+"
-USER = r"[a-zA-Z0-9_.-]+"
+# https://url.spec.whatwg.org/#forbidden-host-code-point
+URL_RESTRICTED = r"[^/\?#:@<>\[\]\|]"
+USER = rf"{URL_RESTRICTED}+"
+USER_AUTH_HTTP = rf"((?P<username>{USER})(:(?P<password>{URL_RESTRICTED}*))?)"
 RESOURCE = r"[a-zA-Z0-9_.-]+"
 PORT = r"\d+"
 PATH = r"[%\w~.\-\+/\\\$]+"
@@ -32,8 +35,18 @@ PATTERN_SUFFIX = (
 PATTERNS = [
     re.compile(
         r"^(git\+)?"
-        r"(?P<protocol>https?|git|ssh|rsync|file)://"
+        r"(?P<protocol>git|ssh|rsync|file)://"
         rf"(?:(?P<user>{USER})@)?"
+        rf"(?P<resource>{RESOURCE})?"
+        rf"(:(?P<port>{PORT}))?"
+        rf"(?P<pathname>[:/\\]({PATH}[/\\])?"
+        rf"((?P<name>{NAME}?)(\.git|[/\\])?)?)"
+        rf"{PATTERN_SUFFIX}"
+    ),
+    re.compile(
+        r"^(git\+)?"
+        r"(?P<protocol>https?)://"
+        rf"(?:(?P<user>{USER_AUTH_HTTP})@)?"
         rf"(?P<resource>{RESOURCE})?"
         rf"(:(?P<port>{PORT}))?"
         rf"(?P<pathname>[:/\\]({PATH}[/\\])?"

--- a/tests/vcs/test_vcs.py
+++ b/tests/vcs/test_vcs.py
@@ -12,7 +12,6 @@ import pytest
 from poetry.core.utils._compat import WINDOWS
 from poetry.core.vcs import get_vcs
 from poetry.core.vcs.git import Git
-from poetry.core.vcs.git import GitError
 from poetry.core.vcs.git import GitUrl
 from poetry.core.vcs.git import ParsedUrl
 from poetry.core.vcs.git import _reset_executable
@@ -438,21 +437,6 @@ def test_parse_url_should_fail() -> None:
 
     with pytest.raises(ValueError):
         ParsedUrl.parse(url)
-
-
-def test_git_clone_raises_error_on_invalid_repository() -> None:
-    with pytest.raises(GitError):
-        Git().clone("-u./payload", Path("foo"))
-
-
-def test_git_checkout_raises_error_on_invalid_repository() -> None:
-    with pytest.raises(GitError):
-        Git().checkout("-u./payload")
-
-
-def test_git_rev_parse_raises_error_on_invalid_repository() -> None:
-    with pytest.raises(GitError):
-        Git().rev_parse("-u./payload")
 
 
 @pytest.mark.skipif(

--- a/tests/vcs/test_vcs.py
+++ b/tests/vcs/test_vcs.py
@@ -273,6 +273,42 @@ def test_normalize_url(url: str, normalized: GitUrl) -> None:
             ),
         ),
         (
+            "git+https://username:@github.com/sdispater/pendulum",
+            ParsedUrl(
+                "https",
+                "github.com",
+                "/sdispater/pendulum",
+                "username:",
+                None,
+                "pendulum",
+                None,
+            ),
+        ),
+        (
+            "git+https://username:password@github.com/sdispater/pendulum",
+            ParsedUrl(
+                "https",
+                "github.com",
+                "/sdispater/pendulum",
+                "username:password",
+                None,
+                "pendulum",
+                None,
+            ),
+        ),
+        (
+            "git+https://username+suffix:password@github.com/sdispater/pendulum",
+            ParsedUrl(
+                "https",
+                "github.com",
+                "/sdispater/pendulum",
+                "username+suffix:password",
+                None,
+                "pendulum",
+                None,
+            ),
+        ),
+        (
             "git+https://github.com/sdispater/pendulum#7a018f2d075b03a73409e8356f9b29c9ad4ea2c5",
             ParsedUrl(
                 "https",


### PR DESCRIPTION
Poetry today does not correctly handle `poetry add 'git+https://username:password@github.com/user/repo.git'`. While we do not recommend sensitive values to be persisted in `pyptoject.toml`, `poetry.lock` or in any other locations, this is the case today when the values are manually put in the `pyproject.toml`.

Eventually, we need to figure out a way to parse the credentials and store it into the password manager and not persist it in any files that are distributed. That is largely a change in Poetry and not in core. However, there are aspects of this that should be handled here. I will follow up with another PR to handle env var credentials as specified in PEP610.

I have also removed some unused code.

Closes: #536