### PR TITLE
fix: ensure all poetry-dependencies are added to lock file (#9959)

### DIFF
--- a/src/poetry/core/packages/dependency_group.py
+++ b/src/poetry/core/packages/dependency_group.py
@@ -39,6 +39,7 @@ class DependencyGroup:
         for dep in self._poetry_dependencies:
             poetry_dependencies_by_name[dep.name].append(dep)
 
+        enriched_poetry_dependencies = []
         dependencies = []
         for dep in self._dependencies:
             if dep.name in poetry_dependencies_by_name:
@@ -59,9 +60,14 @@ class DependencyGroup:
                             marker = dep.marker
                         enriched = True
                         dependencies.append(_enrich_dependency(dep, poetry_dep, marker))
+                        enriched_poetry_dependencies.append(poetry_dep)
                 if not enriched:
                     dependencies.append(dep)
             else:
+                dependencies.append(dep)
+
+        for dep in self._poetry_dependencies:
+            if dep not in enriched_poetry_dependencies:
                 dependencies.append(dep)
 
         return dependencies

--- a/tests/packages/test_dependency_group.py
+++ b/tests/packages/test_dependency_group.py
@@ -347,6 +347,17 @@ def test_remove_dependency_removes_from_both_lists() -> None:
                 ),
             ],
         ),
+        (
+            [create_dependency("requests", constraint="2.32.3,<3")],
+            [
+                create_dependency("numpy", constraint="==2.2.1"),
+                create_dependency("requests", constraint="2.32.3,<3"),
+            ],
+            [
+                create_dependency("requests", constraint="2.32.3,<3"),
+                create_dependency("numpy", constraint="==2.2.1"),
+            ],
+        ),
     ],
 )
 def test_dependencies_for_locking(


### PR DESCRIPTION
Resolves: python-poetry/poetry#9959

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

Bug Fixes:
- Resolve an issue where not all poetry dependencies were added to the lock file.