### PR TITLE
fix `validate` for (atomic) extra markers starting with "in"

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -346,7 +346,7 @@ class SingleMarkerLike(BaseMarker, ABC, Generic[SingleMarkerConstraint]):
 
 class SingleMarker(SingleMarkerLike[Union[BaseConstraint, VersionConstraint]]):
     _CONSTRAINT_RE_PATTERN_1 = re.compile(
-        r"(?i)^(?P<op>~=|!=|>=?|<=?|==?=?|not in|in)?\s*(?P<value>.+)$"
+        r"(?i)^(?P<op>~=|!=|>=?|<=?|==?=?|not in |in )?\s*(?P<value>.+)$"
     )
     _CONSTRAINT_RE_PATTERN_2 = STR_CMP_CONSTRAINT
 
@@ -385,10 +385,7 @@ class SingleMarker(SingleMarkerLike[Union[BaseConstraint, VersionConstraint]]):
                 f"Invalid marker for '{name}': {constraint_string}"
             )
 
-        self._operator = m.group("op")
-        if self._operator is None:
-            self._operator = "=="
-
+        self._operator = (m.group("op") or "==").strip()
         self._value = m.group("value")
         parser = parse_extra_constraint if name == "extra" else parse_generic_constraint
 
@@ -1097,7 +1094,7 @@ def _compact_markers(
 
             sub_marker = SingleMarker(
                 str(name),
-                f'"{value}" {op}' if stringed_value else f"{op}{value}",
+                f'"{value}" {op}' if stringed_value else f"{op} {value}",
                 swapped_name_value=swapped_name_value,
             )
             groups[-1].append(sub_marker)

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -70,6 +70,9 @@ EMPTY = "<empty>"
         '"tegra" not in platform_release',
         '"tegra" in platform_release or "rpi-v8" in platform_release',
         '"tegra" not in platform_release and "rpi-v8" not in platform_release',
+        # extra starting with "in"
+        'extra == "in1" or extra == "in2"',
+        'extra == "in1" and extra == "in2"',
     ],
 )
 def test_parse_marker(marker: str) -> None:
@@ -1514,6 +1517,17 @@ def test_multi_marker_removes_duplicates() -> None:
         ("extra != 'a' or extra == 'b'", {"extra": ("a", "b")}, True),
         ("extra != 'a' or extra == 'b'", {"extra": ("c", "d")}, True),
         ("extra != 'a' or extra == 'b'", {"extra": ("a", "c")}, False),
+        # extras starting with "in"
+        ("extra == 'in1'", {"extra": ("in1",)}, True),
+        ("extra == 'in1'", {"extra": ("other",)}, False),
+        ("extra == 'in1' or extra == 'in2'", {"extra": ("in1",)}, True),
+        ("extra == 'in1' or extra == 'in2'", {"extra": ("in2",)}, True),
+        ("extra == 'in1' or extra == 'in2'", {"extra": ("in1", "in2")}, True),
+        ("extra == 'in1' or extra == 'in2'", {"extra": ("other",)}, False),
+        ("extra == 'in1' and extra == 'in2'", {"extra": ("in1",)}, False),
+        ("extra == 'in1' and extra == 'in2'", {"extra": ("in2",)}, False),
+        ("extra == 'in1' and extra == 'in2'", {"extra": ("in1", "in2")}, True),
+        ("extra == 'in1' and extra == 'in2'", {"extra": ("other",)}, False),
     ],
 )
 def test_validate(


### PR DESCRIPTION
Resolves: python-poetry/poetry#10342

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

Fix parsing of version markers where an extra requirement name starts with 'in'.

Bug Fixes:
- Correct the regular expression and logic used to parse single marker constraints to avoid misinterpreting extras starting with 'in' as the 'in' operator.
- Ensure consistent spacing when reconstructing marker strings from parsed components.

Tests:
- Add test cases for parsing and validating markers with extras starting with 'in'.