### PR TITLE
Better error messaging

### DIFF
--- a/src/poetry/core/masonry/utils/module.py
+++ b/src/poetry/core/masonry/utils/module.py
@@ -82,7 +82,9 @@ class Module:
                     )
                 )
         except KeyError as e:
-            e.add_note("It might be that you are trying to run poetry v2 with a v1 pyproject.toml")
+            e.add_note(
+                "It might be that you are trying to run poetry v2 with a v1 pyproject.toml"
+            )
             raise e
 
         for include in includes:

--- a/src/poetry/core/masonry/utils/module.py
+++ b/src/poetry/core/masonry/utils/module.py
@@ -70,17 +70,20 @@ class Module:
                     )
             default_package["format"] = ["sdist", "wheel"]
             packages = [default_package]
-
-        for package in packages:
-            self._package_includes.append(
-                PackageInclude(
-                    self._path,
-                    package["include"],
-                    formats=package["format"],
-                    source=package.get("from"),
-                    target=package.get("to"),
+        try:
+            for package in packages:
+                self._package_includes.append(
+                    PackageInclude(
+                        self._path,
+                        package["include"],
+                        formats=package["format"],
+                        source=package.get("from"),
+                        target=package.get("to"),
+                    )
                 )
-            )
+        except KeyError as e:
+            e.add_note("It might be that you are trying to run poetry v2 with a v1 pyproject.toml")
+            raise e
 
         for include in includes:
             self._explicit_includes.append(


### PR DESCRIPTION
Resolves: python-poetry#<!-- add issue number/link here -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

I just had a Gitlab pipeline fail with
```
$ poetry run some_script_that_we_defined_in_pyproject_toml
'format'
```
And that's it for the error message.

It failed because of this `formats=package["format"]` KeyError, but in the error message it didn't even mention that it was a KeyError. We didn't know it was poetry related.
I hope to save a lot of people some time by including this try/catch.

## Summary by Sourcery

Bug Fixes:
- Clarify the error message when a `KeyError` occurs during package inclusion to help users diagnose the issue faster.