### PR TITLE
fix enriching [project.optional-dependencies]

### DIFF
--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -167,7 +167,10 @@ class Dependency(PackageSpecification):
                         for _extra in extra_values:
                             if not _extra.startswith("!="):
                                 new_in_extras.append(canonicalize_name(_extra))
-            self._in_extras = [*self._in_extras, *new_in_extras]
+            self._in_extras = [
+                *self._in_extras,
+                *(e for e in new_in_extras if e not in self._in_extras),
+            ]
 
         # Recalculate python versions.
         self._python_versions = "*"

--- a/src/poetry/core/packages/dependency_group.py
+++ b/src/poetry/core/packages/dependency_group.py
@@ -158,6 +158,8 @@ def _enrich_dependency(
             dependency._develop = poetry_dependency._develop  # type: ignore[has-type]
     else:
         dependency = poetry_dependency.with_features(project_dependency.features)
+        dependency._optional = project_dependency.is_optional()  # type: ignore[has-type]
+        dependency._in_extras = project_dependency.in_extras
 
     dependency.constraint = constraint
     dependency.marker = marker

--- a/tests/packages/test_dependency_group.py
+++ b/tests/packages/test_dependency_group.py
@@ -351,6 +351,40 @@ def test_remove_dependency_removes_from_both_lists() -> None:
         # root extras do not have an extra marker, they just have set _in_extras!
         (
             [
+                create_dependency(
+                    "foo", source_name="src", optional=True, in_extras=("extra1",)
+                )
+            ],
+            [create_dependency("foo", source_name="src", optional=True)],
+            [
+                create_dependency(
+                    "foo", source_name="src", optional=True, in_extras=("extra1",)
+                )
+            ],
+        ),
+        (
+            [
+                create_dependency(
+                    "foo", source_name="src", optional=True, in_extras=("extra1",)
+                )
+            ],
+            [create_dependency("foo", source_name="src")],
+            (
+                [
+                    create_dependency(
+                        "foo", source_name="src", optional=True, in_extras=("extra1",)
+                    )
+                ],
+                [
+                    create_dependency(
+                        "foo", source_name="src", optional=True, in_extras=("extra1",)
+                    ),
+                    create_dependency("foo", source_name="src"),
+                ],
+            ),
+        ),
+        (
+            [
                 Dependency.create_from_pep_508("foo;extra!='extra1'"),
                 create_dependency("foo", in_extras=("extra1",)),
             ],
@@ -462,6 +496,9 @@ def test_dependencies_for_locking(
     ]
     assert [d.in_extras for d in group.dependencies_for_locking] == [
         d.in_extras for d in expected_dependencies
+    ]
+    assert [d.is_optional() for d in group.dependencies_for_locking] == [
+        d.is_optional() for d in expected_dependencies
     ]
 
 


### PR DESCRIPTION
Resolves: python-poetry/poetry#10331

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

Fix dependency enrichment process to correctly preserve optional dependencies and extras

Bug Fixes:
- Ensure that optional dependencies and their extras are correctly maintained during dependency enrichment process

Enhancements:
- Improved dependency enrichment logic to handle optional dependencies and extras more accurately

Tests:
- Added test cases to verify preservation of optional dependencies and extras during dependency group operations