### PR TITLE
PEP 753

### DIFF
--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -201,12 +201,18 @@ class Factory:
         package.dynamic_classifiers = not static_classifiers
 
         if urls := project.get("urls"):
-            package.homepage = urls.get("homepage") or urls.get("Homepage")
-            package.repository_url = urls.get("repository") or urls.get("Repository")
-            package.documentation_url = urls.get("documentation") or urls.get(
-                "Documentation"
-            )
-            package.custom_urls = urls
+            custom_urls = {}
+            for name, url in urls.items():
+                lower_name = name.lower()
+                if lower_name == "homepage":
+                    package.homepage = url
+                elif lower_name == "repository":
+                    package.repository_url = url
+                elif lower_name == "documentation":
+                    package.documentation_url = url
+                else:
+                    custom_urls[name] = url
+            package.custom_urls = custom_urls
         else:
             package.homepage = tool_poetry.get("homepage")
             package.repository_url = tool_poetry.get("repository")

--- a/src/poetry/core/masonry/builders/builder.py
+++ b/src/poetry/core/masonry/builders/builder.py
@@ -210,10 +210,6 @@ class Builder:
             summary=str(self._meta.summary),
         )
 
-        # Optional fields
-        if self._meta.home_page:
-            content += f"Home-page: {self._meta.home_page}\n"
-
         if self._meta.license:
             license_field = "License: "
             # Indentation is not only for readability, but required

--- a/src/poetry/core/masonry/metadata.py
+++ b/src/poetry/core/masonry/metadata.py
@@ -105,15 +105,8 @@ class Metadata:
 
         meta.provides_extra = list(package.extras)
 
-        if package.urls:
-            for name, url in package.urls.items():
-                if name.lower() == "homepage" and meta.home_page == url:
-                    continue
-                if name == "repository" and url == package.urls["Repository"]:
-                    continue
-                if name == "documentation" and url == package.urls["Documentation"]:
-                    continue
-
-                meta.project_urls += (f"{name}, {url}",)
+        meta.project_urls = tuple(
+            f"{name}, {url}" for name, url in package.urls.items()
+        )
 
         return meta

--- a/tests/masonry/builders/test_builder.py
+++ b/tests/masonry/builders/test_builder.py
@@ -98,7 +98,7 @@ def test_get_metadata_content() -> None:
     assert parsed["Keywords"] == "packaging,dependency,poetry"
     assert parsed["Requires-Python"] == ">=3.6,<4.0"
     assert parsed["License"] == "MIT"
-    assert parsed["Home-page"] == "https://python-poetry.org/"
+    assert parsed["Home-page"] is None
 
     classifiers = parsed.get_all("Classifier")
     assert classifiers == [
@@ -132,6 +132,7 @@ def test_get_metadata_content() -> None:
     urls = parsed.get_all("Project-URL")
     assert urls == [
         "Documentation, https://python-poetry.org/docs",
+        "Homepage, https://python-poetry.org/",
         "Issue Tracker, https://github.com/python-poetry/poetry/issues",
         "Repository, https://github.com/python-poetry/poetry",
     ]

--- a/tests/masonry/builders/test_complete.py
+++ b/tests/masonry/builders/test_complete.py
@@ -188,7 +188,6 @@ Metadata-Version: 2.3
 Name: my-package
 Version: 1.2.3
 Summary: Some description.
-Home-page: https://python-poetry.org/
 License: MIT
 Keywords: packaging,dependency,poetry
 Author: Sébastien Eustace
@@ -214,6 +213,7 @@ Requires-Dist: cleo (>=0.6,<0.7)
 Requires-Dist: pendulum (>=1.4,<2.0) ; (python_version ~= "2.7"\
  and sys_platform == "win32" or python_version in "3.4 3.5") and (extra == "time")
 Project-URL: Documentation, https://python-poetry.org/docs
+Project-URL: Homepage, https://python-poetry.org/
 Project-URL: Issue Tracker, https://github.com/python-poetry/poetry/issues
 Project-URL: Repository, https://github.com/python-poetry/poetry
 Description-Content-Type: text/x-rst

--- a/tests/masonry/test_api.py
+++ b/tests/masonry/test_api.py
@@ -154,7 +154,6 @@ Metadata-Version: 2.3
 Name: my-package
 Version: 1.2.3
 Summary: Some description.
-Home-page: https://python-poetry.org/
 License: MIT
 Keywords: packaging,dependency,poetry
 Author: Sébastien Eustace
@@ -179,6 +178,7 @@ Requires-Dist: cachy[msgpack] (>=0.2.0,<0.3.0)
 Requires-Dist: cleo (>=0.6,<0.7)
 Requires-Dist: pendulum (>=1.4,<2.0) ; (python_version ~= "2.7" and sys_platform == "win32" or python_version in "3.4 3.5") and (extra == "time")
 Project-URL: Documentation, https://python-poetry.org/docs
+Project-URL: Homepage, https://python-poetry.org/
 Project-URL: Issue Tracker, https://github.com/python-poetry/poetry/issues
 Project-URL: Repository, https://github.com/python-poetry/poetry
 Description-Content-Type: text/x-rst


### PR DESCRIPTION
Also fixes https://github.com/python-poetry/poetry/issues/9957

PEP 753 [says](https://peps.python.org/pep-0753/#metadata-producers)

> When generating metadata 1.2 or later, producers SHOULD emit only Project-URL, and SHOULD NOT emit Home-page or Download-URL fields.

since this is all kinda broken at the moment anyway - #803 etc - it is a good opportunity to fix that

Breaks a couple of downstream tests that expect "Home-page" and do not expect the "Project-URL: Homepage".  I suppose we _could_ do that horrid dance where poetry tests briefly tolerate both.  But anticipating that there will surely be new releases fairly promptly of both projects - for various bits of 2.0 fallout - perhaps we can skip that unpleasantness and tolerate the downstream tests being broken for a small window...

## Summary by Sourcery

Update metadata generation to follow PEP 753. Emit "Project-URL" instead of "Home-page" or "Download-URL".

Enhancements:
- Standardize URL handling in metadata generation.

Tests:
- Update tests to reflect the changes in URL presentation in metadata.