### PR TITLE
Pyproject validation: report an error when a license file does not exist

### DIFF
--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -584,7 +584,9 @@ class Factory:
             if isinstance(license_data, dict) and "file" in license_data:
                 license_path: str = license_data["file"]
                 if not Path(license_path).exists():
-                    result["errors"].append(f"project.license.file must be a valid file: {license_path}")
+                    result["errors"].append(
+                        f"project.license.file must be a valid file: {license_path}"
+                    )
 
         # With PEP 621 [tool.poetry] is not mandatory anymore. We still create and
         # validate it so that default values (e.g. for package-mode) are set.

--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -577,6 +577,15 @@ class Factory:
                 for e in validate_object(project, "project-schema")
             ]
             result["errors"] += project_validation_errors
+
+        # Ensure license file exists, if project.license.file is set
+        if project is not None and project.get("license") is not None:
+            license_data = project.get("license")
+            if isinstance(license_data, dict) and "file" in license_data:
+                license_path: str = license_data["file"]
+                if not Path(license_path).exists():
+                    result["errors"].append("project.license.file must be a valid file")
+
         # With PEP 621 [tool.poetry] is not mandatory anymore. We still create and
         # validate it so that default values (e.g. for package-mode) are set.
         tool_poetry = toml_data.setdefault("tool", {}).setdefault("poetry", {})

--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -584,7 +584,7 @@ class Factory:
             if isinstance(license_data, dict) and "file" in license_data:
                 license_path: str = license_data["file"]
                 if not Path(license_path).exists():
-                    result["errors"].append("project.license.file must be a valid file")
+                    result["errors"].append(f"project.license.file must be a valid file: {license_path}")
 
         # With PEP 621 [tool.poetry] is not mandatory anymore. We still create and
         # validate it so that default values (e.g. for package-mode) are set.

--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -582,10 +582,10 @@ class Factory:
         if project is not None and project.get("license") is not None:
             license_data = project.get("license")
             if isinstance(license_data, dict) and "file" in license_data:
-                license_path: str = license_data["file"]
-                if not Path(license_path).exists():
+                license_path = Path(license_data["file"]).absolute()
+                if not license_path.exists():
                     result["errors"].append(
-                        f"project.license.file must be a valid file: {license_path}"
+                        f"project.license.file '{license_path}' does not exist"
                     )
 
         # With PEP 621 [tool.poetry] is not mandatory anymore. We still create and

--- a/tests/fixtures/missing_license_file/pyproject.toml
+++ b/tests/fixtures/missing_license_file/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "my-package"
+version = "0.1"
+license = { file = "LICENSE" } # License file is intentionally missing
+keywords = ["special"]         # field that comes after license in core metadata

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -642,9 +642,10 @@ def test_validate_missing_license_file() -> None:
     with complete.open("rb") as f:
         content = tomllib.load(f)
 
-    expected = "project.license.file must be a valid file"
-
     with temporary_cd(complete.parent):
+        license_path = Path(content["project"]["license"]["file"]).absolute()
+        expected = f"project.license.file '{license_path}' does not exist"
+
         assert Factory.validate(content) == {"errors": [expected], "warnings": []}
 
 

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import sys
@@ -27,6 +28,23 @@ __toml_build_backend_patch__ = {
         "build-backend": "poetry.core.masonry.api",
     }
 }
+
+
+@contextmanager
+def temporary_cd(path: Path) -> Generator[None, None, None]:
+    """
+    Context manager that temporarily CDs into the given directory.
+
+    Once the context exits, the cwd is returned to its previous state.
+
+    :param path: Path to cd into.
+    """
+    old_path = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(old_path)
 
 
 @contextmanager


### PR DESCRIPTION
Resolves: [python-poetry#10105](https://github.com/python-poetry/poetry/issues/10105)

My first Poetry contribution!

* I've placed this inside the standard (not strict) checks intentionally, since otherwise errors occur later on in Poetry due to it expecting the file to exist.
* I needed to add a `temporary_cd` context manager to the `testutils` module. Is there a better way of doing this?
* The code for checking the property's validity felt extremely convoluted to me. If anyone can think of a cleaner way to write it, I'd love some suggestions.
* This fix could be a band-aid rather than a proper solution. While it should prevent the confusing error described in the original issue, the fact that file-system checking is done during non-strict validation doesn't feel right to me. Would it be better to instead patch code that expects the license file to be valid for seemingly unimportant operations (eg `poetry run pytest` as per the original comment)?

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

Tests:
- Added tests for license file validation.