### PR TITLE
Make WheelBuilder easier to inherit from

### DIFF
--- a/src/poetry/core/masonry/builders/wheel.py
+++ b/src/poetry/core/masonry/builders/wheel.py
@@ -84,7 +84,7 @@ class WheelBuilder(Builder):
         metadata_directory: Path | None = None,
         config_settings: dict[str, Any] | None = None,
     ) -> str:
-        wb = WheelBuilder(
+        wb = cls(
             poetry,
             original=original,
             executable=executable,


### PR DESCRIPTION
When inheriting from WheelBuilder, I also have to overwrite the `make_in` classmethod. As it always creates a `WheelBuilder` instead of using the current class. This small change doesn't affect your implementation. It just makes inheriting from it a little bit easier.

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Summary by Sourcery

Enhancements:
- Modify `make_in` classmethod to use `cls()` instead of directly instantiating WheelBuilder, making the class more flexible for inheritance