### PR TITLE
fix endless recursion introduced in #821

### DIFF
--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -2191,6 +2191,30 @@ def test_intersection_avoids_combinatorial_explosion() -> None:
     )
 
 
+def test_intersection_no_endless_recursion() -> None:
+    m1 = parse_marker(
+        '(python_version < "3.9" or extra != "bigquery" and extra != "parquet"'
+        ' and extra != "motherduck" and extra != "athena" and extra != "synapse"'
+        ' and extra != "clickhouse" and extra != "dremio" and extra != "lancedb"'
+        ' and extra != "deltalake" and extra != "pyiceberg"'
+        ' and python_version < "3.13") and extra != "postgres" and extra != "redshift"'
+        ' and extra != "postgis"'
+    )
+    m2 = parse_marker(
+        'python_version > "3.12" and python_version < "3.13" or extra != "databricks"'
+    )
+    expected = (
+        '(python_version < "3.9" or extra != "bigquery" and extra != "parquet"'
+        ' and extra != "motherduck" and extra != "athena" and extra != "synapse"'
+        ' and extra != "clickhouse" and extra != "dremio" and extra != "lancedb"'
+        ' and extra != "deltalake" and extra != "pyiceberg")'
+        ' and python_version < "3.13" and extra != "postgres" and extra != "redshift"'
+        ' and extra != "postgis" and (python_version > "3.12"'
+        ' and python_version < "3.13" or extra != "databricks")'
+    )
+    assert str(m1.intersect(m2)) == expected
+
+
 @pytest.mark.parametrize(
     "python_version, python_full_version, "
     "expected_intersection_version, expected_union_version",


### PR DESCRIPTION
Related to https://github.com/python-poetry/poetry/issues/9956#issuecomment-2629031927

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Previously, we have always tried to avoid recursions, which is difficult if you do not want to miss any simplifications. Although, #821 provides significant performance improvements for certain cases, it also introduces the risk of endless recursions due to the symmetry of `intersection` and `union`. It might still be possible to avoid this recursion with a more sophisticated fix. However, I decided to detect a recursion early instead of avoiding it.

## Summary by Sourcery

Bug Fixes:
- Fix an endless recursion issue in marker intersection and union operations introduced in #821.