### PR TITLE
chore(ci): run pre-commit on licence update

### DIFF
--- a/.github/workflows/update-licenses.yaml
+++ b/.github/workflows/update-licenses.yaml
@@ -35,6 +35,7 @@ jobs:
       - name: Update licenses list
         run: |
           poetry run python src/poetry/core/spdx/helpers.py
+          poetry run pre-commit run --all-files || :
 
       - name: Generate token
         id: generate_token


### PR DESCRIPTION
Closes: #829

## Summary by Sourcery

CI:
- Run pre-commit on licence update.