### PR TITLE
perf: add support for `AtomicMultiMarker` and `AtomicMarkerUnion` for `extra` markers

### DIFF
--- a/src/poetry/core/constraints/generic/__init__.py
+++ b/src/poetry/core/constraints/generic/__init__.py
@@ -6,6 +6,7 @@ from poetry.core.constraints.generic.constraint import Constraint
 from poetry.core.constraints.generic.empty_constraint import EmptyConstraint
 from poetry.core.constraints.generic.multi_constraint import MultiConstraint
 from poetry.core.constraints.generic.parser import parse_constraint
+from poetry.core.constraints.generic.parser import parse_extra_constraint
 from poetry.core.constraints.generic.union_constraint import UnionConstraint
 
 
@@ -17,4 +18,5 @@ __all__ = (
     "MultiConstraint",
     "UnionConstraint",
     "parse_constraint",
+    "parse_extra_constraint",
 )

--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -161,9 +161,12 @@ class Dependency(PackageSpecification):
                 for op, extra in or_:
                     if op == "==":
                         new_in_extras.append(canonicalize_name(extra))
-                    elif op == "" and "||" in extra:
-                        for _extra in extra.split(" || "):
-                            new_in_extras.append(canonicalize_name(_extra))
+                    elif op == "" and ("||" in extra or "," in extra):
+                        sep = "||" if "||" in extra else ","
+                        extra_values = [e.strip() for e in extra.split(sep)]
+                        for _extra in extra_values:
+                            if not _extra.startswith("!="):
+                                new_in_extras.append(canonicalize_name(_extra))
             self._in_extras = [*self._in_extras, *new_in_extras]
 
         # Recalculate python versions.

--- a/tests/constraints/generic/test_main.py
+++ b/tests/constraints/generic/test_main.py
@@ -7,10 +7,13 @@ from poetry.core.constraints.generic import Constraint
 from poetry.core.constraints.generic import MultiConstraint
 from poetry.core.constraints.generic import UnionConstraint
 from poetry.core.constraints.generic import parse_constraint
