### PR TITLE
perf: cache parsed requirements

### DIFF
--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -350,7 +350,7 @@ class Dependency(PackageSpecification):
         from poetry.core.packages.vcs_dependency import VCSDependency
         from poetry.core.utils.patterns import wheel_file_re
         from poetry.core.vcs.git import ParsedUrl
-        from poetry.core.version.requirements import Requirement
+        from poetry.core.version.requirements import parse_requirement
 
         # Removing comments
         parts = name.split(" #", 1)
@@ -360,7 +360,7 @@ class Dependency(PackageSpecification):
             if " ;" in rest:
                 name += " ;" + rest.split(" ;", 1)[1]
 
-        req = Requirement(name)
+        req = parse_requirement(name)
 
         name = req.name
         link = None
@@ -495,7 +495,7 @@ def _make_file_or_dir_dep(
     path: Path,
     base: Path | None = None,
     subdirectory: str | None = None,
-    extras: list[str] | None = None,
+    extras: Iterable[str] | None = None,
 ) -> FileDependency | DirectoryDependency | None:
     """
     Helper function to create a file or directoru dependency with the given arguments.

--- a/src/poetry/core/version/requirements.py
+++ b/src/poetry/core/version/requirements.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
+import functools
 import urllib.parse as urlparse
+
+from typing import TYPE_CHECKING
 
 from poetry.core.constraints.version import parse_constraint
 from poetry.core.constraints.version.exceptions import ParseConstraintError
 from poetry.core.version.grammars import GRAMMAR_PEP_508_CONSTRAINTS
 from poetry.core.version.markers import _compact_markers
 from poetry.core.version.parser import Parser
+
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class InvalidRequirementError(ValueError):
@@ -61,7 +68,9 @@ class Requirement:
         else:
             self.url = None
 
-        self.extras = [e.value for e in parsed.scan_values(lambda t: t.type == "EXTRA")]
+        self.extras: Sequence[str] = [
+            e.value for e in parsed.scan_values(lambda t: t.type == "EXTRA")
+        ]
         constraint = next(parsed.find_data("version_specification"), None)
         constraint = ",".join(constraint.children) if constraint else "*"
 
@@ -102,3 +111,8 @@ class Requirement:
 
     def __repr__(self) -> str:
         return f"<Requirement({str(self)!r})>"
+
+
+@functools.cache
+def parse_requirement(requirement_string: str) -> Requirement:
+    return Requirement(requirement_string)


### PR DESCRIPTION
<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Caching the requirements should be safe because we use them read-only.

Testing with the `pyproject.toml` from https://github.com/python-poetry/poetry/issues/9956#issuecomment-2582451109:

poetry version|lock (--regenerate)|lock (--no-update)
---|---|---
main|98 s|17.5 s
PR|73 s|11.5 s

## Summary by Sourcery

Cache parsed requirement strings to improve performance, especially when regenerating lock files.

Enhancements:
- Cache requirement strings using `functools.cache`.

Tests:
- Added tests to verify the caching behavior and ensure there are no regressions.