### PR TITLE
simplify extra markers 2

### DIFF
--- a/src/poetry/core/constraints/generic/union_constraint.py
+++ b/src/poetry/core/constraints/generic/union_constraint.py
@@ -165,8 +165,11 @@ class UnionConstraint(BaseConstraint):
 
         else:
             assert isinstance(other, MultiConstraint)
-            # (A or B) or (C and D) => nothing to do
+            # (A or B) or (A and D) => A or B
+            if any(c in other.constraints for c in self._constraints):
+                return self
 
+            # (A or B) or (C and D) => nothing to do
             new_constraints = [*self._constraints, other]
 
         if len(new_constraints) == 1:

--- a/tests/constraints/generic/test_constraint.py
+++ b/tests/constraints/generic/test_constraint.py
@@ -1580,6 +1580,11 @@ def test_union(
                 ),
             ),
         ),
+        (
+            UnionConstraint(ExtraConstraint("extra1"), ExtraConstraint("extra2")),
+            ExtraMultiConstraint(ExtraConstraint("extra1"), ExtraConstraint("extra3")),
+            UnionConstraint(ExtraConstraint("extra1"), ExtraConstraint("extra2")),
+        ),
     ],
 )
 def test_union_extra(

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -668,6 +668,16 @@ def test_single_marker_union_with_inverse() -> None:
             'extra == "a" or extra == "c"',
             'extra != "a" and extra != "b" or extra == "a" or extra == "c"',
         ),
+        (
+            'extra == "a" or extra == "b"',
+            'extra == "a" and extra == "c"',
+            'extra == "a" or extra == "b"',
+        ),
+        (
+            'extra == "a" and extra == "c"',
+            'extra == "a" or extra == "b"',
+            'extra == "a" or extra == "b"',
+        ),
     ],
 )
 def test_single_marker_union_extras(marker1: str, marker2: str, expected: str) -> None:


### PR DESCRIPTION
Without this change the union of `extra == "a" and extra == "c"` and `extra == "a" or extra == "b"` is `extra == "a" and extra == "c" or extra == "a" or extra == "b"`. With the change, it is simplified to `extra == "a" or extra == "b"`.

Related to: python-poetry/poetry#10195

Similar to: #842

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

Tests:
- Add tests for the simplification of extra markers.