### PR TITLE
release: bump version to 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 
 
+## [2.1.1] - 2025-02-16
+
+### Fixed
+
+- Fix an issue where simplifying a `python_version` marker resulted in an invalid marker ([#838](https://github.com/python-poetry/poetry-core/pull/838)).
+
+
 ## [2.1.0] - 2025-02-15
 
 ### Added
@@ -738,7 +745,8 @@ No changes.
 - Fixed support for stub-only packages ([#28](https://github.com/python-poetry/core/pull/28)).
 
 
-[Unreleased]: https://github.com/python-poetry/poetry-core/compare/2.1.0...main
+[Unreleased]: https://github.com/python-poetry/poetry-core/compare/2.1.1...main
+[2.1.1]: https://github.com/python-poetry/poetry-core/releases/tag/2.1.1
 [2.1.0]: https://github.com/python-poetry/poetry-core/releases/tag/2.1.0
 [2.0.1]: https://github.com/python-poetry/poetry-core/releases/tag/2.0.1
 [2.0.0]: https://github.com/python-poetry/poetry-core/releases/tag/2.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "poetry-core"
-version = "2.1.0"
+version = "2.1.1"
 description = "Poetry PEP 517 Build Backend"
 authors = [
   { name = "Sébastien Eustace", email =  "sebastien@eustace.io" }

--- a/src/poetry/core/__init__.py
+++ b/src/poetry/core/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 # this cannot presently be replaced with importlib.metadata.version as when building
 # itself, poetry-core is not available as an installed distribution.
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 
 __vendor_site__ = (Path(__file__).parent / "_vendor").as_posix()
 


### PR DESCRIPTION
### Fixed

- Fix an issue where simplifying a `python_version` marker resulted in an invalid marker ([#838](https://github.com/python-poetry/poetry-core/pull/838)).

## Summary by Sourcery

Prepare for the 2.1.1 release by fixing a bug in the `python_version` marker simplification and updating the changelog and version number.

Bug Fixes:
- Fix an issue where simplifying a `python_version` marker resulted in an invalid marker

Documentation:
- Update changelog for 2.1.1 release

Chores:
- Bump version to 2.1.1