### PR TITLE
add support for PEP 639 License Clarity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ maintainers = [
     { name = "finswimmer", email = "finswimmer77@gmail.com" },
     { name = "Bartosz Sokorski", email = "b.sokorski@gmail.com" },
 ]
-license = { text = "MIT" }
+license = "MIT"
 requires-python = ">=3.9, <4.0"
 readme = "README.md"
 keywords = ["packaging", "dependency", "poetry"]

--- a/src/poetry/core/json/schemas/project-schema.json
+++ b/src/poetry/core/json/schemas/project-schema.json
@@ -136,8 +136,17 @@
           "file": "LICENSE"
         },
         "MIT",
+        "BSD-2-Clause OR Apache-2.0",
         "LicenseRef-Proprietary"
       ]
+    },
+    "license-files": {
+      "title": "License files",
+      "description": "Relative paths or globs to paths of license files. Can be an empty list.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "authors": {
       "title": "Project authors",
@@ -281,6 +290,7 @@
           "readme",
           "requires-python",
           "license",
+          "license-files",
           "authors",
           "maintainers",
           "keywords",

--- a/src/poetry/core/masonry/builders/wheel.py
+++ b/src/poetry/core/masonry/builders/wheel.py
@@ -332,7 +332,7 @@ print(sysconfig.get_platform(), sys.implementation.cache_tag, sep='-')
                 logger.debug(f"Skipping: {legal_file.as_posix()}")
                 continue
 
-            dest = dist_info / legal_file.relative_to(self._path)
+            dest = dist_info / "licenses" / legal_file.relative_to(self._path)
             dest.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy(legal_file, dest)
 

--- a/tests/fixtures/complete_duplicates.toml
+++ b/tests/fixtures/complete_duplicates.toml
@@ -4,7 +4,7 @@ version = "0.5.0"
 description = "Python dependency management and packaging made easy."
 readme = "README.rst"
 requires-python = ">=3.8"
-license = { "text" = "MIT" }
+license = "MIT"
 authors = [
     { "name" = "Sébastien Eustace", "email" = "sebastien@eustace.io" }
 ]

--- a/tests/fixtures/complete_new.toml
+++ b/tests/fixtures/complete_new.toml
@@ -4,7 +4,8 @@ version = "0.5.0"
 description = "Python dependency management and packaging made easy."
 readme = "README.rst"
 requires-python = ">=3.8"
-license = { "text" = "MIT" }
+license = "MIT"
+license-files = [ "LICENSE" ]
 authors = [
     { "name" = "Sébastien Eustace", "email" = "sebastien@eustace.io" }
 ]

--- a/tests/fixtures/sample_project_new/pyproject.toml
+++ b/tests/fixtures/sample_project_new/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.2.3"
 description = "Some description."
 readme = "README.rst"
 requires-python = ">=3.6"
-license = { text = "MIT" }
+license = "MIT"
 keywords = ["packaging", "dependency", "poetry"]
 authors = [
     { name = "Sébastien Eustace", email = "sebastien@eustace.io" }

--- a/tests/fixtures/with_license_type_none/pyproject.toml
+++ b/tests/fixtures/with_license_type_none/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "my-package"
+version = "0.1"
+keywords = ["special"]  # field that comes after license in core metadata

--- a/tests/fixtures/with_license_type_str_empty/pyproject.toml
+++ b/tests/fixtures/with_license_type_str_empty/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "my-package"
+version = "0.1"
+license = ""
+keywords = ["special"]  # field that comes after license in core metadata

--- a/tests/fixtures/with_license_type_str_no_spdx/pyproject.toml
+++ b/tests/fixtures/with_license_type_str_no_spdx/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "my-package"
+version = "0.1"
+license = "No valid SPDX license expression"
+keywords = ["special"]  # field that comes after license in core metadata

--- a/tests/fixtures/with_license_type_text_spdx/pyproject.toml
+++ b/tests/fixtures/with_license_type_text_spdx/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "my-package"
+version = "0.1"
+license = { text = "MIT" }
+keywords = ["special"]  # field that comes after license in core metadata

--- a/tests/masonry/builders/fixtures/complete_new/pyproject.toml
+++ b/tests/masonry/builders/fixtures/complete_new/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.2.3"
 description = "Some description."
 readme = "README.rst"
 requires-python = ">=3.6,<4.0"
-license = { "text" = "MIT" }
+license = "MIT"
 authors = [
     { "name" = "Sébastien Eustace", "email" = "sebastien@eustace.io" }
 ]

--- a/tests/masonry/builders/fixtures/licenses_and_copying/pyproject.toml
+++ b/tests/masonry/builders/fixtures/licenses_and_copying/pyproject.toml
@@ -1,48 +1,8 @@
-[tool.poetry]
+[project]
 name = "my-package"
 version = "1.2.3"
 description = "Some description."
-authors = [
-    "Sébastien Eustace <sebastien@eustace.io>"
-]
-maintainers = [
-    "People Everywhere <people@everywhere.com>"
-]
+requires-python = ">=3.9"
 license = "MIT"
-
 readme = "README.rst"
-
-homepage = "https://python-poetry.org/"
-repository = "https://github.com/python-poetry/poetry"
-documentation = "https://python-poetry.org/docs"
-
-keywords = ["packaging", "dependency", "poetry"]
-
-classifiers = [
-    "Topic :: Software Development :: Build Tools",
-    "Topic :: Software Development :: Libraries :: Python Modules"
-]
-
-# Requirements
-[tool.poetry.dependencies]
-python = "^3.6"
-cleo = "^0.6"
-cachy = { version = "^0.2.0", extras = ["msgpack"] }
-
-[tool.poetry.dependencies.pendulum]
-version = "^1.4"
-markers= 'python_version ~= "2.7" and sys_platform == "win32" or python_version in "3.4 3.5"'
-optional = true
-
-[tool.poetry.group.dev.dependencies]
-pytest = "~3.4"
-
-[tool.poetry.extras]
-time = ["pendulum"]
-
-[tool.poetry.scripts]
-my-script = "my_package:main"
-my-2nd-script = "my_package:main2"
-
-[tool.poetry.urls]
-"Issue Tracker" = "https://github.com/python-poetry/poetry/issues"
+dynamic = ["classifiers", "dependencies", "requires-python"]

--- a/tests/masonry/test_api.py
+++ b/tests/masonry/test_api.py
@@ -176,11 +176,15 @@ Root-Is-Purelib: true
 Tag: py3-none-any
 """
     metadata = """\
-Metadata-Version: 2.3
+Metadata-Version: 2.4
 Name: my-package
 Version: 1.2.3
 Summary: Some description.
 License: MIT
+License-File: AUTHORS
+License-File: COPYING
+License-File: LICENCE
+License-File: LICENSE
 Keywords: packaging,dependency,poetry
 Author: Sébastien Eustace
 Author-email: sebastien@eustace.io
@@ -213,6 +217,10 @@ My Package
 ==========
 
 """
+    if project == "complete_new":
+        metadata = metadata.replace("License:", "License-Expression:").replace(
+            "Classifier: License :: OSI Approved :: MIT License\n", ""
+        )
     with temporary_directory() as tmp_dir, cwd(fixtures / project):
         dirname = api.prepare_metadata_for_build_wheel(str(tmp_dir))
 
@@ -253,11 +261,15 @@ Root-Is-Purelib: true
 Tag: py3-none-any
 """
     metadata = f"""\
-Metadata-Version: 2.3
+Metadata-Version: 2.4
 Name: my-package
 Version: 1.2.3+{local_version}
 Summary: Some description.
 License: MIT
+License-File: AUTHORS
+License-File: COPYING
+License-File: LICENCE
+License-File: LICENSE
 Keywords: packaging,dependency,poetry
 Author: Sébastien Eustace
 Author-email: sebastien@eustace.io
@@ -326,7 +338,7 @@ def test_prepare_metadata_excludes_optional_without_extras() -> None:
             assert (
                 f.read()
                 == """\
-Metadata-Version: 2.3
+Metadata-Version: 2.4
 Name: my-packager
 Version: 0.1
 Summary: Something

--- a/tests/masonry/test_metadata.py
+++ b/tests/masonry/test_metadata.py
@@ -5,12 +5,56 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from packaging.licenses import canonicalize_license_expression
+
 from poetry.core.masonry.metadata import Metadata
 from poetry.core.packages.project_package import ProjectPackage
+from poetry.core.spdx.helpers import license_by_id
 
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
+
+
+@pytest.fixture
+def package(tmp_path: Path) -> ProjectPackage:
+    package = ProjectPackage("foo", "1.0")
+    package.root_dir = tmp_path
+    return package
+
+
+@pytest.fixture
+def default_license_files(tmp_path: Path) -> tuple[str, ...]:
+    # everything that is covered by our default handling
+    license_files = (
+        "AUTHORS",
+        "AUTHORS1",
+        "COPYING",
+        "COPYING1",
+        "LICENCE",
+        "LICENCE1",
+        "LICENSE",
+        "LICENSE1",
+        "LICENSES/FILE1",
+        "LICENSES/FILE2",
+        "LICENSES/sub/FILE",
+        "NOTICE",
+        "NOTICE1",
+    )
+    for file in license_files:
+        path = tmp_path / file
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+
+        # subdirectory that should not be covered
+        path = tmp_path / "sub" / file
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+
+    # a directory which should not be covered
+    (tmp_path / "LICENSE2").mkdir()
+
+    return license_files
 
 
 @pytest.mark.parametrize(
@@ -22,9 +66,11 @@ if TYPE_CHECKING:
     ],
 )
 def test_from_package_requires_python(
-    requires_python: str | None, python: str | None, expected: str
+    package: ProjectPackage,
+    requires_python: str | None,
+    python: str | None,
+    expected: str,
 ) -> None:
-    package = ProjectPackage("foo", "1")
     if requires_python:
         package.requires_python = requires_python
     if python:
@@ -35,11 +81,108 @@ def test_from_package_requires_python(
     assert meta.requires_python == expected
 
 
-def test_from_package_readme(tmp_path: Path) -> None:
-    readme_path = tmp_path / "README.md"
+@pytest.mark.parametrize(
+    "license",
+    [None, "MIT", "Apache-2.0 OR BSD-2-Clause", "LicenseRef-MyProprietaryLicense"],
+)
+def test_from_package_license_expression(
+    package: ProjectPackage, license: str | None
+) -> None:
+    if license:
+        package.license_expression = canonicalize_license_expression(license)
+
+    metadata = Metadata.from_package(package)
+
+    assert metadata.license_expression == license
+    assert metadata.license is None
+
+
+def test_from_package_license(package: ProjectPackage) -> None:
+    package.license = license_by_id("MIT")
+
+    metadata = Metadata.from_package(package)
+
+    assert metadata.license_expression is None
+    assert metadata.license == "MIT"
+
+
+def test_from_package_license_files_not_set_no_files(package: ProjectPackage) -> None:
+    package.license_files = None
+
+    metadata = Metadata.from_package(package)
+
+    assert metadata.license_files == ()
+
+
+def test_from_package_license_files_not_set_default_files(
+    package: ProjectPackage, default_license_files: tuple[str, ...]
+) -> None:
+    package.license_files = None
+
+    metadata = Metadata.from_package(package)
+
+    assert metadata.license_files == default_license_files
+
+
+def test_from_package_license_files_explicitly_no_files(
+    package: ProjectPackage, default_license_files: tuple[str, ...]
+) -> None:
+    package.license_files = ()
+
+    metadata = Metadata.from_package(package)
+
+    assert metadata.license_files == ()
+
+
+def test_from_package_license_files_path(package: ProjectPackage) -> None:
+    package.license_files = Path("sub", "LICENSE")
+    assert package.root_dir
+    (package.root_dir / package.license_files).parent.mkdir()
+    (package.root_dir / package.license_files).touch()
+
+    metadata = Metadata.from_package(package)
+
+    assert metadata.license_files == ("sub/LICENSE",)
+
+
+def test_from_package_license_files_path_and_default_files(
+    package: ProjectPackage, default_license_files: tuple[str, ...]
+) -> None:
+    package.license_files = Path("sub", "LICENSE")
+
+    metadata = Metadata.from_package(package)
+
+    assert metadata.license_files == (*default_license_files, "sub/LICENSE")
+
+
+def test_from_package_license_files_glob_patterns(
+    package: ProjectPackage, default_license_files: tuple[str, ...]
+) -> None:
+    package.license_files = ("sub/**/*", "**/LICENSE")
+
+    metadata = Metadata.from_package(package)
+
+    assert metadata.license_files == (
+        "LICENSE",
+        *[f"sub/{f}" for f in default_license_files],
+    )
+
+
+def test_from_package_license_files_no_file_for_pattern(
+    package: ProjectPackage, default_license_files: tuple[str, ...]
+) -> None:
+    package.license_files = ("COPYING*", "foo/*", "**/LICENSE")
+
+    with pytest.raises(RuntimeError) as e:
+        Metadata.from_package(package)
+    assert str(e.value) == "No files found for license file glob pattern 'foo/*'"
+
+
+def test_from_package_readme(package: ProjectPackage) -> None:
+    assert package.root_dir
+    readme_path = package.root_dir / "README.md"
     readme_path.write_text("This is a description\néöß", encoding="utf-8")
 
-    package = ProjectPackage("foo", "1.0")
     package.readmes = (readme_path,)
 
     metadata = Metadata.from_package(package)
@@ -47,14 +190,14 @@ def test_from_package_readme(tmp_path: Path) -> None:
     assert metadata.description == "This is a description\néöß"
 
 
-def test_from_package_multiple_readmes(tmp_path: Path) -> None:
-    readme_path1 = tmp_path / "README1.md"
+def test_from_package_multiple_readmes(package: ProjectPackage) -> None:
+    assert package.root_dir
+    readme_path1 = package.root_dir / "README1.md"
     readme_path1.write_text("Description 1", encoding="utf-8")
 
-    readme_path2 = tmp_path / "README2.md"
+    readme_path2 = package.root_dir / "README2.md"
     readme_path2.write_text("Description 2", encoding="utf-8")
 
-    package = ProjectPackage("foo", "1.0")
     package.readmes = (readme_path1, readme_path2)
 
     metadata = Metadata.from_package(package)
@@ -71,9 +214,11 @@ def test_from_package_multiple_readmes(tmp_path: Path) -> None:
     ],
 )
 def test_from_package_readme_issues(
-    mocker: MockerFixture, exception: type[OSError], message: str
+    package: ProjectPackage,
+    mocker: MockerFixture,
+    exception: type[OSError],
+    message: str,
 ) -> None:
