### PR TITLE
Canonicalize dependency group name

### DIFF
--- a/src/poetry/core/packages/dependency_group.py
+++ b/src/poetry/core/packages/dependency_group.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
+from packaging.utils import canonicalize_name
+
 from poetry.core.version.markers import parse_marker
 
 
@@ -17,7 +19,8 @@ class DependencyGroup:
     def __init__(
         self, name: str, *, optional: bool = False, mixed_dynamic: bool = False
     ) -> None:
-        self._name: str = name
+        self._name: str = canonicalize_name(name)
+        self._original_name: str = name
         self._optional: bool = optional
         self._mixed_dynamic = mixed_dynamic
         self._dependencies: list[Dependency] = []

--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -10,6 +10,7 @@ from poetry.core.constraints.version import parse_constraint
 from poetry.core.constraints.version.exceptions import ParseConstraintError
 from poetry.core.packages.dependency_group import MAIN_GROUP
 from poetry.core.packages.specification import PackageSpecification
+from poetry.core.utils.helpers import CanonicalizedDict
 from poetry.core.utils.patterns import AUTHOR_REGEX
 from poetry.core.version.exceptions import InvalidVersionError
 
@@ -99,7 +100,9 @@ class Package(PackageSpecification):
 
         self.extras: Mapping[NormalizedName, Sequence[Dependency]] = {}
 
-        self._dependency_groups: Mapping[str, DependencyGroup] = {}
+        self._dependency_groups: CanonicalizedDict[DependencyGroup] = (
+            CanonicalizedDict()
+        )
 
         self.files: Sequence[Mapping[str, str]] = []
         self.optional = False
@@ -390,7 +393,7 @@ class Package(PackageSpecification):
         }
 
     def add_dependency_group(self, group: DependencyGroup) -> None:
-        groups = dict(self._dependency_groups)
+        groups = CanonicalizedDict(self._dependency_groups)
         groups[group.name] = group
         self._dependency_groups = groups
 
@@ -429,7 +432,7 @@ class Package(PackageSpecification):
         }
 
         package = self.clone()
-        package._dependency_groups = updated_groups
+        package._dependency_groups = CanonicalizedDict(updated_groups)
 
         return package
 
@@ -443,7 +446,7 @@ class Package(PackageSpecification):
             if not group.is_optional()
         }
         package = self.clone()
-        package._dependency_groups = updated_groups
+        package._dependency_groups = CanonicalizedDict(updated_groups)
 
         return package
 
@@ -464,7 +467,7 @@ class Package(PackageSpecification):
             if group_name in groups or (not only and not group.is_optional())
         }
         package = self.clone()
-        package._dependency_groups = updated_groups
+        package._dependency_groups = CanonicalizedDict(updated_groups)
 
         return package
 

