### PR TITLE
add `has_upper_bound` method to `VersionConstraint`

### DIFF
--- a/src/poetry/core/constraints/version/empty_constraint.py
+++ b/src/poetry/core/constraints/version/empty_constraint.py
@@ -22,6 +22,14 @@ class EmptyConstraint(VersionConstraint):
     def is_simple(self) -> bool:
         return True
 
+    def has_upper_bound(self) -> bool:
+        # Rationale:
+        # 1. If no version can satisfy the constraint,
+        #    this is like an upper bound of 0 (not included).
+        # 2. The opposite of an empty constraint, which is *, has no upper bound
+        #    and the two extremes often behave the other way around.
+        return True
+
     def allows(self, version: Version) -> bool:
         return False
 

--- a/src/poetry/core/constraints/version/version_constraint.py
+++ b/src/poetry/core/constraints/version/version_constraint.py
@@ -25,6 +25,10 @@ class VersionConstraint:
         raise NotImplementedError
 
     @abstractmethod
+    def has_upper_bound(self) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
     def allows(self, version: Version) -> bool:
         raise NotImplementedError
 

--- a/src/poetry/core/constraints/version/version_range_constraint.py
+++ b/src/poetry/core/constraints/version/version_range_constraint.py
@@ -62,6 +62,9 @@ class VersionRangeConstraint(VersionConstraint):
         # https://peps.python.org/pep-0440/#exclusive-ordered-comparison
         return self.max.first_devrelease()
 
+    def has_upper_bound(self) -> bool:
+        return self.max is not None
+
     def allows_lower(self, other: VersionRangeConstraint) -> bool:
         _this, _other = self.allowed_min, other.allowed_min
 

--- a/src/poetry/core/constraints/version/version_union.py
+++ b/src/poetry/core/constraints/version/version_union.py
@@ -95,6 +95,9 @@ class VersionUnion(VersionConstraint):
     def is_simple(self) -> bool:
         return self.excludes_single_version
 
+    def has_upper_bound(self) -> bool:
+        return all(constraint.has_upper_bound() for constraint in self._ranges)
+
     def allows(self, version: Version) -> bool:
         if self.excludes_single_version:
             # when excluded version is local, special handling is required

--- a/tests/constraints/version/test_version_constraint.py
+++ b/tests/constraints/version/test_version_constraint.py
@@ -30,3 +30,32 @@ def test_constraints_are_hashable(constraint: VersionConstraint) -> None:
     # We're just testing that constraints are hashable, there's nothing much to say
     # about the result.
     hash(constraint)
+
+
+@pytest.mark.parametrize(
+    ("constraint", "expected"),
+    [
+        (EmptyConstraint(), True),
+        (Version.parse("1"), True),
+        (VersionRange(), False),
+        (VersionRange(Version.parse("1")), False),
+        (VersionRange(max=Version.parse("2")), True),
+        (VersionRange(Version.parse("1"), Version.parse("2")), True),
+        (
+            VersionUnion(
+                VersionRange(Version.parse("1"), Version.parse("2")),
+                VersionRange(Version.parse("3"), Version.parse("4")),
+            ),
+            True,
+        ),
+        (
+            VersionUnion(
+                VersionRange(Version.parse("1"), Version.parse("2")),
+                VersionRange(Version.parse("3")),
+            ),
+            False,
+        ),
+    ],
+)
+def test_has_upper_bound(constraint: VersionConstraint, expected: bool) -> None:
+    assert constraint.has_upper_bound() is expected


### PR DESCRIPTION
Required for python-poetry/poetry#10146

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

Tests:
- Add tests for the `has_upper_bound` method.