### PR TITLE
Remove unused folder in test

### DIFF
--- a/tests/masonry/builders/test_builder.py
+++ b/tests/masonry/builders/test_builder.py
@@ -285,10 +285,6 @@ def test_builder_convert_entry_points(
     "fixture, result",
     [
         (
-            "script_callable_legacy_table",
-            [],
-        ),
-        (
             "script_callable_legacy_string",
             [],
         ),


### PR DESCRIPTION
Lot of logic was removed in PR#702 and this was missed.

This commit remove in that particular test the folder that does not exists.

## Summary by Sourcery

Tests:
- Remove the `script_callable_legacy_table` test fixture which is no longer used.