### PR TITLE
fix simplification of `python_version` markers to `AnyMarker`

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -1222,11 +1222,14 @@ def _merge_single_markers(
 
         elif isinstance(result_constraint, VersionUnion) and merge_class == MarkerUnion:
             # Convert 'python_version == "3.8" or python_version >= "3.9"'
-            # to 'python_version >= "3.8"'
+            # to 'python_version >= "3.8"'.
+            # Convert 'python_version <= "3.8" or python_version >= "3.9"' to "any".
             result_constraint = get_python_constraint_from_marker(marker1).union(
                 get_python_constraint_from_marker(marker2)
             )
-            if result_constraint.is_simple():
+            if result_constraint.is_any():
+                result_marker = AnyMarker()
+            elif result_constraint.is_simple():
                 result_marker = SingleMarker(marker1.name, result_constraint)
 
     return result_marker

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -412,6 +412,11 @@ def test_single_marker_union_is_any() -> None:
             'python_version >= "3.7"',
             'python_version >= "3.6"',
         ),
+        (
+            'python_version <= "3.6"',
+            'python_version >= "3.7"',
+            "",
+        ),
     ],
 )
 def test_single_marker_union_is_single_marker(


### PR DESCRIPTION
Fixes `Could not parse version constraint: ==*`

Resolves: python-poetry/poetry#10184

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

Fix the simplification of multiple overlapping `python_version` markers.  Ensure that overlapping marker constraints are correctly merged into a `MarkerUnion` instead of being incorrectly simplified to an `AnyMarker`.

Bug Fixes:
- Fix incorrect simplification of multiple version markers into a single `AnyMarker` when merging overlapping constraints.  This addresses the issue where version constraints such as `python_version <= "3.6" or python_version >= "3.7"` were incorrectly simplified to `AnyMarker` instead of remaining separate.  This resolves parsing errors when evaluating overlapping constraints that should result in a `MarkerUnion` rather than an `AnyMarker`

Tests:
- Add tests to verify the correct merging behavior of overlapping version markers, ensuring that they are combined into a `MarkerUnion` when appropriate.