### PR TITLE
simplify extra markers

### DIFF
--- a/tests/constraints/generic/test_constraint.py
+++ b/tests/constraints/generic/test_constraint.py
@@ -920,6 +920,11 @@ def test_intersect(
             UnionConstraint(ExtraConstraint("extra1"), ExtraConstraint("extra2")),
             EmptyConstraint(),
         ),
+        (
+            ExtraMultiConstraint(ExtraConstraint("extra1"), ExtraConstraint("extra2")),
+            UnionConstraint(ExtraConstraint("extra1"), ExtraConstraint("extra2")),
+            ExtraMultiConstraint(ExtraConstraint("extra1"), ExtraConstraint("extra2")),
+        ),
     ],
 )
 def test_intersect_extra(

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -357,6 +357,16 @@ def test_single_marker_not_in_python_intersection() -> None:
             'extra == "a" or extra == "c"',
             'extra == "c" and extra != "a" and extra != "b"',
         ),
+        (
+            'extra == "a" and extra == "b"',
+            'extra == "a" or extra == "b"',
+            'extra == "a" and extra == "b"',
+        ),
+        (
+            'extra == "a" or extra == "b"',
+            'extra == "a" and extra == "b"',
+            'extra == "a" and extra == "b"',
+        ),
     ],
 )
 def test_single_marker_intersect_extras(


### PR DESCRIPTION
Without this change the intersection of `extra == "a" and extra == "b"` and `extra == "a" or extra == "b"` is `extra == "a" and extra == "b" and (extra == "a" or extra == "b")`. With the change, it is simplified to `extra == "a" and extra == "b"`.

Related to: python-poetry/poetry#10195

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

Simplifies the intersection logic for union and multi constraints, particularly when dealing with extra markers, to produce cleaner and more concise expressions. Adds new test cases to ensure the correctness of the intersection logic.

Bug Fixes:
- Fixes an issue where intersecting union and multi constraints involving extra markers could result in unnecessarily complex expressions.

Tests:
- Adds test cases to verify the correct intersection of union and multi constraints with extra markers.