### PR TITLE
release: bump version to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Change Log
 
 
+## [2.1.0] - 2025-02-15
+
+### Added
+
+- Pass a local version label to the build backend interface ([#814](https://github.com/python-poetry/poetry-core/pull/814)).
+- Expose build-system dependencies via the `poetry` instance ([#319](https://github.com/python-poetry/poetry-core/pull/319)).
+- Add `has_upper_bound method` to `VersionConstraint` ([#833](https://github.com/python-poetry/poetry-core/pull/833)).
+
+### Changed
+
+- Improve performance of calculating intersections and unions of `extra` markers ([#818](https://github.com/python-poetry/poetry-core/pull/818)).
+- Improve performance of calculating intersections and unions of complex markers ([#821](https://github.com/python-poetry/poetry-core/pull/821),
+  [#832](https://github.com/python-poetry/poetry-core/pull/832)).
+- Improve performance of marker operations by simplifying `python_version` markers ([#826](https://github.com/python-poetry/poetry-core/pull/826)).
+- Improve performance by caching parsed requirements ([#828](https://github.com/python-poetry/poetry-core/pull/828)).
+- Improve error message when a referenced license file is missing ([#827](https://github.com/python-poetry/poetry-core/pull/827)).
+
+### Fixed
+
+- Fix an issue where inclusive ordering with post releases was inconsistent with PEP 440 ([#379](https://github.com/python-poetry/poetry-core/pull/379)).
+- Fix an issue where invalid URI tokens in PEP 508 requirement strings were silently discarded ([#817](https://github.com/python-poetry/poetry-core/pull/817)).
+- Fix an issue where wrong markers were calculated when removing parts covered by the project's python constraint ([#824](https://github.com/python-poetry/poetry-core/pull/824)).
+- Fix an issue where optional dependencies that are not part of an extra were included in the wheel metadata ([#830](https://github.com/python-poetry/poetry-core/pull/830)).
+- Fix an issue where the `__pycache__` directory and `*.pyc` files were included in sdists and wheels ([#835](https://github.com/python-poetry/poetry-core/pull/835)).
+
+
 ## [2.0.1] - 2025-01-11
 
 ### Changed
@@ -712,7 +738,8 @@ No changes.
 - Fixed support for stub-only packages ([#28](https://github.com/python-poetry/core/pull/28)).
 
 
-[Unreleased]: https://github.com/python-poetry/poetry-core/compare/2.0.1...main
+[Unreleased]: https://github.com/python-poetry/poetry-core/compare/2.1.0...main
+[2.1.0]: https://github.com/python-poetry/poetry-core/releases/tag/2.1.0
 [2.0.1]: https://github.com/python-poetry/poetry-core/releases/tag/2.0.1
 [2.0.0]: https://github.com/python-poetry/poetry-core/releases/tag/2.0.0
 [1.9.1]: https://github.com/python-poetry/poetry-core/releases/tag/1.9.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "poetry-core"
-version = "2.0.1"
+version = "2.1.0"
 description = "Poetry PEP 517 Build Backend"
 authors = [
   { name = "Sébastien Eustace", email =  "sebastien@eustace.io" }

--- a/src/poetry/core/__init__.py
+++ b/src/poetry/core/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 # this cannot presently be replaced with importlib.metadata.version as when building
 # itself, poetry-core is not available as an installed distribution.
-__version__ = "2.0.1"
+__version__ = "2.1.0"
 
 __vendor_site__ = (Path(__file__).parent / "_vendor").as_posix()
 


### PR DESCRIPTION
# TODO

* [x] set release date in Changelog
* [x] @radoering: add changelog entries for performance improvements
* [ ] ~add changelog entry for PEP 735~

---

### Added

- Pass a local version label to build backend interface ([#814](https://github.com/python-poetry/poetry-core/pull/814)).
- Expose build-system dependencies via the `poetry` instance ([#319](https://github.com/python-poetry/poetry-core/pull/319)).
- Add `has_upper_bound method` to `VersionConstraint` ([#833](https://github.com/python-poetry/poetry-core/pull/833)).

### Changed

- Improve performance of calculating intersections and unions of `extra` markers ([#818](https://github.com/python-poetry/poetry-core/pull/818)).
- Improve performance of calculating intersections and unions of complex markers ([#821](https://github.com/python-poetry/poetry-core/pull/821), [#832](https://github.com/python-poetry/poetry-core/pull/832)).
- Improve performance of marker operations by simplifying `python_version` markers ([#826](https://github.com/python-poetry/poetry-core/pull/826)).
- Improve performance by caching parsed requirements ([#828](https://github.com/python-poetry/poetry-core/pull/828)).
- Improve error message when a referenced license file is missing ([#827](https://github.com/python-poetry/poetry-core/pull/827)).

### Fixed

- Fix an issue where inclusive ordering with post releases was inconsistent with PEP 440 ([#379](https://github.com/python-poetry/poetry-core/pull/379)).
- Fix an issue where invalid URI tokens in PEP 508 requirement strings were silently discarded ([#817](https://github.com/python-poetry/poetry-core/pull/817)).
- Fix an issue where wrong markers were calculated when removing parts covered by the project's python constraint ([#824](https://github.com/python-poetry/poetry-core/pull/824)).
- Fix an issue where optional dependencies that are not part of an extra were included in the wheel metadata ([#830](https://github.com/python-poetry/poetry-core/pull/830)).
- Fix an issue where the `__pycache__` directory and `*.pyc` files were includes in sdists and wheels ([#835](https://github.com/python-poetry/poetry-core/pull/835)).

## Summary by Sourcery

Bump version to 2.1.0.

New Features:
- Pass local version label to build backend interface.
- Add support for `AtomicMultiMarker` and `AtomicMarkerUnion` for extra markers.