--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -464,10 +464,12 @@ class Package(PackageSpecification):
 
         If `only` is set to True, then only the given groups will be selected.
         """
+        canonicalized_groups = {canonicalize_name(group) for group in groups}
         updated_groups = {
             group_name: group
             for group_name, group in self._dependency_groups.items()
-            if group_name in groups or (not only and not group.is_optional())
+            if group_name in canonicalized_groups
+            or (not only and not group.is_optional())
         }
         package = self.clone()
         package._dependency_groups = CanonicalizedDict(updated_groups)

--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 from typing import ClassVar
 from typing import TypeVar
 
+from packaging.utils import canonicalize_name
+
 from poetry.core.constraints.version import parse_constraint
 from poetry.core.constraints.version.exceptions import ParseConstraintError
 from poetry.core.packages.dependency_group import MAIN_GROUP
@@ -425,10 +427,11 @@ class Package(PackageSpecification):
         """
         Returns a clone of the package with the given dependency groups excluded.
         """
+        canonicalized_groups = {canonicalize_name(group) for group in groups}
         updated_groups = {
             group_name: group
             for group_name, group in self._dependency_groups.items()
-            if group_name not in groups
+            if group_name not in canonicalized_groups
         }
 
         package = self.clone()

--- a/src/poetry/core/utils/helpers.py
+++ b/src/poetry/core/utils/helpers.py
@@ -7,11 +7,14 @@ import tempfile
 import time
 import unicodedata
 
+from collections import UserDict
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import TypeVar
 
+from packaging.utils import NormalizedName
 from packaging.utils import canonicalize_name
 
 
@@ -124,3 +127,29 @@ def readme_content_type(path: str | Path) -> str:
         return "text/markdown"
     else:
         return "text/plain"
+
+
+_VT = TypeVar("_VT")
+
+
+class CanonicalizedDict(UserDict[NormalizedName, _VT]):
+    """Represent a dictionary that canonicalizes string keys.
+
+    This specialized dictionary ensures that string keys are stored
+    and looked up in their canonicalized form.
+    """
+
+    def __setitem__(self, key: str, value: _VT) -> None:
+        self.data[canonicalize_name(key)] = value
+
+    def __getitem__(self, key: str) -> _VT:
+        return self.data[canonicalize_name(key)]
+
+    def __delitem__(self, key: str) -> None:
+        del self.data[canonicalize_name(key)]
+
+    def __contains__(self, key: object) -> bool:
+        if isinstance(key, str):
+            return canonicalize_name(key) in self.data
+
+        return False

--- a/tests/packages/test_dependency_group.py
+++ b/tests/packages/test_dependency_group.py
@@ -491,3 +491,19 @@ def test_dependencies_for_locking_failure(
 
     with pytest.raises(ValueError):
         _ = group.dependencies_for_locking
+
+
+@pytest.mark.parametrize(
+    ["group_name", "canonicalized_name"],
+    [
+        ("Group", "group"),
+        ("foo_bar", "foo-bar"),
+        ("Foo-Bar", "foo-bar"),
+    ],
+)
+def test_dependency_group_use_canonicalize_name(
+    group_name: str, canonicalized_name: str
+) -> None:
+    group = DependencyGroup(name=group_name)
+    assert group.name == canonicalized_name
+    assert group._original_name == group_name

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -505,6 +505,15 @@ def test_with_dependency_groups(package_with_groups: Package) -> None:
     assert len(package.all_requires) == 4
 
 
+def test_with_dependency_groups_ensure_canonicalize_names_are_used(
+    package_with_groups: Package,
+) -> None:
+    package = package_with_groups.with_dependency_groups(["OpTioNal"])
+
+    assert len(package.requires) == 2
+    assert len(package.all_requires) == 4
+
+
 def test_without_optional_dependency_groups(package_with_groups: Package) -> None:
     package = package_with_groups.without_optional_dependency_groups()
 

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -667,3 +667,20 @@ def test_package_empty_python_versions() -> None:
 
     expected = "Python versions '~2.7, >=3.4, <3.8' on foo (1.2.3) is empty"
     assert str(exc_info.value) == expected
+
+
+@pytest.mark.parametrize("group_name", ["optional", "Optional", "OpTiOnAl"])
+def test_package_has_dependency_group(
+    package_with_groups: Package, group_name: str
+) -> None:
+    assert package_with_groups.has_dependency_group(group_name)
+
+
+@pytest.mark.parametrize("group_name", ["optional", "Optional", "OpTiOnAl"])
+def test_package_get_dependency_group(
+    package_with_groups: Package, group_name: str
+) -> None:
+    group = package_with_groups.dependency_group(group_name)
+
+    assert group.name == "optional"
+    assert group._original_name == "optional"

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -684,3 +684,21 @@ def test_package_get_dependency_group(
 
     assert group.name == "optional"
     assert group._original_name == "optional"
+
+
+@pytest.mark.parametrize("group_name", ["optional", "Optional", "OpTiOnAl"])
+def test_package_add_to_dependency_group(
+    package_with_groups: Package, group_name: str
+) -> None:
+    dependency = Dependency("foo-bar", "^1.0.0", groups=[group_name])
+
+    assert dependency not in package_with_groups.all_requires
+    assert (
+        dependency
+        not in package_with_groups._dependency_groups["optional"].dependencies
+    )
+
+    package_with_groups.add_dependency(dependency)
+
+    assert dependency in package_with_groups.all_requires
+    assert dependency in package_with_groups._dependency_groups["optional"].dependencies

--- a/tests/packages/test_package.py
+++ b/tests/packages/test_package.py
@@ -479,6 +479,20 @@ def test_without_dependency_groups(package_with_groups: Package) -> None:
     assert len(package.all_requires) == 2
 
 
+def test_without_dependency_groups_ensure_canonicalize_names_are_used(
+    package_with_groups: Package,
+) -> None:
+    package = package_with_groups.without_dependency_groups(["DeV"])
+
+    assert len(package.requires) == 2
+    assert len(package.all_requires) == 3
+
+    package = package_with_groups.without_dependency_groups(["DeV", "OpTioNal"])
+
+    assert len(package.requires) == 2
+    assert len(package.all_requires) == 2
+
+
 def test_with_dependency_groups(package_with_groups: Package) -> None:
     package = package_with_groups.with_dependency_groups([])
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -6,6 +6,7 @@ import tempfile
 from pathlib import Path
 from stat import S_IREAD
 from typing import TYPE_CHECKING
+from typing import Any
 
 import pytest
 
@@ -13,6 +14,7 @@ import pytest
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
+from poetry.core.utils.helpers import CanonicalizedDict
 from poetry.core.utils.helpers import combine_unicode
 from poetry.core.utils.helpers import parse_requires
 from poetry.core.utils.helpers import readme_content_type
@@ -234,3 +236,31 @@ def test_robust_rmtree(mocker: MockerFixture) -> None:
     # use the real method to remove the temp folder we created for this test
     robust_rmtree(name)
     assert not Path(name).exists()
+
+
+def test_canonicalized_dict() -> None:
+    groups: CanonicalizedDict[Any] = CanonicalizedDict()
+
+    # add item
+    groups["FoO"] = "bar"
+
+    # get item
+    assert groups["foo"] == "bar"
+    assert groups["FoO"] == "bar"
+
+    # contains item
+    assert "foo" in groups
+    assert "Foo" in groups
+
+    # ensure canonicalized name is used during update
+    groups["foo"] = "baz"
+    assert groups["foo"] == "baz"
+    assert groups["FoO"] == "baz"
+    assert "foo" in groups
+    assert "Foo" in groups
+
+    # delete item
+    del groups["Foo"]
+
+    assert "foo" not in groups
+    assert "Foo" not in groups


### PR DESCRIPTION
Resolves: python-poetry#<!-- add issue number/link here -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

Canonicalize dependency group names to ensure consistent handling and add tests to verify the correct behavior.

Enhancements:
- Canonicalize dependency group names to ensure consistent handling of group names regardless of case or format.

Tests:
- Add tests to verify that dependency group names are correctly canonicalized and handled in various scenarios.