### PR TITLE
markers: simplify union of inverse (or partially inverse) atomic single markers

### DIFF
--- a/tests/constraints/generic/test_constraint.py
+++ b/tests/constraints/generic/test_constraint.py
@@ -1129,20 +1129,12 @@ def test_intersect_extra(
         (
             UnionConstraint(Constraint("win32"), Constraint("linux")),
             MultiConstraint(Constraint("win32", "!="), Constraint("darwin", "!=")),
-            UnionConstraint(
-                Constraint("win32"),
-                Constraint("linux"),
-                MultiConstraint(Constraint("win32", "!="), Constraint("darwin", "!=")),
-            ),
+            Constraint("darwin", "!="),
         ),
         (
             UnionConstraint(Constraint("win32"), Constraint("linux")),
             MultiConstraint(Constraint("win32", "!="), Constraint("linux", "!=")),
-            UnionConstraint(
-                Constraint("win32"),
-                Constraint("linux"),
-                MultiConstraint(Constraint("win32", "!="), Constraint("linux", "!=")),
-            ),
+            AnyConstraint(),
         ),
         (
             MultiConstraint(Constraint("win32", "!="), Constraint("linux", "!=")),
@@ -1513,14 +1505,25 @@ def test_union(
         (
             UnionConstraint(ExtraConstraint("extra1"), ExtraConstraint("extra2")),
             ExtraMultiConstraint(
-                ExtraConstraint("extra1", "!="), ExtraConstraint("extra3", "!=")
+                ExtraConstraint("extra3", "!="), ExtraConstraint("extra4", "!=")
             ),
             UnionConstraint(
                 ExtraConstraint("extra1"),
                 ExtraConstraint("extra2"),
                 ExtraMultiConstraint(
-                    ExtraConstraint("extra1", "!="), ExtraConstraint("extra3", "!=")
+                    ExtraConstraint("extra3", "!="), ExtraConstraint("extra4", "!=")
                 ),
+            ),
+        ),
+        (
+            UnionConstraint(ExtraConstraint("extra1"), ExtraConstraint("extra2")),
+            ExtraMultiConstraint(
+                ExtraConstraint("extra1", "!="), ExtraConstraint("extra3", "!=")
+            ),
+            UnionConstraint(
+                ExtraConstraint("extra1"),
+                ExtraConstraint("extra2"),
+                ExtraConstraint("extra3", "!="),
             ),
         ),
         (
@@ -1528,13 +1531,7 @@ def test_union(
             ExtraMultiConstraint(
                 ExtraConstraint("extra1", "!="), ExtraConstraint("extra2", "!=")
             ),
-            UnionConstraint(
-                ExtraConstraint("extra1"),
-                ExtraConstraint("extra2"),
-                ExtraMultiConstraint(
-                    ExtraConstraint("extra1", "!="), ExtraConstraint("extra2", "!=")
-                ),
-            ),
+            AnyConstraint(),
         ),
         (
             ExtraMultiConstraint(ExtraConstraint("extra1"), ExtraConstraint("extra2")),


### PR DESCRIPTION
<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Without the fix, the union of
`sys_platform == "win32" or sys_platform == "linux"` and
`sys_platform != "win32" and sys_platform != "darwin"` is not simplified to
`sys_platform != "darwin"`.


Further, the union of
`sys_platform == "win32" or sys_platform == "linux"` and
`sys_platform != "win32" and sys_platform != "linux"`
is not recognized as `AnyMarker`.

## Summary by Sourcery

Improve marker constraint simplification logic for union and intersection operations, focusing on handling inverse and partially inverse atomic markers

New Features:
- Add support for simplifying unions of inverse and partially inverse atomic markers

Enhancements:
- Optimize union constraint simplification to handle more complex marker scenarios
- Improve handling of marker intersections and unions

Tests:
- Add test cases for inverse and partially inverse atomic markers
- Expand test coverage for marker constraint simplification