### PR TITLE
Fix urls entries in pyproject.toml with variable cases

### DIFF
--- a/src/poetry/core/masonry/metadata.py
+++ b/src/poetry/core/masonry/metadata.py
@@ -107,11 +107,12 @@ class Metadata:
 
         if package.urls:
             for name, url in package.urls.items():
-                if name.lower() == "homepage" and meta.home_page == url:
+                name_lower = name.lower()
+                if name_lower == "homepage" and meta.home_page == url:
                     continue
-                if name == "repository" and url == package.urls["Repository"]:
+                if name_lower == "repository" and url == package.urls.get(name):
                     continue
-                if name == "documentation" and url == package.urls["Documentation"]:
+                if name_lower == "documentation" and url == package.urls.get(name):
                     continue
 
                 meta.project_urls += (f"{name}, {url}",)

--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -117,6 +117,9 @@ class Package(PackageSpecification):
 
         self._yanked = yanked
 
+        # Currently only used for testing purposes
+        self._urls: dict[str, str] = {}
+
     @property
     def name(self) -> NormalizedName:
         return self._name
@@ -354,6 +357,9 @@ class Package(PackageSpecification):
     @property
     def urls(self) -> dict[str, str]:
         urls = {}
+
+        if self._urls:
+            return self._urls
 
         if self.homepage:
             urls["Homepage"] = self.homepage

--- a/tests/masonry/test_metadata.py
+++ b/tests/masonry/test_metadata.py
@@ -60,3 +60,53 @@ def test_from_package_readme_issues(
         Metadata.from_package(package)
 
     assert str(e.value) == message
+
+def test_from_package_urls_case_sensitive() -> None:
+    package = ProjectPackage("foo", "1.0")
+    package.homepage = "https://example.com"
+    package._urls = {
+        "Homepage": "https://example.com",
+        "Repository": "https://github.com/example/repo",
+        "Documentation": "https://docs.example.com",
+        "Other": "https://other.example.com",
+    }
+
+    metadata = Metadata.from_package(package)
+
+    # Only "Other" should be in project_urls since others are special cases
+    assert len(metadata.project_urls) == 1
+    assert metadata.project_urls[0] == "Other, https://other.example.com"
+
+
+def test_from_package_urls_case_mixed() -> None:
+    package = ProjectPackage("foo", "1.0")
+    package.homepage = "https://example.com"
+    package._urls = {
+        "homepage": "https://example.com",
+        "Repository": "https://github.com/example/repo",
+        "DOCUMENTATION": "https://docs.example.com",
+        "other": "https://other.example.com",
+    }
+
+    metadata = Metadata.from_package(package)
+
+    # Only "other" should be in project_urls since others are special cases
+    assert len(metadata.project_urls) == 1
+    assert metadata.project_urls[0] == "other, https://other.example.com"
+
+
+def test_from_package_urls_lowercase() -> None:
+    package = ProjectPackage("foo", "1.0")
+    package._urls = {
+        "homepage": "https://example.com",
+        "repository": "https://github.com/example/repo",
+        "documentation": "https://docs.example.com",
+        "other": "https://other.example.com",
+    }
+
+    metadata = Metadata.from_package(package)
+
+    # Only "other" should be in project_urls since others are special cases
+    assert len(metadata.project_urls) == 2
+    assert metadata.project_urls[0] == "homepage, https://example.com"
+    assert metadata.project_urls[1] == "other, https://other.example.com"


### PR DESCRIPTION
Came across an issue trying to `poetry install` today with `streaming-form-data` in my `pyproject.toml`. The [library's pyproject.toml](https://github.com/siddhantgoel/streaming-form-data/blob/main/pyproject.toml) uses lowercase keys for entries under `[tool.poetry.urls]`, which breaks when `Metadata.from_package` tries to build `project_urls`. Added a couple tests for upper, lower and mixed-case entries.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
