### PR TITLE
canonicalize dependency group names

### DIFF
--- a/src/poetry/core/packages/dependency.py
+++ b/src/poetry/core/packages/dependency.py
@@ -73,7 +73,7 @@ class Dependency(PackageSpecification):
         if not groups:
             groups = [MAIN_GROUP]
 
-        self._groups = frozenset(groups)
+        self._groups = frozenset(canonicalize_name(g) for g in groups)
         self._allows_prereleases = allows_prereleases
         # "_develop" is only required for enriching [project] dependencies
         self._develop = False
@@ -116,7 +116,7 @@ class Dependency(PackageSpecification):
         return self._pretty_name
 
     @property
-    def groups(self) -> frozenset[str]:
+    def groups(self) -> frozenset[NormalizedName]:
         return self._groups
 
     @property

--- a/src/poetry/core/packages/dependency_group.py
+++ b/src/poetry/core/packages/dependency_group.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
+from packaging.utils import NormalizedName
+from packaging.utils import canonicalize_name
+
 from poetry.core.version.markers import parse_marker
 
 
@@ -10,22 +13,27 @@ if TYPE_CHECKING:
     from poetry.core.packages.dependency import Dependency
     from poetry.core.version.markers import BaseMarker
 
-MAIN_GROUP = "main"
+MAIN_GROUP: NormalizedName = canonicalize_name("main")
 
 
 class DependencyGroup:
     def __init__(
         self, name: str, *, optional: bool = False, mixed_dynamic: bool = False
     ) -> None:
-        self._name: str = name
+        self._name: NormalizedName = canonicalize_name(name)
+        self._pretty_name: str = name
         self._optional: bool = optional
         self._mixed_dynamic = mixed_dynamic
         self._dependencies: list[Dependency] = []
         self._poetry_dependencies: list[Dependency] = []
 
     @property
-    def name(self) -> str:
+    def name(self) -> NormalizedName:
         return self._name
+
+    @property
+    def pretty_name(self) -> str:
+        return self._pretty_name
 
     @property
     def dependencies(self) -> list[Dependency]:
@@ -126,7 +134,11 @@ class DependencyGroup:
 
     def __repr__(self) -> str:
         cls = self.__class__.__name__
-        return f"{cls}({self._name}, optional={self._optional})"
+        return (
+            f"{cls}({self._pretty_name!r},"
+            f" optional={self._optional},"
+            f" mixed_dynamic={self._mixed_dynamic})"
+        )
 
 
 def _enrich_dependency(

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -323,7 +323,7 @@ def test_with_constraint() -> None:
         "foo",
         "^1.2.3",
         optional=True,
-        groups=["dev"],
+        groups=["DEV"],
         allows_prereleases=True,
         extras=["bar", "baz"],
     )

--- a/tests/packages/test_dependency_group.py
+++ b/tests/packages/test_dependency_group.py
@@ -528,3 +528,19 @@ def test_dependencies_for_locking_failure(
 
     with pytest.raises(ValueError):
         _ = group.dependencies_for_locking
+
+
+@pytest.mark.parametrize(
+    ["pretty_name", "canonicalized_name"],
+    [
+        ("Group", "group"),
+        ("foo_bar", "foo-bar"),
+        ("Foo-Bar", "foo-bar"),
+    ],
+)
+def test_dependency_group_use_canonicalize_name(
+    pretty_name: str, canonicalized_name: str
+) -> None:
+    group = DependencyGroup(pretty_name)
+    assert group.name == canonicalized_name
+    assert group.pretty_name == pretty_name


### PR DESCRIPTION
Closes:  #852

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

Alternative to #852 with some small changes:

- do not introduce `CanonicalizedDict` because _in my opinion_ it is a bit overkill and I am not sure if would help to avoid errors or would be a source of new errors
- normalize groups of a dependency
- add test for `dependency_group_names`

## Summary by Sourcery

Canonicalize dependency group names to provide case-insensitive and normalized handling of dependency groups across the package management system.

New Features:
- Add support for case-insensitive dependency group name matching

Enhancements:
- Normalize dependency group names using canonicalization
- Introduce case-insensitive lookup for dependency groups

Tests:
- Add tests to verify case-insensitive dependency group handling
- Add tests for dependency group name normalization