### PR TITLE
fix: Fix handling of "format" in package includes initialization

### DIFF
--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -376,7 +376,15 @@ class Factory:
             package.exclude = exclude
 
         if packages := tool_poetry.get("packages"):
-            package.packages = packages
+            packages_ = []
+            for p in packages:
+                formats = p.get("format", ["sdist", "wheel"])
+                if not isinstance(formats, list):
+                    formats = [formats]
+
+                packages_.append({**p, "format": formats})
+
+            package.packages = packages_
 
     @classmethod
     def create_dependency(

--- a/src/poetry/core/masonry/builders/builder.py
+++ b/src/poetry/core/masonry/builders/builder.py
@@ -46,23 +46,16 @@ class Builder:
     def _module(self) -> Module:
         from poetry.core.masonry.utils.module import Module
 
-        packages: list[dict[str, str | dict[str, str]]] = []
-        includes: list[dict[str, str | dict[str, str]]] = []
-        for source_list, target_list, default in [
-            (self._package.packages, packages, ["sdist", "wheel"]),
-            (self._package.include, includes, ["sdist"]),
-        ]:
-            for item in source_list:
-                # Default to including in both sdist & wheel
-                # if the `format` key is not provided.
-                formats = item.get("format", default)
-                if not isinstance(formats, list):
-                    formats = [formats]
-
-                if self.format and self.format not in formats:
-                    continue
-
-                target_list.append({**item, "format": formats})
+        packages = [
+            item
+            for item in self._package.packages
+            if not self.format or self.format in item["format"]
+        ]
+        includes = [
+            item
+            for item in self._package.include
+            if not self.format or self.format in item["format"]
+        ]
 
         return Module(
             self._package.name,

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -376,7 +376,7 @@ def test_create_poetry_with_packages_and_includes() -> None:
 
     assert package.include == [
         {"path": "extra_dir/vcs_excluded.py", "format": ["sdist", "wheel"]},
-        {"path": "notes.txt"},
+        {"path": "notes.txt", "format": ["sdist"]},
     ]
 
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -354,15 +354,24 @@ def test_create_poetry_with_packages_and_includes() -> None:
     package = poetry.package
 
     assert package.packages == [
-        {"include": "extra_dir/**/*.py"},
-        {"include": "extra_dir/**/*.py"},
-        {"include": "my_module.py"},
-        {"include": "package_with_include"},
-        {"include": "tests", "format": "sdist"},
+        {"include": "extra_dir/**/*.py", "format": ["sdist", "wheel"]},
+        {"include": "extra_dir/**/*.py", "format": ["sdist", "wheel"]},
+        {"include": "my_module.py", "format": ["sdist", "wheel"]},
+        {"include": "package_with_include", "format": ["sdist", "wheel"]},
+        {"include": "tests", "format": ["sdist"]},
         {"include": "for_wheel_only", "format": ["wheel"]},
-        {"include": "src_package", "from": "src"},
-        {"include": "from_to", "from": "etc", "to": "target_from_to"},
-        {"include": "my_module_to.py", "to": "target_module"},
+        {"include": "src_package", "from": "src", "format": ["sdist", "wheel"]},
+        {
+            "include": "from_to",
+            "from": "etc",
+            "to": "target_from_to",
+            "format": ["sdist", "wheel"],
+        },
+        {
+            "include": "my_module_to.py",
+            "to": "target_module",
+            "format": ["sdist", "wheel"],
+        },
     ]
 
     assert package.include == [


### PR DESCRIPTION
Ensure that "format" is always processed as a list when initializing package includes. If not explicit set default to sdist and wheel.

Resolves: https://github.com/python-poetry/poetry/issues/9961

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

Bug Fixes:
- Fix handling of "format" in package includes initialization.

## Summary by Sourcery

Bug Fixes:
- Resolve an issue where package includes were not correctly handled if the "format" field was not a list.