### PR TITLE
fix `reduce_by_python_constraint` for marker unions

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -965,9 +965,7 @@ class MarkerUnion(BaseMarker):
             if get_python_constraint_from_marker(
                 self.of(*python_only_markers)
             ).allows_all(python_constraint):
-                if not other_markers:
-                    return AnyMarker()
-                markers = other_markers
+                return AnyMarker()
 
         return self.of(
             *(m.reduce_by_python_constraint(python_constraint) for m in markers)

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -1507,7 +1507,7 @@ def test_only(marker: str, only: list[str], expected: str) -> None:
         ("", "~3.8", ""),
         ("<empty>", "~3.8", "<empty>"),
         ('sys_platform == "linux"', "~3.8", 'sys_platform == "linux"'),
-        ('python_version >= "3.8"', "~3.8", ""),
+        ('python_version == "3.8"', "~3.8", ""),
         ('python_version == "3.8"', ">=3.8.7,<3.9.0", ""),
         ('python_version == "3.8" or python_version >= "3.9"', ">=3.8.0,<4.0.0", ""),
         ('python_version == "3.8" or python_version >= "3.9"', ">=3.8.7,<4.0.0", ""),
@@ -1553,6 +1553,11 @@ def test_only(marker: str, only: list[str], expected: str) -> None:
             'python_version < "3.8" or python_version >= "3.9"',
         ),
         (
+            'python_version == "3.8" or sys_platform == "linux"',
+            "~3.8",
+            "",
+        ),
+        (
             (
                 'python_version < "3.8"'
                 ' or python_version >= "3.9" and sys_platform == "linux"'
@@ -1572,7 +1577,7 @@ def test_only(marker: str, only: list[str], expected: str) -> None:
                 ' or python_version >= "3.9"'
             ),
             "~3.7 || ~3.9",
-            'sys_platform == "linux"',
+            "",
         ),
         (
             (
@@ -1580,17 +1585,12 @@ def test_only(marker: str, only: list[str], expected: str) -> None:
                 ' or python_version >= "3.9" or sys_platform == "win32"'
             ),
             "~3.7 || ~3.9",
-            'sys_platform == "linux" or sys_platform == "win32"',
+            "",
         ),
         (
-            'python_version == "3.8" or sys_platform == "linux" or python_version >= "3.9"',
-            ">=3.8.0,<4.0.0",
-            'sys_platform == "linux"',
-        ),
-        (
-            'python_version == "3.8" or sys_platform == "linux" or python_version >= "3.9"',
-            ">=3.8.7,<4.0.0",
-            'sys_platform == "linux"',
+            '(python_version == "3.8" or platform_system == "Linux") and sys_platform == "darwin"',
+            "~3.8",
+            'sys_platform == "darwin"',
         ),
     ],
 )


### PR DESCRIPTION
E.g. if the python constraint is `>=3.9`, reducing `python_version >= "3.8" or sys_platform == "linux"` should be `AnyMarker` (not `sys_platform == "linux"`).

Resolves: python-poetry/poetry#10239
Related-to: python-poetry/poetry#10237

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

Bug Fixes:
- Fixes an issue in `reduce_by_python_constraint` where marker unions were not correctly reduced when a python constraint was applied, resulting in incorrect marker evaluation.