### PR TITLE
feat: support nesting dependency groups

### DIFF
--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -347,7 +347,7 @@ class Factory:
                 cls._add_package_group_dependencies(
                     package=package,
                     group=group,
-                    dependencies=group_config["dependencies"],
+                    dependencies=group_config.get("dependencies", {}),
                 )
 
             for group_name, group_config in tool_poetry["group"].items():

--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -355,8 +355,8 @@ class Factory:
                     current_group = package.dependency_group(group_name)
                     for name in include_groups:
                         try:
-                            # `name` isn't normalized, but `.dependency_group()`
-                            # handles that.
+                            # `name` isn't normalized,
+                            # but `.dependency_group()` handles that.
                             group_to_include = package.dependency_group(name)
                         except ValueError as e:
                             raise ValueError(

--- a/src/poetry/core/json/schemas/poetry-schema.json
+++ b/src/poetry/core/json/schemas/poetry-schema.json
@@ -171,8 +171,17 @@
         "^[a-zA-Z-_.0-9]+$": {
           "type": "object",
           "description": "This represents a single dependency group",
-          "required": [
-            "dependencies"
+          "anyOf": [
+            {
+              "required": [
+                "dependencies"
+              ]
+            },
+            {
+              "required": [
+                "include-groups"
+              ]
+            }
           ],
           "properties": {
             "optional": {

--- a/src/poetry/core/json/schemas/poetry-schema.json
+++ b/src/poetry/core/json/schemas/poetry-schema.json
@@ -179,6 +179,13 @@
               "type": "boolean",
               "description": "Whether the dependency group is optional or not"
             },
+            "include-groups": {
+              "type": "array",
+              "description": "List of dependency group names included in this group.",
+              "items": {
+                "type": "string"
+              }
+            },
             "dependencies": {
               "type": "object",
               "description": "The dependencies of this dependency group",

--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -73,7 +73,7 @@ class Dependency(PackageSpecification):
         if not groups:
             groups = [MAIN_GROUP]
 
-        self._groups = frozenset(canonicalize_name(g) for g in groups)
+        self.groups = frozenset(canonicalize_name(g) for g in groups)
         self._allows_prereleases = allows_prereleases
         # "_develop" is only required for enriching [project] dependencies
         self._develop = False
@@ -114,10 +114,6 @@ class Dependency(PackageSpecification):
     @property
     def pretty_name(self) -> str:
         return self._pretty_name
-
-    @property
-    def groups(self) -> frozenset[NormalizedName]:
-        return self._groups
 
     @property
     def python_versions(self) -> str:
@@ -330,6 +326,11 @@ class Dependency(PackageSpecification):
     def with_constraint(self: T, constraint: str | VersionConstraint) -> T:
         dependency = self.clone()
         dependency.constraint = constraint  # type: ignore[assignment]
+        return dependency
+
+    def with_groups(self, groups: Iterable[str]) -> Dependency:
+        dependency = self.clone()
+        dependency.groups = frozenset(canonicalize_name(g) for g in groups)
         return dependency
 
     @classmethod

--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -505,7 +505,7 @@ def _make_file_or_dir_dep(
     Helper function to create a file or directoru dependency with the given arguments.
 
     If path is not a file or directory that exists, a guess is made based on the suffix
-    of the given path. This is done to prevent dependendencies from being parsed as normal
+    of the given path. This is done to prevent dependencies from being parsed as normal
     dependencies. This allows for downstream error handling.
 
     See also: poetry#10068

--- a/src/poetry/core/packages/dependency_group.py
+++ b/src/poetry/core/packages/dependency_group.py
@@ -38,27 +38,27 @@ class DependencyGroup:
 
     @property
     def dependencies(self) -> list[Dependency]:
-        group_dependencies = self._dependencies
+        dependencies = self._dependencies
         included_group_dependencies = self._resolve_included_dependency_groups(
             dependencies_for_locking=False
         )
 
-        if not group_dependencies:
+        if not dependencies:
             # legacy mode
-            group_dependencies = self._poetry_dependencies
+            dependencies = self._poetry_dependencies
         elif self._mixed_dynamic and self._poetry_dependencies:
             if all(dep.is_optional() for dep in self._dependencies):
-                group_dependencies = [
+                dependencies = [
                     *self._dependencies,
                     *(d for d in self._poetry_dependencies if not d.is_optional()),
                 ]
             elif all(not dep.is_optional() for dep in self._dependencies):
-                group_dependencies = [
+                dependencies = [
                     *self._dependencies,
                     *(d for d in self._poetry_dependencies if d.is_optional()),
                 ]
 
-        return group_dependencies + included_group_dependencies
+        return dependencies + included_group_dependencies
 
     @property
     def dependencies_for_locking(self) -> list[Dependency]:
@@ -105,7 +105,7 @@ class DependencyGroup:
         return dependencies + included_group_dependencies
 
     def _resolve_included_dependency_groups(
-        self, dependencies_for_locking: bool = False
+        self, *, dependencies_for_locking: bool = False
     ) -> list[Dependency]:
         """Resolves and returns the dependencies from included dependency groups.
 

--- a/src/poetry/core/packages/dependency_group.py
+++ b/src/poetry/core/packages/dependency_group.py
@@ -39,7 +39,9 @@ class DependencyGroup:
     @property
     def dependencies(self) -> list[Dependency]:
         group_dependencies = self._dependencies
-        included_group_dependencies = self._resolve_included_dependency_groups()
+        included_group_dependencies = self._resolve_included_dependency_groups(
+            dependencies_for_locking=False
+        )
 
         if not group_dependencies:
             # legacy mode
@@ -60,7 +62,9 @@ class DependencyGroup:
 
     @property
     def dependencies_for_locking(self) -> list[Dependency]:
-        included_group_dependencies = self._resolve_included_dependency_groups()
+        included_group_dependencies = self._resolve_included_dependency_groups(
+            dependencies_for_locking=True
+        )
 
         if not self._poetry_dependencies:
             dependencies = self._dependencies
@@ -100,7 +104,9 @@ class DependencyGroup:
 
         return dependencies + included_group_dependencies
 
-    def _resolve_included_dependency_groups(self) -> list[Dependency]:
+    def _resolve_included_dependency_groups(
+        self, dependencies_for_locking: bool = False
+    ) -> list[Dependency]:
         """Resolves and returns the dependencies from included dependency groups.
 
         This method iterates over all included dependency groups and collects
@@ -109,7 +115,11 @@ class DependencyGroup:
         return [
             dependency.with_groups([self.name])
             for dependency_group in self._included_dependency_groups.values()
-            for dependency in dependency_group.dependencies
+            for dependency in (
+                dependency_group.dependencies_for_locking
+                if dependencies_for_locking
+                else dependency_group.dependencies
+            )
         ]
 
     def is_optional(self) -> bool:

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -339,6 +339,7 @@ def test_with_constraint() -> None:
 
     assert new.name == dependency.name
     assert str(new.constraint) == ">=1.2.6,<2.0.0"
+    assert str(dependency.constraint) == ">=1.2.3,<2.0.0"
     assert new.is_optional()
     assert new.groups == frozenset(["dev"])
     assert new.allows_prereleases()
@@ -346,6 +347,17 @@ def test_with_constraint() -> None:
     assert new.marker == dependency.marker
     assert new.transitive_marker == dependency.transitive_marker
     assert new.python_constraint == dependency.python_constraint
+
+
+def test_with_groups() -> None:
+    dependency = Dependency("foo", "^1.2.3", groups=["DEV"])
+
+    new = dependency.with_groups(["DOC", "test"])
+
+    assert new.name == dependency.name
+    assert str(dependency.constraint) == ">=1.2.3,<2.0.0"
+    assert new.groups == frozenset(["doc", "test"])
+    assert dependency.groups == frozenset(["dev"])
 
 
 @pytest.mark.parametrize(

--- a/tests/packages/test_dependency_group.py
+++ b/tests/packages/test_dependency_group.py
@@ -544,3 +544,65 @@ def test_dependency_group_use_canonicalize_name(
     group = DependencyGroup(pretty_name)
     assert group.name == canonicalized_name
     assert group.pretty_name == pretty_name
+
+
+def test_include_dependency_groups() -> None:
+    group = DependencyGroup(name="group")
+    group.add_poetry_dependency(
+        Dependency(name="foo", constraint="*", groups=["group"])
+    )
+
+    group_2 = DependencyGroup(name="group2")
+    group_2.add_poetry_dependency(
+        Dependency(name="bar", constraint="*", groups=["group2"])
+    )
+
+    group.include_dependency_group(group_2)
+
+    assert [dep.name for dep in group.dependencies] == ["foo", "bar"]
+    assert [dep.name for dep in group.dependencies_for_locking] == ["foo", "bar"]
+    for dep in group.dependencies:
+        assert dep.groups == {"group"}
+
+    assert [dep.name for dep in group_2.dependencies] == ["bar"]
+    assert [dep.name for dep in group_2.dependencies_for_locking] == ["bar"]
+    for dep in group_2.dependencies:
+        assert dep.groups == {"group2"}
+
+
+@pytest.mark.parametrize("group_name", ["group_2", "Group-2", "group-2"])
+def test_include_dependency_group_raise_if_including_itself(group_name: str) -> None:
+    group = DependencyGroup(name="group-2")
+    group.add_poetry_dependency(
+        Dependency(name="foo", constraint="*", groups=["group"])
+    )
+
+    with pytest.raises(
+        ValueError, match="Cannot include the dependency group to itself"
+    ):
+        group.include_dependency_group(DependencyGroup(name=group_name))
+
+
+@pytest.mark.parametrize("group_name", ["group_2", "Group-2", "group-2"])
+def test_include_dependency_group_raise_if_already_included(group_name: str) -> None:
+    group = DependencyGroup(name="group")
+    group.add_poetry_dependency(
+        Dependency(name="foo", constraint="*", groups=["group"])
+    )
+
+    group_2 = DependencyGroup(name="group_2")
+    group_2.add_poetry_dependency(
+        Dependency(name="bar", constraint="*", groups=["group2"])
+    )
+
+    group.include_dependency_group(group_2)
+
+    group_3 = DependencyGroup(name=group_name)
+    group_3.add_poetry_dependency(
+        Dependency(name="bar", constraint="*", groups=["group2"])
+    )
+
+    with pytest.raises(
+        ValueError, match=f"Dependency group {group_name} is already included"
+    ):
+        group.include_dependency_group(group_3)

--- a/tests/packages/test_dependency_group.py
+++ b/tests/packages/test_dependency_group.py
@@ -593,6 +593,21 @@ def test_include_dependency_groups() -> None:
         assert dep.groups == {"group3"}
 
 
+def test_include_empty_dependency_group() -> None:
+    group_main = DependencyGroup(name="group")
+    group_main.add_poetry_dependency(
+        Dependency(name="foo", constraint="*", groups=["group"])
+    )
+
+    empty_group = DependencyGroup(name="empty")
+    # Include empty dependency group
+    group_main.include_dependency_group(empty_group)
+
+    # Assert that including an empty group does not affect group_main's dependencies.
+    assert [dep.name for dep in group_main.dependencies] == ["foo"]
+    assert [dep.name for dep in group_main.dependencies_for_locking] == ["foo"]
+
+
 @pytest.mark.parametrize("group_name", ["group_2", "Group-2", "group-2"])
 def test_include_dependency_group_raise_if_including_itself(group_name: str) -> None:
     group = DependencyGroup(name="group-2")

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1307,3 +1307,36 @@ black = "*"
         error_type=ValueError,
         temporary_directory=temporary_directory,
     )
+
+
+def test_create_poetry_with_included_groups_only(temporary_directory: Path) -> None:
+    pyproject_toml = temporary_directory / "pyproject.toml"
+    content = """\
+[project]
+name = "my-package"
+version = "1.2.3"
+
+[tool.poetry.group.lint.dependencies]
+black = "*"
+
+[tool.poetry.group.testing.dependencies]
+pytest = "*"
+
+[tool.poetry.group.all]
+include-groups = [
+    "lint",
+    "testing",
+]
+"""
+    pyproject_toml.write_text(content)
+
+    poetry = Factory().create_poetry(temporary_directory)
+    assert len(poetry.package.all_requires) == 4
+    assert [
+        (dep.name, ",".join(dep.groups)) for dep in poetry.package.all_requires
+    ] == [
+        ("black", "lint"),
+        ("pytest", "testing"),
+        ("black", "all"),
+        ("pytest", "all"),
+    ]

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1417,7 +1417,7 @@ quux = "*"
         ("quux", "child-1"),
         ("quux", "child-2"),
         # Duplicates because dependency is included via several groups.
-        # This is ok because they are merged during depenendency resolution.
+        # This is ok because they are merged during dependency resolution.
         ("quux", "root"),
         ("quux", "root"),
         ("quux", "shared"),
@@ -1492,7 +1492,7 @@ quux = "*"
         ("quux", "child-2"),
         ("quux", "grandchild"),
         # Duplicates because dependency is included via several groups.
-        # This is ok because they are merged during depenendency resolution.
+        # This is ok because they are merged during dependency resolution.
         ("quux", "root"),
         ("quux", "root"),
         ("quux", "shared"),
@@ -1708,7 +1708,7 @@ foo = "*"
         (dep.name, ",".join(dep.groups)) for dep in poetry.package.all_requires
     ] == [
         # Duplicates because dependency is included via several groups.
-        # This is ok because they are merged during depenendency resolution.
+        # This is ok because they are merged during dependency resolution.
         ("foo", "parent"),
         ("foo", "parent"),
         ("foo", "child"),


### PR DESCRIPTION
Include dependency groups into other dependency groups was requested earlier, e.g. https://github.com/python-poetry/poetry/issues/7494. Also PEP 735 describes this mechanism.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code -> https://github.com/python-poetry/poetry/pull/10166

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

New Features:
- Allow including dependencies from other groups within a dependency group.

## Summary by Sourcery

Add support for nested dependency groups.

New Features:
- Allow dependency groups to include other groups.

Tests:
- Add tests for nested dependency groups.

## Summary by Sourcery

Add support for nested dependency groups.

New Features:
- Allow dependency groups to include other groups.

Tests:
- Add tests for nested dependency groups.