### PR TITLE
simplify `python_version` markers

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -723,8 +723,20 @@ class MultiMarker(BaseMarker):
             - union between two multimarkers where there are some common markers
               and the union of unique markers is a single marker
         """
+        from poetry.core.packages.utils.utils import get_python_constraint_from_marker
+
         if other in self._markers:
             return other
+
+        if isinstance(other, SingleMarker) and other.name in PYTHON_VERSION_MARKERS:
+            # Convert 'python_version >= "3.8" and sys_platform == "linux" or python_version > "3.6"'
+            # to 'python_version > "3.6"'
+            for m in self._markers:
+                if isinstance(m, SingleMarker) and m.name in PYTHON_VERSION_MARKERS:
+                    constraint = get_python_constraint_from_marker(m)
+                    other_constraint = get_python_constraint_from_marker(other)
+                    if other_constraint.allows_all(constraint):
+                        return other
 
         if isinstance(other, MultiMarker):
             our_markers = set(self.markers)
@@ -746,7 +758,13 @@ class MultiMarker(BaseMarker):
             unique_union = MultiMarker(*unique_markers).union(
                 MultiMarker(*other_unique_markers)
             )
-            if isinstance(unique_union, (SingleMarkerLike, AnyMarker)):
+            if isinstance(unique_union, (SingleMarkerLike, AnyMarker)) or (
+                # Convert 'python_version >= "3.8" and python_version < "3.10"
+                # or python_version >= "3.10" and python_version < "3.12"'
+                # to 'python_version >= "3.6" and python_version < "3.12"'
+                isinstance(unique_union, MultiMarker)
+                and unique_union.complexity <= (2, 2)
+            ):
                 common_markers = [
                     marker for marker in self.markers if marker in shared_markers
                 ]
@@ -856,12 +874,19 @@ class MarkerUnion(BaseMarker):
 
                     # If we have a SingleMarker then with any luck after union it'll
                     # become another SingleMarker.
+                    # Especially, for `python_version` markers a multi marker is also
+                    # an improvement. E.g. the union of 'python_version == "3.6"' and
+                    # 'python_version == "3.7" or python_version == "3.8"' is
+                    # 'python_version >= "3.6" and python_version < "3.9"'.
                     if not is_one_multi and isinstance(mark, SingleMarkerLike):
                         new_marker = mark.union(marker)
                         if new_marker.is_any():
                             return AnyMarker()
 
-                        if isinstance(new_marker, SingleMarkerLike):
+                        if isinstance(new_marker, SingleMarkerLike) or (
+                            isinstance(new_marker, MultiMarker)
+                            and new_marker.complexity <= (2, 2)
+                        ):
                             new_markers[i] = new_marker
                             included = True
                             break
@@ -903,8 +928,20 @@ class MarkerUnion(BaseMarker):
             - intersection between two markerunions where there are some common markers
               and the intersection of unique markers is not a single marker
         """
+        from poetry.core.packages.utils.utils import get_python_constraint_from_marker
+
         if other in self._markers:
             return other
+
+        if isinstance(other, SingleMarker) and other.name in PYTHON_VERSION_MARKERS:
+            # Convert '(python_version >= "3.6" or sys_platform == "linux") and python_version > "3.8"'
+            # to 'python_version > "3.8"'
+            for m in self._markers:
+                if isinstance(m, SingleMarker) and m.name in PYTHON_VERSION_MARKERS:
+                    constraint = get_python_constraint_from_marker(m)
+                    other_constraint = get_python_constraint_from_marker(other)
+                    if constraint.allows_all(other_constraint):
+                        return other
 
         if isinstance(other, MarkerUnion):
             our_markers = set(self.markers)
@@ -926,7 +963,14 @@ class MarkerUnion(BaseMarker):
             unique_intersection = MarkerUnion(*unique_markers).intersect(
                 MarkerUnion(*other_unique_markers)
             )
