### PR TITLE
simplify extra markers 3

### DIFF
--- a/src/poetry/core/constraints/generic/multi_constraint.py
+++ b/src/poetry/core/constraints/generic/multi_constraint.py
@@ -145,8 +145,12 @@ class ExtraMultiConstraint(MultiConstraint):
         from poetry.core.constraints.generic import UnionConstraint
 
         if isinstance(other, MultiConstraint):
-            if set(other.constraints) == set(self._constraints):
+            our_constraints = set(self._constraints)
+            their_constraints = set(other.constraints)
+            if our_constraints.issubset(their_constraints):
                 return self
+            if their_constraints.issubset(our_constraints):
+                return other
             return UnionConstraint(self, other)
 
         if isinstance(other, Constraint):

--- a/src/poetry/core/constraints/generic/union_constraint.py
+++ b/src/poetry/core/constraints/generic/union_constraint.py
@@ -93,6 +93,16 @@ class UnionConstraint(BaseConstraint):
                     seen_multi_constraints.add(frozenset(constraint.constraints))
 
         if isinstance(other, UnionConstraint):
+            # (A or B) and (A or B or C) => A or B
+            our_constraints = set(self._constraints)
+            their_constraints = set(other.constraints)
+            if our_constraints.issubset(their_constraints):
+                return self
+            if their_constraints.issubset(our_constraints):
+                if len(other.constraints) == 1:
+                    return other.constraints[0]
+                return other
+
             # (A or B) and (C or D) => (A and C) or (A and D) or (B and C) or (B and D)
             for our_constraint in self._constraints:
                 for their_constraint in other.constraints:
@@ -101,7 +111,7 @@ class UnionConstraint(BaseConstraint):
         else:
             assert isinstance(other, MultiConstraint)
             # (A or B) and (C and D) => (A and C and D) or (B and C and D)
-
+            # (A or B) and (A and D) => A and D
             for our_constraint in self._constraints:
                 intersection = our_constraint
                 for their_constraint in other.constraints:

--- a/tests/constraints/generic/test_constraint.py
+++ b/tests/constraints/generic/test_constraint.py
@@ -812,6 +812,15 @@ def test_intersect(
         ),
         (
             UnionConstraint(ExtraConstraint("extra1"), ExtraConstraint("extra2")),
+            UnionConstraint(
+                ExtraConstraint("extra1"),
+                ExtraConstraint("extra2"),
+                ExtraConstraint("extra3"),
+            ),
+            UnionConstraint(ExtraConstraint("extra1"), ExtraConstraint("extra2")),
+        ),
+        (
+            UnionConstraint(ExtraConstraint("extra1"), ExtraConstraint("extra2")),
             UnionConstraint(ExtraConstraint("extra2"), ExtraConstraint("extra1")),
             (
                 UnionConstraint(ExtraConstraint("extra1"), ExtraConstraint("extra2")),
@@ -1530,6 +1539,15 @@ def test_union(
         (
             ExtraMultiConstraint(ExtraConstraint("extra1"), ExtraConstraint("extra2")),
             ExtraMultiConstraint(ExtraConstraint("extra1"), ExtraConstraint("extra2")),
+            ExtraMultiConstraint(ExtraConstraint("extra1"), ExtraConstraint("extra2")),
+        ),
+        (
+            ExtraMultiConstraint(ExtraConstraint("extra1"), ExtraConstraint("extra2")),
+            ExtraMultiConstraint(
+                ExtraConstraint("extra1"),
+                ExtraConstraint("extra2"),
+                ExtraConstraint("extra3"),
+            ),
             ExtraMultiConstraint(ExtraConstraint("extra1"), ExtraConstraint("extra2")),
         ),
         (

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -314,6 +314,16 @@ def test_single_marker_not_in_python_intersection() -> None:
         ),
         (
             'extra == "a" and extra == "b"',
+            'extra == "a" and extra == "b" and extra == "c"',
+            'extra == "a" and extra == "b" and extra == "c"',
+        ),
+        (
+            'extra == "a" and extra == "b" and extra == "c" and extra == "d"',
+            'extra == "a" and extra == "b"',
+            'extra == "a" and extra == "b" and extra == "c" and extra == "d"',
+        ),
+        (
+            'extra == "a" and extra == "b"',
             'extra == "c" and extra != "d"',
             'extra == "a" and extra == "b" and extra == "c" and extra != "d"',
         ),
@@ -355,6 +365,16 @@ def test_single_marker_not_in_python_intersection() -> None:
         (
             'extra == "a" or extra == "b"',
             'extra == "b" or extra == "a"',
+            'extra == "a" or extra == "b"',
+        ),
+        (
+            'extra == "a" or extra == "b"',
+            'extra == "a" or extra == "b" or extra == "c"',
+            'extra == "a" or extra == "b"',
+        ),
+        (
+            'extra == "a" or extra == "b" or extra == "c" or extra == "d"',
+            'extra == "a" or extra == "b"',
             'extra == "a" or extra == "b"',
         ),
         (
@@ -614,6 +634,16 @@ def test_single_marker_union_with_inverse() -> None:
         ),
         (
             'extra == "a" and extra == "b"',
+            'extra == "a" and extra == "b" and extra == "c"',
+            'extra == "a" and extra == "b"',
+        ),
+        (
+            'extra == "a" and extra == "b" and extra == "c" and extra == "d"',
+            'extra == "a" and extra == "b"',
+            'extra == "a" and extra == "b"',
+        ),
+        (
+            'extra == "a" and extra == "b"',
             'extra == "c" and extra != "d"',
             'extra == "a" and extra == "b" or extra == "c" and extra != "d"',
         ),
@@ -667,6 +697,16 @@ def test_single_marker_union_with_inverse() -> None:
             'extra == "a" or extra == "b"',
             'extra == "a" or extra == "b"',
             'extra == "a" or extra == "b"',
+        ),
+        (
+            'extra == "a" or extra == "b"',
+            'extra == "a" or extra == "b" or extra == "c"',
+            'extra == "a" or extra == "b" or extra == "c"',
+        ),
+        (
+            'extra == "a" or extra == "b" or extra == "c" or extra == "d"',
+            'extra == "a" or extra == "b"',
+            'extra == "a" or extra == "b" or extra == "c" or extra == "d"',
         ),
         (
             'extra == "a" or extra == "b"',


### PR DESCRIPTION
With this change unions of multi markers and intersections of union markers where one marker is the subset of the other are simplified.

Related to: python-poetry/poetry#10195

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

Tests:
- Adds tests for the changed code.