### PR TITLE
fix `created_nested_marker` for python wildcard constraints

### DIFF
--- a/src/poetry/core/packages/utils/utils.py
+++ b/src/poetry/core/packages/utils/utils.py
@@ -274,7 +274,7 @@ def create_nested_marker(
                 padding = ".0" * (3 - version.precision)
                 part = f'python_full_version > "{version}{padding}"'
             else:
-                part = f'{min_name} {op} "{version}"'
+                part = f'{min_name} {op} "{version.stable}"'
 
             parts.append(part)
 
@@ -292,7 +292,7 @@ def create_nested_marker(
                 padding = ".0" * (3 - version.precision)
                 part = f'python_full_version <= "{version}{padding}"'
             else:
-                part = f'{max_name} {op} "{version}"'
+                part = f'{max_name} {op} "{version.stable}"'
 
             parts.append(part)
 

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -150,6 +150,12 @@ def test_create_nested_marker_base_constraint(constraint: str, expected: str) ->
                 ' or (python_version >= "3.9" and python_full_version <= "3.10.0")'
             ),
         ),
+        # wildcard
+        ("3.*", 'python_version >= "3" and python_version < "4"'),
+        ("3.9.*", 'python_version >= "3.9" and python_version < "3.10"'),
+        ("3.*,>=3.9", 'python_version >= "3.9" and python_version < "4"'),
+        ("3.*,>=3.9.0", 'python_full_version >= "3.9.0" and python_version < "4"'),
+        ("3.*,>=3.9.1", 'python_full_version >= "3.9.1" and python_version < "4"'),
     ],
 )
 def test_create_nested_marker_version_constraint(


### PR DESCRIPTION
Resolves: python-poetry/poetry#10290

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where nested markers were not correctly created for Python wildcard constraints.