### PR TITLE
fix(metadata): ignore optional deps not part of an extra

### DIFF
--- a/src/poetry/core/masonry/metadata.py
+++ b/src/poetry/core/masonry/metadata.py
@@ -95,7 +95,11 @@ class Metadata:
         elif package.python_versions != "*":
             meta.requires_python = format_python_constraint(package.python_constraint)
 
-        meta.requires_dist = [d.to_pep_508() for d in package.requires]
+        meta.requires_dist = [
+            d.to_pep_508()
+            for d in package.requires
+            if not d.is_optional() or d.in_extras
+        ]
 
         # Version 2.1
         if package.readme_content_type:

--- a/tests/masonry/builders/fixtures/with_optional_without_extras/pyproject.toml
+++ b/tests/masonry/builders/fixtures/with_optional_without_extras/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "my-packager"
+description = "Something"
+version = "0.1"
+classifiers = [
+    "Topic :: Software Development :: Build Tools",
+    "Topic :: Software Development :: Libraries :: Python Modules"
+]
+dynamic = ["dependencies"]
+
+[tool.poetry.dependencies]
+requests = { version = "^0.28.1", optional = true }
+httpx = { version = "^0.28.1", optional = true }
+grpcio = { version = "^0.2.0" }
+pycowsay = { version = "^0.1.0" }
+
+[tool.poetry.extras]
+http = ["httpx"]
+grpc = ["grpcio"]

--- a/tests/masonry/test_api.py
+++ b/tests/masonry/test_api.py
@@ -313,6 +313,34 @@ My Package
             assert f.read() == metadata
 
 
+def test_prepare_metadata_excludes_optional_without_extras() -> None:
+    with (
+        temporary_directory() as tmp_dir,
+        cwd(fixtures / "with_optional_without_extras"),
+    ):
+        dirname = api.prepare_metadata_for_build_wheel(str(tmp_dir))
+        dist_info = Path(tmp_dir, dirname)
+        assert (dist_info / "METADATA").exists()
+
+        with (dist_info / "METADATA").open(encoding="utf-8") as f:
+            assert (
+                f.read()
+                == """\
+Metadata-Version: 2.3
+Name: my-packager
+Version: 0.1
+Summary: Something
+Classifier: Topic :: Software Development :: Build Tools
+Classifier: Topic :: Software Development :: Libraries :: Python Modules
+Provides-Extra: grpc
+Provides-Extra: http
+Requires-Dist: grpcio (>=0.2.0,<0.3.0) ; extra == "grpc"
+Requires-Dist: httpx (>=0.28.1,<0.29.0) ; extra == "http"
+Requires-Dist: pycowsay (>=0.1.0,<0.2.0)
+"""
+            )
+
+
 def test_prepare_metadata_for_build_wheel_with_bad_path_dev_dep_succeeds() -> None:
     with temporary_directory() as tmp_dir, cwd(fixtures / "with_bad_path_dev_dep"):
         api.prepare_metadata_for_build_wheel(str(tmp_dir))


### PR DESCRIPTION
Resolves: python-poetry/poetry#2357

## Summary by Sourcery

Ignore optional dependencies that are not part of an extra when building a wheel.

Bug Fixes:
- Fixed a bug where optional dependencies that are not part of an extra were included in the wheel metadata.

Tests:
- Added a test to verify that optional dependencies without extras are excluded from the metadata.