### PR TITLE
make complex marker unions and intersections deterministic

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -734,13 +734,13 @@ class MultiMarker(BaseMarker):
             if not shared_markers:
                 return None
 
-            unique_markers = our_markers - their_markers
-            other_unique_markers = their_markers - our_markers
+            # Do not use sets to create MultiMarkers for deterministic order!
+            unique_markers = [m for m in self.markers if m not in their_markers]
+            other_unique_markers = [m for m in other.markers if m not in our_markers]
             unique_union = MultiMarker(*unique_markers).union(
                 MultiMarker(*other_unique_markers)
             )
             if isinstance(unique_union, (SingleMarkerLike, AnyMarker)):
-                # Use list instead of set for deterministic order.
                 common_markers = [
                     marker for marker in self.markers if marker in shared_markers
                 ]
@@ -908,13 +908,13 @@ class MarkerUnion(BaseMarker):
             if not shared_markers:
                 return None
 
-            unique_markers = our_markers - their_markers
-            other_unique_markers = their_markers - our_markers
+            # Do not use sets to create MarkerUnions for deterministic order!
+            unique_markers = [m for m in self.markers if m not in their_markers]
+            other_unique_markers = [m for m in other.markers if m not in our_markers]
             unique_intersection = MarkerUnion(*unique_markers).intersect(
                 MarkerUnion(*other_unique_markers)
             )
             if isinstance(unique_intersection, (SingleMarkerLike, EmptyMarker)):
-                # Use list instead of set for deterministic order.
                 common_markers = [
                     marker for marker in self.markers if marker in shared_markers
                 ]

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -2154,6 +2154,35 @@ def test_complex_intersection() -> None:
     )
 
 
+def test_complex_union_is_deterministic() -> None:
+    """
+    This test might fail sporadically if marker operations are not deterministic!
+    """
+    m1 = parse_marker(
+        'sys_platform != "darwin" and python_version >= "3.12"'
+        ' and platform_system != "Emscripten" and (python_version < "4.0"'
+        ' and sys_platform == "linux" and extra == "stretch"'
+        ' or platform_system == "Windows" or extra == "test"'
+        ' and sys_platform == "win32")'
+    )
+    m2 = parse_marker(
+        'sys_platform == "linux" and python_version >= "3.12"'
+        ' and platform_system == "Emscripten" and python_version < "4.0"'
+        ' and extra == "stretch" or sys_platform == "win32"'
+        ' and python_version >= "3.12" and platform_system == "Emscripten"'
+        ' and extra == "test"'
+    )
+    assert str(m1.union(m2)) == (
+        'python_version >= "3.12" and platform_system == "Windows"'
+        ' and sys_platform != "darwin" or sys_platform == "linux"'
+        ' and python_version >= "3.12" and python_version < "4.0"'
+        ' and extra == "stretch" or python_version >= "3.12" and python_version < "4.0"'
+        ' and extra == "stretch" and extra == "test" and (sys_platform == "linux"'
+        ' or sys_platform == "win32") or sys_platform == "win32"'
+        ' and python_version >= "3.12" and extra == "test"'
+    )
+
+
 def test_union_avoids_combinatorial_explosion() -> None:
     """
     combinatorial explosion without AtomicMultiMarker and AtomicMarkerUnion


### PR DESCRIPTION
Requires: #842

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

This pull request makes complex marker unions and intersections deterministic by preventing duplicate constraints and improving performance.

Enhancements:
- Ensures that marker unions and intersections are deterministic by avoiding duplicate constraints when intersecting union constraints.
- Improves the performance of marker operations by using generators instead of sets to determine unique markers.

Tests:
- Adds a test to ensure that complex marker unions are deterministic, preventing sporadic test failures.