### PR TITLE
improve `reduce_by_python_constraint`

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -456,6 +456,7 @@ class SingleMarker(SingleMarkerLike[Union[BaseConstraint, VersionConstraint]]):
         self, python_constraint: VersionConstraint
     ) -> BaseMarker:
         if self.name in PYTHON_VERSION_MARKERS:
+            from poetry.core.packages.utils.utils import create_nested_marker
             from poetry.core.packages.utils.utils import (
                 get_python_constraint_from_marker,
             )
@@ -466,6 +467,13 @@ class SingleMarker(SingleMarkerLike[Union[BaseConstraint, VersionConstraint]]):
                 return AnyMarker()
             elif not constraint.allows_any(python_constraint):
                 return EmptyMarker()
+
+            python_marker = parse_marker(
+                create_nested_marker("python_version", python_constraint)
+            )
+            intersection = self.intersect(python_marker)
+            if isinstance(intersection, SingleMarker):
+                return intersection
 
         return self
 

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -1495,6 +1495,11 @@ def test_only(marker: str, only: list[str], expected: str) -> None:
         ('python_version > "3.8"', "~3.8", "<empty>"),
         ('python_version >= "3.8"', "~3.8", ""),
         ('python_version >= "3.9"', "~3.8", "<empty>"),
+        ('python_version == "3.9"', ">=3.9", 'python_version == "3.9"'),
+        ('python_version <= "3.9"', ">=3.9", 'python_version == "3.9"'),
+        ('python_version < "3.10"', ">=3.9", 'python_version == "3.9"'),
+        ('python_version <= "3.10"', ">=3.9", 'python_version <= "3.10"'),
+        ('python_version < "3.11"', ">=3.9", 'python_version < "3.11"'),
         ('python_full_version >= "3.8.0"', "~3.8", ""),
         ('python_full_version >= "3.8.1"', "~3.8", 'python_full_version >= "3.8.1"'),
         ('python_full_version < "3.8.0"', "~3.8", "<empty>"),
@@ -1519,7 +1524,7 @@ def test_only(marker: str, only: list[str], expected: str) -> None:
         (
             'python_version < "3.8" or python_version >= "3.9"',
             ">=3.7",
-            'python_version < "3.8" or python_version >= "3.9"',
+            'python_version == "3.7" or python_version >= "3.9"',
         ),
         ('python_version < "3.8" or python_version >= "3.9"', "~3.7", ""),
         (
@@ -1539,7 +1544,7 @@ def test_only(marker: str, only: list[str], expected: str) -> None:
         (
             'python_version < "3.8" or python_version >= "3.9"',
             "~3.6 || ~3.8",
-            'python_version < "3.8"',
+            'python_version == "3.6"',
         ),
         (
             (


### PR DESCRIPTION
Related to: python-poetry/poetry#10195

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

This pull request enhances the `reduce_by_python_constraint` function to improve its accuracy when dealing with Python version constraints. It also adds new test cases to ensure the correctness of the changes.

Enhancements:
- Improves the `reduce_by_python_constraint` function to better handle version constraints, especially when intersecting with `python_version` markers.

Tests:
- Adds new test cases to cover the improved logic for reducing markers based on Python version constraints.