### PR TITLE
simplify `python_version` markers

### DIFF
--- a/tests/masonry/builders/test_sdist.py
+++ b/tests/masonry/builders/test_sdist.py
@@ -108,11 +108,10 @@ def test_convert_dependencies() -> None:
     main = ["B>=1.0,<1.1"]
 
     extra_python = (
-        ':python_version >= "2.7" and python_version < "2.8" '
-        'or python_version >= "3.6" and python_version < "4.0"'
+        ':python_version == "2.7" or python_version >= "3.6" and python_version < "4.0"'
     )
     extra_d_dependency = (
-        'baz:python_version >= "2.7" and python_version < "2.8" '
+        'baz:python_version == "2.7" '
         'or python_version >= "3.4" and python_version < "4.0"'
     )
     extras = {extra_python: ["C==1.2.3"], extra_d_dependency: ["D==3.4.5"]}

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -55,7 +55,7 @@ def test_to_pep_508() -> None:
     result = dependency.to_pep_508()
     assert (
         result == "Django (>=1.23,<2.0) ; "
-        'python_version >= "2.7" and python_version < "2.8" '
+        'python_version == "2.7" '
         'or python_version >= "3.6" and python_version < "4.0"'
     )
 
@@ -88,7 +88,7 @@ def test_to_pep_508_in_extras() -> None:
     assert (
         result == "Django (>=1.23,<2.0) ; "
         "("
-        'python_version >= "2.7" and python_version < "2.8" '
+        'python_version == "2.7" '
         'or python_version >= "3.6" and python_version < "4.0"'
         ") "
         'and (extra == "foo" or extra == "bar")'
@@ -97,7 +97,7 @@ def test_to_pep_508_in_extras() -> None:
     result = dependency.to_pep_508(with_extras=False)
     assert (
         result == "Django (>=1.23,<2.0) ; "
-        'python_version >= "2.7" and python_version < "2.8" '
+        'python_version == "2.7" '
         'or python_version >= "3.6" and python_version < "4.0"'
     )
 

--- a/tests/packages/test_main.py
+++ b/tests/packages/test_main.py
@@ -176,11 +176,8 @@ def test_dependency_from_pep_508_with_python_version_union_of_multi() -> None:
     assert dep.name == "requests"
     assert str(dep.constraint) == "2.18.0"
     assert dep.extras == frozenset()
-    assert dep.python_versions == ">=2.7 <2.8 || >=3.4 <3.5"
-    assert (
-        str(dep.marker) == 'python_version >= "2.7" and python_version < "2.8" '
-        'or python_version >= "3.4" and python_version < "3.5"'
-    )
+    assert dep.python_versions == "~2.7 || ~3.4"
+    assert str(dep.marker) == 'python_version == "2.7" or python_version == "3.4"'
 
 
 def test_dependency_from_pep_508_with_not_in_op_marker() -> None:
@@ -294,9 +291,9 @@ def test_dependency_from_pep_508_with_python_full_version() -> None:
     assert dep.name == "requests"
     assert str(dep.constraint) == "2.18.0"
     assert dep.extras == frozenset()
-    assert dep.python_versions == ">=2.7 <2.8 || >=3.4.0 <3.5.4"
+    assert dep.python_versions == "~2.7 || >=3.4.0 <3.5.4"
     assert (
-        str(dep.marker) == 'python_version >= "2.7" and python_version < "2.8" '
+        str(dep.marker) == 'python_version == "2.7" '
         'or python_full_version >= "3.4.0" and python_full_version < "3.5.4"'
     )
 

--- a/tests/version/test_requirements.py
+++ b/tests/version/test_requirements.py
@@ -103,10 +103,7 @@ def assert_requirement(
             {
                 "name": "foo",
                 "constraint": ">=1.2.3",
-                "marker": (
-                    'python_version >= "2.7" and python_version < "2.8" or'
-                    ' python_version >= "3.4" and python_version < "3.5"'
-                ),
+                "marker": ('python_version == "2.7" or python_version == "3.4"'),
             },
         ),
         (


### PR DESCRIPTION
Examples of new simplifications:

- `python_version >= "3.8" and python_version < "3.9"` -> `python_version == "3.8"`
-  `python_version == "3.8" or python_version >= "3.9"` -> `python_version >= "3.8"`

The downstream failures are caused by cosmetic changes. The tests are fixed in python-poetry/poetry#10110. We should probably merge this PR with failing downstream tests and switch from the released poetry-core version to the main branch afterwards.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Testing with the `pyproject.toml` from https://github.com/python-poetry/poetry/issues/9956#issuecomment-2582451109:

poetry version|lock (--regenerate)|lock (--no-update)
---|---|---
main|131 s|20 s
PR|101 s|19 s

## Summary by Sourcery

Tests:
- Added tests for the simplified version markers.