-    package = ProjectPackage("foo", "1.0")
     package.readmes = (Path("MyReadme.md"),)
 
     mocker.patch("pathlib.Path.read_text", side_effect=exception)

--- a/vendors/poetry.lock
+++ b/vendors/poetry.lock
@@ -90,4 +90,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "f6228430f81bce01a02629641ce803174db214effac30b5f5bee4e67cd45a22c"
+content-hash = "6fa7a0923b44d12dab42d32d1dd8cd4d7538c96a8386f44291fd99df5807196b"

--- a/vendors/pyproject.toml
+++ b/vendors/pyproject.toml
@@ -12,5 +12,5 @@ poetry-plugin-export = "^1.9"
 [tool.poetry.dependencies]
 fastjsonschema = "^2.18.0"
 lark = "^1.1.3"
-packaging = ">=22.0"
+packaging = ">=24.2"  # PEP 639 support was added in 24.2
 tomli = "^2.0.1"


### PR DESCRIPTION
Related to: python-poetry/poetry#9670
Downstream tests will be fixed in python-poetry/poetry#10413 after merging this one.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

## Summary by Sourcery

Implement PEP 639 license clarity support by adding parsing and validation for project.license-files and SPDX license expressions, bump core metadata version to 2.4, include license data in distributions, and deprecate legacy license tables and classifiers.

New Features:
- Support the [project].license-files key with glob patterns for specifying license files.
- Support SPDX license expressions via [project].license as a top-level string instead of the legacy table format.

Bug Fixes:
- Raise errors when mixing legacy [project].license table definitions with license-files or invalid glob patterns.
- Provide clear exceptions for missing or unreadable license files during package creation and metadata export.

Enhancements:
- Bump core metadata version to 2.4 and emit License-Expression and License-File fields in built distributions.
- Emit deprecation warnings for legacy [project].license table subkeys and deprecated license classifiers during strict validation.
- Place license files under dist-info/licenses in built wheels and include them in source distributions.

Tests:
- Add extensive tests for license parsing scenarios, invalid glob patterns, validation warnings, metadata generation, and builder inclusion of license files.