### PR TITLE
Fixes a typo in a warning message

### DIFF
--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -731,7 +731,7 @@ class Factory:
             result["warnings"].append(
                 "[tool.poetry.dependencies] is set but [project.dependencies] is not"
                 " and 'dependencies' is not in [project.dynamic]."
-                " You should either migrate [tool.poetry.depencencies] to"
+                " You should either migrate [tool.poetry.dependencies] to"
                 " [project.dependencies] (if you do not need Poetry-specific features)"
                 " or add [project.dependencies] in addition to"
                 " [tool.poetry.dependencies] or add 'dependencies' to"

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -742,7 +742,7 @@ def test_validate_dependencies_non_package_mode(with_project_section: bool) -> N
             (
                 "[tool.poetry.dependencies] is set but [project.dependencies] is "
                 "not and 'dependencies' is not in [project.dynamic]. You should "
-                "either migrate [tool.poetry.depencencies] to "
+                "either migrate [tool.poetry.dependencies] to "
                 "[project.dependencies] (if you do not need Poetry-specific "
                 "features) or add [project.dependencies] in addition to "
                 "[tool.poetry.dependencies] or add 'dependencies' to "


### PR DESCRIPTION
## Summary by Sourcery

Fixes a typo in a warning message and updates the corresponding test case.

Bug Fixes:
- Fixes a typo in a warning message related to migrating dependencies from `tool.poetry.dependencies` to `project.dependencies`.

Tests:
- Updates the corresponding test case to reflect the typo fix in the warning message.