+from poetry.core.constraints.generic.constraint import ExtraConstraint
+from poetry.core.constraints.generic.multi_constraint import ExtraMultiConstraint
+from poetry.core.constraints.generic.parser import parse_extra_constraint
 
 
 @pytest.mark.parametrize(
-    "input,constraint",
+    ("input", "constraint"),
     [
         ("*", AnyConstraint()),
         ("win32", Constraint("win32", "=")),
@@ -27,7 +30,7 @@ def test_parse_constraint(input: str, constraint: AnyConstraint | Constraint) ->
 
 
 @pytest.mark.parametrize(
-    "input,constraint",
+    ("input", "constraint"),
     [
         (
             "!=win32,!=linux",
@@ -55,7 +58,7 @@ def test_parse_constraint_multi(input: str, constraint: MultiConstraint) -> None
 
 
 @pytest.mark.parametrize(
-    "input,constraint",
+    ("input", "constraint"),
     [
         ("win32 || linux", UnionConstraint(Constraint("win32"), Constraint("linux"))),
         (
@@ -70,3 +73,76 @@ def test_parse_constraint_multi(input: str, constraint: MultiConstraint) -> None
 )
 def test_parse_constraint_union(input: str, constraint: UnionConstraint) -> None:
     assert parse_constraint(input) == constraint
+
+
+def test_constraint_is_not_equal_to_extra_constraint() -> None:
+    constraint = Constraint("a", "=")
+    extra_constraint = ExtraConstraint("a", "=")
+    assert constraint != extra_constraint
+    assert extra_constraint != constraint
+
+
+@pytest.mark.parametrize(
+    ("input", "constraint"),
+    [
+        ("*", AnyConstraint()),
+        ("extra1", ExtraConstraint("extra1", "=")),
+        ("=extra1", ExtraConstraint("extra1", "=")),
+        ("==extra1", ExtraConstraint("extra1", "=")),
+        ("!=extra1", ExtraConstraint("extra1", "!=")),
+        ("!= extra1", ExtraConstraint("extra1", "!=")),
+    ],
+)
+def test_parse_extra_constraint(
+    input: str, constraint: AnyConstraint | Constraint
+) -> None:
+    parsed_constraint = parse_extra_constraint(input)
+
+    assert type(parsed_constraint) is type(constraint)
+    assert parsed_constraint == constraint
+
+
+@pytest.mark.parametrize(
+    ("input", "constraint"),
+    [
+        (
+            "!=extra1,!=extra2",
+            ExtraMultiConstraint(
+                ExtraConstraint("extra1", "!="), ExtraConstraint("extra2", "!=")
+            ),
+        ),
+        (
+            "==extra1,==extra2",
+            ExtraMultiConstraint(
+                ExtraConstraint("extra1", "=="), ExtraConstraint("extra2", "==")
+            ),
+        ),
+        (
+            "==extra1,!=extra2,==extra3",
+            ExtraMultiConstraint(
+                ExtraConstraint("extra1", "=="),
+                ExtraConstraint("extra2", "!="),
+                ExtraConstraint("extra3", "=="),
+            ),
+        ),
+    ],
+)
+def test_parse_extra_constraint_multi(input: str, constraint: MultiConstraint) -> None:
+    assert parse_extra_constraint(input) == constraint
+
+
+@pytest.mark.parametrize(
+    ("input", "constraint"),
+    [
+        (
+            "extra1 || extra2",
+            UnionConstraint(ExtraConstraint("extra1"), ExtraConstraint("extra2")),
+        ),
+        (
+            "extra1 || !=extra2",
+            UnionConstraint(ExtraConstraint("extra1"), ExtraConstraint("extra2", "!=")),
+        ),
+    ],
+)
+def test_parse_extra_constraint_union(input: str, constraint: UnionConstraint) -> None:
+    assert parse_extra_constraint(input) == constraint

--- a/tests/packages/test_main.py
+++ b/tests/packages/test_main.py
@@ -56,6 +56,16 @@ def test_dependency_from_pep_508_with_extras() -> None:
     assert str(dep.marker) == 'extra == "foo" or extra == "bar"'
 
 
+def test_dependency_from_pep_508_with_extra_and_inverse_extra() -> None:
+    name = 'requests==2.18.0; extra != "foo" and extra == "bar"'
+    dep = Dependency.create_from_pep_508(name)
+
+    assert dep.name == "requests"
+    assert str(dep.constraint) == "2.18.0"
+    assert dep.in_extras == ["bar"]
+    assert str(dep.marker) == 'extra != "foo" and extra == "bar"'
+
+
 def test_dependency_from_pep_508_with_python_version() -> None:
     name = 'requests (==2.18.0); python_version == "2.7" or python_version == "2.6"'
     dep = Dependency.create_from_pep_508(name)

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -59,10 +59,12 @@ EMPTY = "<empty>"
         'extra == "a" and extra != "b"',
         'extra != "a" and extra == "b"',
         'extra != "a" and extra != "b"',
+        'extra == "a" and extra == "b" and extra != "c" and extra != "d"',
         'extra == "a" or extra == "b"',
         'extra == "a" or extra != "b"',
         'extra != "a" or extra == "b"',
         'extra != "a" or extra != "b"',
+        'extra == "a" or extra == "b" or extra != "c" or extra != "d"',
         # String comparison markers
         '"tegra" in platform_release',
         '"tegra" not in platform_release',
@@ -250,6 +252,98 @@ def test_single_marker_not_in_python_intersection() -> None:
         ('extra == "a"', 'extra != "b"', 'extra == "a" and extra != "b"'),
         ('extra != "a"', 'extra == "b"', 'extra != "a" and extra == "b"'),
         ('extra != "a"', 'extra != "b"', 'extra != "a" and extra != "b"'),
+        # AtomicMultiMarker
+        (
+            'extra == "a" and extra == "b"',
+            'extra == "c"',
+            'extra == "a" and extra == "b" and extra == "c"',
+        ),
+        (
+            'extra != "a" and extra != "b"',
+            'extra != "c"',
+            'extra != "a" and extra != "b" and extra != "c"',
+        ),
+        (
+            'extra != "a" and extra != "b"',
+            'extra == "c"',
+            'extra != "a" and extra != "b" and extra == "c"',
+        ),
+        (
+            'extra == "a" and extra == "b"',
+            'extra != "c"',
+            'extra == "a" and extra == "b" and extra != "c"',
+        ),
+        (
+            'extra == "a" and extra == "b"',
+            'extra == "a" and extra == "b"',
+            'extra == "a" and extra == "b"',
+        ),
+        (
+            'extra == "a" and extra == "b"',
+            'extra == "b" and extra == "a"',
+            'extra == "a" and extra == "b"',
+        ),
+        (
+            'extra == "a" and extra == "b"',
+            'extra == "c" and extra != "d"',
+            'extra == "a" and extra == "b" and extra == "c" and extra != "d"',
+        ),
+        ('extra != "a" and extra != "b"', 'extra == "a"', "<empty>"),
+        ('extra != "a" and extra == "b"', 'extra == "a" and extra == "c"', "<empty>"),
+        (
+            'extra != "a" and extra != "b"',
+            'extra != "a"',
+            'extra != "a" and extra != "b"',
+        ),
+        (
+            'extra == "a" and extra != "b"',
+            'extra == "a"',
+            'extra == "a" and extra != "b"',
+        ),
+        # AtomicMarkerUnion
+        (
+            'extra == "a" or extra == "b"',
+            'extra == "c"',
+            '(extra == "a" or extra == "b") and extra == "c"',
+        ),
+        (
+            'extra == "a" or extra == "b"',
+            'extra != "c"',
+            '(extra == "a" or extra == "b") and extra != "c"',
+        ),
+        ('extra == "a" or extra == "b"', 'extra == "a"', 'extra == "a"'),
+        ('extra != "a" or extra == "b"', 'extra != "a"', 'extra != "a"'),
+        (
+            'extra == "a" or extra == "b"',
+            'extra != "a"',
+            'extra == "b" and extra != "a"',
+        ),
+        (
+            'extra == "a" or extra == "b"',
+            'extra == "a" or extra == "b"',
+            'extra == "a" or extra == "b"',
+        ),
+        (
+            'extra == "a" or extra == "b"',
+            'extra == "b" or extra == "a"',
+            'extra == "a" or extra == "b"',
+        ),
+        (
+            'extra == "a" or extra == "b"',
+            'extra == "a" or extra != "c"',
+            '(extra == "a" or extra == "b") and (extra == "a" or extra != "c")',
+        ),
+        # AtomicMultiMarker and AtomicMarkerUnion
+        (
+            'extra != "a" and extra != "b"',
+            'extra == "a" or extra == "b"',
+            "<empty>",
+        ),
+        (
+            'extra != "a" and extra != "b"',
+            'extra == "a" or extra == "c"',
+            'extra == "c" and extra != "a" and extra != "b"',
+        ),
     ],
 )
 def test_single_marker_intersect_extras(
@@ -443,6 +537,104 @@ def test_single_marker_union_with_inverse() -> None:
         ('extra == "a"', 'extra != "b"', 'extra == "a" or extra != "b"'),
         ('extra != "a"', 'extra == "b"', 'extra != "a" or extra == "b"'),
         ('extra != "a"', 'extra != "b"', 'extra != "a" or extra != "b"'),
+        # AtomicMultiMarker
+        (
+            'extra == "a" and extra == "b"',
+            'extra == "c"',
+            'extra == "a" and extra == "b" or extra == "c"',
+        ),
+        (
+            'extra != "a" and extra != "b"',
+            'extra != "c"',
+            'extra != "a" and extra != "b" or extra != "c"',
+        ),
+        (
+            'extra != "a" and extra != "b"',
+            'extra == "c"',
+            'extra != "a" and extra != "b" or extra == "c"',
+        ),
+        (
+            'extra == "a" and extra == "b"',
+            'extra != "c"',
+            'extra == "a" and extra == "b" or extra != "c"',
+        ),
+        (
+            'extra == "a" and extra == "b"',
+            'extra == "a" and extra == "b"',
+            'extra == "a" and extra == "b"',
+        ),
+        (
+            'extra == "a" and extra == "b"',
+            'extra == "c" and extra != "d"',
+            'extra == "a" and extra == "b" or extra == "c" and extra != "d"',
+        ),
+        (
+            'extra != "a" and extra != "b"',
+            'extra == "a"',
+            'extra != "b" or extra == "a"',
+        ),
+        (
+            'extra != "a" and extra == "b"',
+            'extra == "a" and extra == "c"',
+            'extra != "a" and extra == "b" or extra == "a" and extra == "c"',
+        ),
+        (
+            'extra != "a" and extra != "b"',
+            'extra != "a"',
+            'extra != "a"',
+        ),
+        (
+            'extra == "a" and extra != "b"',
+            'extra == "a"',
+            'extra == "a"',
+        ),
+        # AtomicMarkerUnion
+        (
+            'extra == "a" or extra == "b"',
+            'extra == "c"',
+            'extra == "a" or extra == "b" or extra == "c"',
+        ),
+        (
+            'extra == "a" or extra == "b"',
+            'extra != "c"',
+            'extra == "a" or extra == "b" or extra != "c"',
+        ),
+        (
+            'extra == "a" or extra == "b"',
+            'extra == "a"',
+            'extra == "a" or extra == "b"',
+        ),
+        (
+            'extra != "a" or extra == "b"',
+            'extra != "a"',
+            'extra != "a" or extra == "b"',
+        ),
+        (
+            'extra == "a" or extra == "b"',
+            'extra != "a"',
+            "",
+        ),
+        (
+            'extra == "a" or extra == "b"',
+            'extra == "a" or extra == "b"',
+            'extra == "a" or extra == "b"',
+        ),
+        (
+            'extra == "a" or extra == "b"',
+            'extra == "a" or extra != "c"',
+            'extra == "a" or extra == "b" or extra != "c"',
+        ),
+        # AtomicMultiMarker and AtomicMarkerUnion
+        (
+            'extra != "a" and extra != "b"',
+            'extra == "a" or extra == "b"',
+            'extra != "a" and extra != "b" or extra == "a" or extra == "b"',
+        ),
+        (
+            'extra != "a" and extra != "b"',
+            'extra == "a" or extra == "c"',
+            'extra != "a" and extra != "b" or extra == "a" or extra == "c"',
+        ),
     ],
 )
 def test_single_marker_union_extras(marker1: str, marker2: str, expected: str) -> None:


### PR DESCRIPTION
Relates to: python-poetry/poetry#9956

The downstream failures are caused by cosmetic changes. The tests are fixed in python-poetry/poetry#10073. We should probably merge this PR with failing downstream tests and switch from the released poetry-core version to the main branch afterwards.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

This seems to mostly fix the performance regression reported in python-poetry/poetry#9956 - at least for the simplified repro. It might still not be enough for the real world examples...

Using the simplified repro from https://github.com/python-poetry/poetry/issues/9956#issuecomment-2573922549, Poetry 1.8 can solve it in 0.2 s, no matter if there is only one extra or 14 extras. Poetry 2 takes longer the more extras are defined:

```toml
[tool.poetry.dependencies]
python = ">=3.8,<3.11"
opencv-python = {version = "^4.6.0.66", optional = true}
ale-py = { version = "0.8.1", optional = true }

[tool.poetry.extras]
extra01 = ["ale-py"]
extra02 = ["ale-py"]
extra03 = ["ale-py"]
# ...
```

number of extras|poetry 2.0.1|PR
---|---|---
1|0.5 s|0.5 s
2|1.7 s|0.6 s
3|6.4 s|0.6 s
4|19 s|0.6 s
5|57 s|0.6 s
...|...|...
14|?|0.7 s

## Summary by Sourcery

Tests:
- Add tests for the new extra markers logic.