### PR TITLE
fix: do not include `__pycache__` and `.pyc` files in sdist and wheel

### DIFF
--- a/src/poetry/core/masonry/builders/builder.py
+++ b/src/poetry/core/masonry/builders/builder.py
@@ -126,6 +126,9 @@ class Builder:
     def is_excluded(self, filepath: str | Path) -> bool:
         exclude_path = Path(filepath)
 
+        if "__pycache__" in exclude_path.parts or exclude_path.suffix == ".pyc":
+            return True
+
         while True:
             if exclude_path.as_posix() in self.find_excluded_files(fmt=self.format):
                 return True
@@ -150,7 +153,8 @@ class Builder:
             formats = include.formats
 
             for file in include.elements:
-                if "__pycache__" in str(file):
+                if "__pycache__" in file.parts:
+                    # This is just a shortcut. It will be ignored later anyway.
                     continue
 
                 if (
@@ -200,9 +204,6 @@ class Builder:
                 if self.is_excluded(
                     include_file.relative_to_project_root()
                 ) and isinstance(include, PackageInclude):
-                    continue
-
-                if file.suffix == ".pyc":
                     continue
 
                 logger.debug(f"Adding: {file}")

--- a/src/poetry/core/masonry/builders/sdist.py
+++ b/src/poetry/core/masonry/builders/sdist.py
@@ -270,6 +270,7 @@ class SdistBuilder(Builder):
 
         for path, _dirnames, filenames in os.walk(base, topdown=True):
             if Path(path).name == "__pycache__":
+                # This is just a shortcut. It will be ignored later anyway.
                 continue
 
             from_top_level = os.path.relpath(path, base)

--- a/tests/masonry/builders/conftest.py
+++ b/tests/masonry/builders/conftest.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import shutil
+
+from pathlib import Path
+
+import pytest
+
+
+fixtures_dir = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def complete_with_pycache_and_pyc_files(tmp_path: Path) -> Path:
+    root = fixtures_dir / "complete"
+    tmp_root = tmp_path / "complete"  # not git repo!
+
+    shutil.copytree(root, tmp_root)
+    for location in (".", "sub_pkg1"):
+        abs_location = tmp_root / "my_package" / location
+        (abs_location / "module1.cpython-39.pyc").touch()
+        pycache_location = tmp_root / "my_package" / location / "__pycache__"
+        pycache_location.mkdir(parents=True)
+        (pycache_location / "module1.cpython-39.pyc").touch()
+        (pycache_location / "some_other_file").touch()
+
+    return tmp_root

--- a/tests/masonry/builders/test_sdist.py
+++ b/tests/masonry/builders/test_sdist.py
@@ -578,6 +578,25 @@ def test_proper_python_requires_if_three_digits_precision_version_specified() ->
     assert parsed["Requires-Python"] == "==2.7.15"
 
 
+def test_sdist_does_not_include_pycache_and_pyc_files(
+    complete_with_pycache_and_pyc_files: Path,
+) -> None:
+    poetry = Factory().create_poetry(complete_with_pycache_and_pyc_files)
+
+    builder = SdistBuilder(poetry)
+
+    builder.build()
+
+    sdist = complete_with_pycache_and_pyc_files / "dist" / "my_package-1.2.3.tar.gz"
+
+    assert sdist.exists()
+
+    with tarfile.open(str(sdist), "r") as tar:
+        for name in tar.getnames():
+            assert "__pycache__" not in name
+            assert not name.endswith(".pyc")
+
+
 def test_includes() -> None:
     poetry = Factory().create_poetry(project("with-include"))
 

--- a/tests/masonry/builders/test_wheel.py
+++ b/tests/masonry/builders/test_wheel.py
@@ -126,6 +126,23 @@ def test_wheel_epoch() -> None:
         assert "epoch-1!2.0.dist-info/METADATA" in z.namelist()
 
 
+def test_wheel_does_not_include_pycache_and_pyc_files(
+    complete_with_pycache_and_pyc_files: Path,
+) -> None:
+    WheelBuilder.make_in(Factory().create_poetry(complete_with_pycache_and_pyc_files))
+
+    whl = (
+        complete_with_pycache_and_pyc_files / "dist"
+    ) / "my_package-1.2.3-py3-none-any.whl"
+
+    assert whl.exists()
+
+    with zipfile.ZipFile(str(whl)) as z:
+        for name in z.namelist():
+            assert "__pycache__" not in name
+            assert not name.endswith(".pyc")
+
+
 def test_wheel_excluded_data() -> None:
     module_path = fixtures_dir / "default_with_excluded_data_toml"
     WheelBuilder.make(Factory().create_poetry(module_path))


### PR DESCRIPTION
Resolves: python-poetry/poetry#10160

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Our logic to exclude `__pycache__` and `.pyc` files did not work. We did not notice because git ignores stepped in.

## Summary by Sourcery

Tests:
- Added tests to verify that .pyc and __pycache__ files are not included in sdist and wheel distributions.