### PR TITLE
fix(test): mock get_vcs correctly

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
     from pytest import Config
     from pytest import Parser
+    from pytest_mock import MockerFixture
 
 
 def pytest_addoption(parser: Parser) -> None:
@@ -109,3 +110,13 @@ def python(venv: Path) -> str:
 @pytest.fixture()
 def f() -> Factory:
     return Factory()
+
+
+@pytest.fixture(autouse=True)
+def with_mocked_get_vcs(mocker: MockerFixture) -> None:
+    from poetry.core.vcs.git import Git
+
+    mocker.patch(
+        "poetry.core.vcs.git.Git.run", return_value="This is a mocked Git.run() output."
+    )
+    mocker.patch("poetry.core.vcs.get_vcs", return_value=Git())

--- a/tests/vcs/test_vcs.py
+++ b/tests/vcs/test_vcs.py
@@ -33,6 +33,12 @@ def reset_git() -> Iterator[None]:
         _reset_executable()
 
 
+@pytest.fixture(autouse=True)
+def with_mocked_get_vcs() -> None:
+    # disabled global mocking of get_vcs
+    pass
+
+
 @pytest.mark.parametrize(
     "url, normalized",
     [


### PR DESCRIPTION
Previously, the test suite relied on the test environment to be the same as that of a developer and hence implicitly providing a git boundary. This allowed for certain test cases using fixtures to fail when tests are run from the release sdist. This change mocks `get_vcs` to ensure that these cases pass as expected.

Resolves: python-poetry/poetry#9967

## Summary by Sourcery

Tests:
- Mock `get_vcs` to ensure that test cases using fixtures pass as expected when tests are run from the release sdist.