-            if isinstance(unique_intersection, (SingleMarkerLike, EmptyMarker)):
+            if isinstance(unique_intersection, (SingleMarkerLike, EmptyMarker)) or (
+                # Convert '(python_version == "3.6" or python_version >= "3.8)"
+                # and (python_version >= "3.6" and python_version < "3.8"
+                # or python_version == "3.9")'
+                # to 'python_version == "3.6" or python_version == "3.9"'
+                isinstance(unique_intersection, MarkerUnion)
+                and unique_intersection.complexity <= (2, 2)
+            ):
                 common_markers = [
                     marker for marker in self.markers if marker in shared_markers
                 ]
@@ -1247,16 +1291,38 @@ def _merge_single_markers(
                     result_marker = EmptyMarker()
 
         elif isinstance(result_constraint, VersionUnion) and merge_class == MarkerUnion:
-            # Convert 'python_version == "3.8" or python_version >= "3.9"'
-            # to 'python_version >= "3.8"'.
-            # Convert 'python_version <= "3.8" or python_version >= "3.9"' to "any".
             result_constraint = get_python_constraint_from_marker(marker1).union(
                 get_python_constraint_from_marker(marker2)
             )
             if result_constraint.is_any():
+                # Convert 'python_version <= "3.8" or python_version >= "3.9"' to "any".
                 result_marker = AnyMarker()
             elif result_constraint.is_simple():
+                # Convert 'python_version == "3.8" or python_version >= "3.9"'
+                # to 'python_version >= "3.8"'.
                 result_marker = SingleMarker(marker1.name, result_constraint)
+            elif isinstance(result_constraint, VersionRange):
+                # Convert 'python_version' == "3.8" or python_version == "3.9"'
+                # to 'python_version >= "3.8" and python_version < "3.10"'.
+                # Although both markers have the same complexity, the latter behaves
+                # better if it is merged with 'python_version == "3.10' in a next step
+                # for example.
+                result_marker = MultiMarker(
+                    SingleMarker(
+                        marker1.name,
+                        VersionRange(
+                            min=result_constraint.min,
+                            include_min=result_constraint.include_min,
+                        ),
+                    ),
+                    SingleMarker(
+                        marker1.name,
+                        VersionRange(
+                            max=result_constraint.max,
+                            include_max=result_constraint.include_max,
+                        ),
+                    ),
+                )
 
     return result_marker
 

--- a/tests/packages/test_main.py
+++ b/tests/packages/test_main.py
@@ -73,8 +73,8 @@ def test_dependency_from_pep_508_with_python_version() -> None:
     assert dep.name == "requests"
     assert str(dep.constraint) == "2.18.0"
     assert dep.extras == frozenset()
-    assert dep.python_versions == "~2.7 || ~2.6"
-    assert str(dep.marker) == 'python_version == "2.7" or python_version == "2.6"'
+    assert dep.python_versions == ">=2.6 <2.8"
+    assert str(dep.marker) == 'python_version >= "2.6" and python_version < "2.8"'
 
 
 def test_dependency_from_pep_508_with_single_python_version() -> None:

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -46,7 +46,7 @@ from poetry.core.version.markers import parse_marker
         ),
         (
             'python_version == "2.7" or python_version == "2.6"',
-            {"python_version": [[("==", "2.7")], [("==", "2.6")]]},
+            {"python_version": [[(">=", "2.6"), ("<", "2.8")]]},
         ),
         (
             (

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -897,6 +897,96 @@ def test_multi_marker_union_multi_is_multi(
 @pytest.mark.parametrize(
     "marker1, marker2, expected",
     [
+        # Equivalent ranges
+        (
+            'python_version == "3.8" or python_version == "3.9"',
+            'python_version >= "3.8" and python_version <= "3.9"',
+            'python_version >= "3.8" and python_version < "3.10"',
+        ),
+        (
+            'python_version == "3.8" or python_version == "3.9"',
+            (
+                'python_version >= "3.8" and python_version <= "3.9"'
+                ' and sys_platform == "linux"'
+            ),
+            'python_version >= "3.8" and python_version < "3.10"',
+        ),
+        (
+            'python_version == "3.8" or python_version == "3.9"',
+            (
+                'python_version >= "3.8" and python_version <= "3.9"'
+                ' and sys_platform == "linux"'
+            ),
+            'python_version >= "3.8" and python_version < "3.10"',
+        ),
+        (
+            'python_version == "3.8" or python_version == "3.9"',
+            (
+                'python_version >= "3.8" and python_version < "3.10"'
+                ' and sys_platform == "linux"'
+            ),
+            'python_version >= "3.8" and python_version < "3.10"',
+        ),
+        (
+            'python_version == "3.8" or python_version == "3.9"',
+            (
+                'python_version > "3.7" and python_version < "3.10"'
+                ' and sys_platform == "linux"'
+            ),
+            'python_version > "3.7" and python_version < "3.10"',
+        ),
+        (
+            'python_version == "3.8" or python_version == "3.9"',
+            (
+                'python_version > "3.7" and python_version <= "3.9"'
+                ' and sys_platform == "linux"'
+            ),
+            'python_version > "3.7" and python_version < "3.10"',
+        ),
+        (
+            (
+                'python_version == "3.8" or python_version == "3.9"'
+                ' or python_version == "3.10"'
+            ),
+            (
+                'python_version >= "3.8" and python_version <= "3.10"'
+                ' and sys_platform == "linux"'
+            ),
+            'python_version >= "3.8" and python_version <= "3.10"',
+        ),
+        (
+            (
+                'python_version == "3.8" or python_version == "3.9"'
+                ' or python_version == "3.10"'
+            ),
+            (
+                'python_version >= "3.8" and python_version < "3.11"'
+                ' and sys_platform == "linux"'
+            ),
+            'python_version >= "3.8" and python_version < "3.11"',
+        ),
+        (
+            (
+                'python_version == "3.8" or python_version == "3.9"'
+                ' or python_version == "3.10"'
+            ),
+            (
+                'python_version > "3.7" and python_version <= "3.10"'
+                ' and sys_platform == "linux"'
+            ),
+            'python_version > "3.7" and python_version <= "3.10"',
+        ),
+        (
+            (
+                'python_version == "3.8" or python_version == "3.9"'
+                ' or python_version == "3.10"'
+            ),
+            (
+                'python_version > "3.7" and python_version < "3.11"'
+                ' and sys_platform == "linux"'
+            ),
+            'python_version > "3.7" and python_version < "3.11"',
+        ),
         # Ranges with same start
         (
             'python_version >= "3.6" and python_full_version < "3.6.2"',
@@ -913,7 +1003,12 @@ def test_multi_marker_union_multi_is_multi(
             'python_version > "3.6" and python_version < "3.8"',
             'python_version > "3.6" and python_version < "3.8"',
         ),
-        # Ranges meet exactly
+        (
+            'python_version > "3.7"',
+            'python_version >= "3.8" and sys_platform == "linux"',
+            'python_version > "3.7"',
+        ),
+        # Ranges meet exactly (adjacent ranges)
         (
             'python_version >= "3.6" and python_full_version < "3.6.2"',
             'python_full_version >= "3.6.2" and python_version < "3.7"',
@@ -933,6 +1028,21 @@ def test_multi_marker_union_multi_is_multi(
             'python_version >= "3.6" and python_full_version <= "3.7.2"',
             'python_full_version > "3.6.2" and python_version < "3.8"',
             'python_version >= "3.6" and python_version < "3.8"',
+        ),
+        (
+            'python_version >= "3.8" and python_version < "3.9"',
+            'python_version >= "3.9" and python_version < "3.11"',
+            'python_version >= "3.8" and python_version < "3.11"',
+        ),
+        (
+            'python_version >= "3.8" and python_version < "3.9"',
+            'python_version >= "3.9" and python_version < "3.10"',
+            'python_version >= "3.8" and python_version < "3.10"',
+        ),
+        (
+            'python_version == "3.8"',
+            'python_version == "3.9"',
+            'python_version >= "3.8" and python_version < "3.10"',
         ),
         # Ranges overlap
         (
@@ -992,15 +1102,58 @@ def test_multi_marker_union_multi_is_multi(
             'python_version == "3.7" and implementation_name == "cpython"',
             'python_version >= "3.6" and python_version <= "3.7"',
         ),
+        # complex
+        (
+            'python_version == "3.10" and platform_system == "Linux"',
+            (
+                'python_version == "3.11" and platform_system != "Darwin"'
+                ' or platform_system != "Linux" and platform_system != "Darwin"'
+                ' and python_version <= "3.11" and python_full_version >= "3.10.0"'
+            ),
+            (
+                'python_version >= "3.10" and python_version <= "3.11"'
+                ' and platform_system != "Darwin"'
+            ),
+        ),
+        (
+            (
+                'python_version == "3.6" and platform_system == "Linux"'
+                ' and platform_machine == "aarch64" or python_version == "3.9"'
+                ' and platform_system != "Darwin" or python_version == "3.9"'
+                ' and platform_machine != "arm64" or python_version >= "3.8"'
+                ' and platform_system == "Linux" and platform_machine == "aarch64"'
+                ' and python_version < "3.10"'
+            ),
+            (
+                'python_version == "3.7" and platform_system == "Linux"'
+                ' and platform_machine == "aarch64"'
+            ),
+            (
+                (
+                    'python_version >= "3.6" and python_version < "3.10"'
+                    ' and platform_system == "Linux" and platform_machine == "aarch64"'
+                    ' or python_version == "3.9" and platform_system != "Darwin"'
+                    ' or python_version == "3.9" and platform_machine != "arm64"'
+                ),
+                (
+                    'python_version >= "3.6" and python_version < "3.10"'
+                    ' and platform_system == "Linux" and platform_machine == "aarch64"'
+                    ' or python_version == "3.9" and platform_machine != "arm64"'
+                    ' or python_version == "3.9" and platform_system != "Darwin"'
+                ),
+            ),
+        ),
     ],
 )
 def test_version_ranges_collapse_on_union(
-    marker1: str, marker2: str, expected: str
+    marker1: str, marker2: str, expected: str | tuple[str, str]
 ) -> None:
     m1 = parse_marker(marker1)
     m2 = parse_marker(marker2)
-    assert str(m1.union(m2)) == expected
-    assert str(m2.union(m1)) == expected
+    if isinstance(expected, str):
+        expected = (expected, expected)
+    assert str(m1.union(m2)) == expected[0]
+    assert str(m2.union(m1)) == expected[1]
 
 
 def test_multi_marker_union_with_union() -> None:
@@ -2177,8 +2330,8 @@ def test_complex_union() -> None:
     ]
     assert (
         str(union(*markers))
-        == 'python_version >= "3.6" and platform_system == "Darwin"'
-        ' and platform_machine == "arm64" or python_version >= "3.10"'
+        == 'platform_system == "Darwin" and platform_machine == "arm64"'
+        ' and python_version >= "3.6" or python_version >= "3.10"'
     )
 
 
@@ -2210,8 +2363,8 @@ def test_complex_intersection() -> None:
     ]
     assert (
         str(dnf(intersection(*markers).invert()))
-        == 'python_version >= "3.6" and platform_system == "Darwin"'
-        ' and platform_machine == "arm64" or python_version >= "3.10"'
+        == 'platform_system == "Darwin" and platform_machine == "arm64"'
+        ' and python_version >= "3.6" or python_version >= "3.10"'
     )
 
 
@@ -2237,10 +2390,10 @@ def test_complex_union_is_deterministic() -> None:
         'python_version >= "3.12" and platform_system == "Windows"'
         ' and sys_platform != "darwin" or sys_platform == "linux"'
         ' and python_version >= "3.12" and python_version < "4.0"'
-        ' and extra == "stretch" or python_version >= "3.12" and python_version < "4.0"'
-        ' and extra == "stretch" and extra == "test" and (sys_platform == "linux"'
-        ' or sys_platform == "win32") or sys_platform == "win32"'
-        ' and python_version >= "3.12" and extra == "test"'
+        ' and extra == "stretch" or sys_platform == "win32"'
+        ' and python_version >= "3.12" and extra == "test" or (sys_platform == "linux"'
+        ' or sys_platform == "win32") and python_version >= "3.12"'
+        ' and extra == "stretch" and extra == "test" and python_version < "4.0"'
     )
 
 
@@ -2301,28 +2454,56 @@ def test_intersection_avoids_combinatorial_explosion() -> None:
     )
 
 
-def test_intersection_no_endless_recursion() -> None:
-    m1 = parse_marker(
-        '(python_version < "3.9" or extra != "bigquery" and extra != "parquet"'
-        ' and extra != "motherduck" and extra != "athena" and extra != "synapse"'
-        ' and extra != "clickhouse" and extra != "dremio" and extra != "lancedb"'
-        ' and extra != "deltalake" and extra != "pyiceberg"'
-        ' and python_version < "3.13") and extra != "postgres" and extra != "redshift"'
-        ' and extra != "postgis"'
-    )
-    m2 = parse_marker(
-        'python_version >= "3.12" and python_version < "3.13" or extra != "databricks"'
-    )
-    expected = (
-        '(python_version < "3.9" or extra != "bigquery" and extra != "parquet"'
-        ' and extra != "motherduck" and extra != "athena" and extra != "synapse"'
-        ' and extra != "clickhouse" and extra != "dremio" and extra != "lancedb"'
-        ' and extra != "deltalake" and extra != "pyiceberg")'
-        ' and python_version < "3.13" and extra != "postgres" and extra != "redshift"'
-        ' and extra != "postgis"'
-        ' and (python_version == "3.12" or extra != "databricks")'
-    )
-    assert str(m1.intersect(m2)) == expected
+@pytest.mark.parametrize(
+    ("marker1", "marker2", "expected"),
+    [
+        (
+            (
+                '(python_version < "3.9" or extra != "bigquery" and extra != "parquet"'
+                ' and extra != "motherduck" and extra != "athena"'
+                ' and extra != "synapse" and extra != "clickhouse"'
+                ' and extra != "dremio" and extra != "lancedb"'
+                ' and extra != "deltalake" and extra != "pyiceberg"'
+                ' and python_version < "3.13") and extra != "postgres"'
+                ' and extra != "redshift" and extra != "postgis"'
+            ),
+            (
+                'python_version >= "3.12" and python_version < "3.13"'
+                ' or extra != "databricks"'
+            ),
+            (
+                '(python_version < "3.9" or extra != "bigquery" and extra != "parquet"'
+                ' and extra != "motherduck" and extra != "athena"'
+                ' and extra != "synapse" and extra != "clickhouse"'
+                ' and extra != "dremio" and extra != "lancedb"'
+                ' and extra != "deltalake" and extra != "pyiceberg")'
+                ' and python_version < "3.13" and extra != "postgres"'
+                ' and extra != "redshift" and extra != "postgis"'
+                ' and (python_version == "3.12" or extra != "databricks")'
+            ),
+        ),
+        (
+            (
+                'python_version < "3.7" and (python_version < "3.6"'
+                ' or platform_system != "Darwin" or platform_machine != "arm64")'
+            ),
+            (
+                '(python_version < "3.6" or platform_system != "Linux"'
+                ' or platform_machine != "aarch64") and python_version < "3.9"'
+            ),
+            (
+                'python_version < "3.7" and (python_version < "3.6"'
+                ' or platform_system != "Darwin" or platform_machine != "arm64")'
+                ' and (python_version < "3.6" or platform_system != "Linux"'
+                ' or platform_machine != "aarch64")'
+            ),
+        ),
+    ],
+)
+def test_intersection_no_endless_recursion(
+    marker1: str, marker2: str, expected: str
+) -> None:
+    assert str(parse_marker(marker1).intersect(parse_marker(marker2))) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Resolves: python-poetry/poetry#10249
Requires: python-poetry/poetry#10274

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

Tests:
- Adds test cases to verify the correct simplification of `python_version` markers.

## Summary by Sourcery

Tests:
- Adds test cases to verify the correct simplification of `python_version` markers.