### PR TITLE
fix(pyproject): relax validation for non-packages

### DIFF
--- a/tests/fixtures/non_package_mode_with_invalid_project/pyproject.toml
+++ b/tests/fixtures/non_package_mode_with_invalid_project/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+requires-python = ">=3.10,<3.13"
+
+[tool.poetry]
+package-mode = false
+
+[tool.poetry.dependencies]
+cleo = "^0.6"

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -798,6 +798,19 @@ The Poetry configuration is invalid:
     assert str(e.value) == expected
 
 
+def test_create_poetry_succeeds_for_non_package_without_required_project_metadata(
+    common_fixtures_directory: Path,
+) -> None:
+    assert (
+        Factory().create_poetry(
+            common_fixtures_directory
+            / "non_package_mode_with_invalid_project"
+            / "pyproject.toml"
+        )
+        is not None
+    )
+
+
 def test_create_poetry_fails_on_invalid_mode() -> None:
     with pytest.raises(RuntimeError) as e:
         Factory().create_poetry(


### PR DESCRIPTION
Relates-to: python-poetry/poetry#10031 python-poetry/poetry#10032

Proposing this fix to see what the team makes of this. This ensures that non-package projects do not need to adhere to strict project section requirements.

## Summary by Sourcery

Relax project metadata validation for non-package projects.

Bug Fixes:
- Fixed an issue where non-package projects were subject to the same strict project section requirements as package projects.

Tests:
- Added a test case to verify that project creation succeeds for non-package projects even without all required project metadata.