### PR TITLE
fix parsing of generic constraints with "==="

### DIFF
--- a/src/poetry/core/constraints/generic/parser.py
+++ b/src/poetry/core/constraints/generic/parser.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from poetry.core.constraints.generic.base_constraint import BaseConstraint
 
 
-BASIC_CONSTRAINT = re.compile(r"^(!?==?)?\s*([^\s]+?)\s*$")
+BASIC_CONSTRAINT = re.compile(r"^(?P<op>!=|==?=?)?\s*(?P<value>\S+?)\s*$")
 STR_CMP_CONSTRAINT = re.compile(
     r"""(?ix)^ # case insensitive and verbose mode
     (?P<quote>['"]) # Single or double quotes
@@ -87,11 +87,11 @@ def _parse_single_constraint(
     # Basic comparator
 
     if m := BASIC_CONSTRAINT.match(constraint):
-        op = m.group(1)
-        if op is None:
+        op = m.group("op")
+        if op in {None, "==="}:
             op = "=="
 
-        version = m.group(2).strip()
+        version = m.group("value").strip()
 
         return constraint_type(version, op)
 

--- a/tests/constraints/generic/test_main.py
+++ b/tests/constraints/generic/test_main.py
@@ -19,6 +19,7 @@ from poetry.core.constraints.generic.parser import parse_extra_constraint
         ("win32", Constraint("win32", "=")),
         ("=win32", Constraint("win32", "=")),
         ("==win32", Constraint("win32", "=")),
+        ("===win32", Constraint("win32", "=")),
         ("!=win32", Constraint("win32", "!=")),
         ("!= win32", Constraint("win32", "!=")),
         ("'tegra' not in", Constraint("tegra", "not in")),

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -95,6 +95,8 @@ def test_parse_marker_non_python_versions(marker: str, valid: bool) -> None:
     ("marker", "expected_name", "expected_constraint"),
     [
         ('sys_platform == "darwin"', "sys_platform", "darwin"),
+        ('sys_platform === "darwin"', "sys_platform", "darwin"),
+        ('python_version == "3.9"', "python_version", "3.9"),
         (
             'python_version in "2.7, 3.0, 3.1"',
             "python_version",


### PR DESCRIPTION
<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Before, the marker `sys_platform === "linux"` had been parsed to

```
name == "sys_platform"
operator == "=="
value == "=linux"
```

which is obviously wrong.

Now it is parsed to 

```
name == "sys_platform"
operator == "=="
value == "linux"
```

which is correct because "==" and "===" are the same for generic constraints.

Disclaimer: This does not change the fact that we do not support "===" for version constraints.

## Summary by Sourcery

Fix the parsing of generic constraints to correctly handle the `===` operator as equivalent to `==`.

Bug Fixes:
- Correctly parse generic constraints that use the `===` operator.

Tests:
- Add tests for parsing generic constraints and markers using the `===` operator.