### PR TITLE
constraints/markers: fix union of multi constraints and thereby union of atomic multi markers resulting in invalid marker strings

### DIFF
--- a/src/poetry/core/constraints/generic/multi_constraint.py
+++ b/src/poetry/core/constraints/generic/multi_constraint.py
@@ -87,6 +87,11 @@ class MultiConstraint(BaseConstraint):
         if isinstance(other, MultiConstraint):
             theirs = set(other.constraints)
             common = [c for c in self.constraints if c in theirs]
+            if not common:
+                return AnyConstraint()
+            if len(common) == 1:
+                return common[0]
+
             return self.__class__(*common)
 
         if not isinstance(other, Constraint):

--- a/tests/constraints/generic/test_constraint.py
+++ b/tests/constraints/generic/test_constraint.py
@@ -1152,7 +1152,12 @@ def test_intersect_extra(
         (
             MultiConstraint(Constraint("win32", "!="), Constraint("linux", "!=")),
             MultiConstraint(Constraint("win32", "!="), Constraint("darwin", "!=")),
-            MultiConstraint(Constraint("win32", "!=")),
+            Constraint("win32", "!="),
+        ),
+        (
+            MultiConstraint(Constraint("win32", "!="), Constraint("linux", "!=")),
+            MultiConstraint(Constraint("bsd", "!="), Constraint("darwin", "!=")),
+            AnyConstraint(),
         ),
         (
             Constraint("tegra", "not in"),

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -1910,6 +1910,27 @@ def test_partially_inverse_atomic_markers() -> None:
     assert str(m2.union(m1)) == 'sys_platform != "darwin"'
 
 
+def test_atomic_marker_union_is_any() -> None:
+    m1 = parse_marker('platform_machine != "arm64" and platform_machine != "aarch64"')
+    m2 = parse_marker('platform_machine != "darwin" and platform_machine != "x86_64"')
+
+    assert m1.union(m2).is_any()
+    assert m2.union(m1).is_any()
+
+
+def test_atomic_marker_union_is_single() -> None:
+    m1 = parse_marker('platform_machine != "arm64" and platform_machine != "aarch64"')
+    m2 = parse_marker('platform_machine != "arm64" and platform_machine != "x86_64"')
+
+    result1 = m1.union(m2)
+    assert str(result1) == 'platform_machine != "arm64"'
+    assert isinstance(result1, SingleMarker)
+
+    result2 = m2.union(m1)
+    assert str(result2) == 'platform_machine != "arm64"'
+    assert isinstance(result2, SingleMarker)
+
+
 @pytest.mark.parametrize(
     "scheme, marker, expected",
     [


### PR DESCRIPTION
Resolves: python-poetry/poetry#10439

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

Fix union logic for multi constraints and atomic multi markers to properly return AnyConstraint/AnyMarker when there are no common elements and return a single constraint/marker when there is exactly one common element, accompanied by new tests to verify these behaviors.

Bug Fixes:
- Ensure MultiConstraint.union returns AnyConstraint when there are no shared constraints
- Ensure MultiConstraint.union returns a single Constraint when there is exactly one shared constraint
- Fix atomic marker union to return AnyMarker for disjoint sets and a SingleMarker for a single common element

Tests:
- Add tests for atomic marker union to verify is_any and single marker results
- Update generic constraint tests to expect AnyConstraint for unions with no common constraints