### PR TITLE
Package metadata: give more-descriptive error when license file not found

### DIFF
--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import Literal
 from typing import Union
+from typing import cast
 
 from packaging.utils import canonicalize_name
 
@@ -182,9 +183,14 @@ class Factory:
             else:
                 raw_license = project_license.get("text", "")
                 if not raw_license and (
-                    license_file := project_license.get("file", "")
+                    license_file := cast(str, project_license.get("file", ""))
                 ):
-                    raw_license = (root / license_file).read_text(encoding="utf-8")
+                    license_path = (root / license_file).absolute()
+                    if not license_path.is_file():
+                        raise FileNotFoundError(
+                            f"Poetry: license file '{license_path}' does not exist"
+                        )
+                    raw_license = license_path.read_text(encoding="utf-8")
         else:
             raw_license = tool_poetry.get("license", "")
         try:

--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -185,12 +185,15 @@ class Factory:
                 if not raw_license and (
                     license_file := cast(str, project_license.get("file", ""))
                 ):
-                    license_path = (root / license_file).absolute()
-                    if not license_path.is_file():
-                        raise FileNotFoundError(
-                            f"Poetry: license file '{license_path}' does not exist"
+                    try:
+                        raw_license = Path(root / license_file).read_text(
+                            encoding="utf-8"
                         )
-                    raw_license = license_path.read_text(encoding="utf-8")
+                    except FileNotFoundError as e:
+                        license_path = (root / license_file).absolute()
+                        raise FileNotFoundError(
+                            f"Poetry: license file '{license_path}' not found"
+                        ) from e
         else:
             raw_license = tool_poetry.get("license", "")
         try:

--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -185,12 +185,10 @@ class Factory:
                 if not raw_license and (
                     license_file := cast(str, project_license.get("file", ""))
                 ):
+                    license_path = (root / license_file).absolute()
                     try:
-                        raw_license = Path(root / license_file).read_text(
-                            encoding="utf-8"
-                        )
+                        raw_license = Path(license_path).read_text(encoding="utf-8")
                     except FileNotFoundError as e:
-                        license_path = (root / license_file).absolute()
                         raise FileNotFoundError(
                             f"Poetry: license file '{license_path}' not found"
                         ) from e

--- a/tests/fixtures/missing_license_file/pyproject.toml
+++ b/tests/fixtures/missing_license_file/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "my-package"
+version = "0.1"
+license = { file = "LICENSE" }  # This file is intentionally missing
+keywords = ["special"]  # field that comes after license in core metadata

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -421,6 +421,14 @@ def test_create_poetry_with_license_type_file(license_type: str) -> None:
     assert poetry.package.license.id == license_content
 
 
+def test_create_poetry_fails_with_missing_license_file() -> None:
+    project_dir = fixtures_dir / "missing_license_file"
+    with pytest.raises(FileNotFoundError) as e:
+        Factory().create_poetry(project_dir)
+
+    assert str((project_dir / "LICENSE").absolute()) in str(e.value)
+
+
 @pytest.mark.parametrize(
     ("requires_python", "python", "expected_versions", "expected_constraint"),
     [


### PR DESCRIPTION
Resolves: [python-poetry#10105](https://github.com/python-poetry/poetry/issues/10105)

This is a second (much simpler) attempt at solving this issue. My first can be found at #825, and is massively more complex.

This time, the change is in `Factory._configure_package_metadata`, and just adds a `FileNotFoundError` exception. Much easier to comprehend.

One thing I want to check is how this error is reported by poetry's main CLI. I want to make sure that the detail of the error is properly conveyed in the CLI. Does anyone have advice on how I can test my modifications against the Poetry CLI?

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

Raise a FileNotFoundError when the license file specified in pyproject.toml is not found.

Bug Fixes:
- Fixed an issue where Poetry did not report an error when the license file was missing.

Tests:
- Added a test case to verify that a FileNotFoundError is raised when the license file is missing.