### PR TITLE
ensure Python 3.14 compatibility

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,6 +25,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
         include:
           - os: Ubuntu
             python-version: pypy-3.10

--- a/src/poetry/core/spdx/helpers.py
+++ b/src/poetry/core/spdx/helpers.py
@@ -10,7 +10,12 @@ from poetry.core.spdx.license import License
 
 
 if TYPE_CHECKING:
-    from importlib.abc import Traversable
+    import sys
+
+    if sys.version_info < (3, 11):
+        from importlib.abc import Traversable
+    else:
+        from importlib.resources.abc import Traversable
 
 
 def _get_license_file() -> Traversable:

--- a/tests/integration/test_pep517_backend.py
+++ b/tests/integration/test_pep517_backend.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.integration
 
 BUILD_SYSTEM_TEMPLATE = """
 [build-system]
-requires = ["poetry-core @ file://{project_path}"]
+requires = ["poetry-core @ {project_uri}"]
 build-backend = "poetry.core.masonry.api"
 """
 
@@ -41,9 +41,7 @@ def test_pip_install(
     with (temp_pep_517_backend_path / "pyproject.toml").open(
         mode="a", encoding="utf-8"
     ) as f:
-        f.write(
-            BUILD_SYSTEM_TEMPLATE.format(project_path=project_source_root.as_posix())
-        )
+        f.write(BUILD_SYSTEM_TEMPLATE.format(project_uri=project_source_root.as_uri()))
 
     subprocess_run(
         python,

--- a/tests/packages/test_directory_dependency.py
+++ b/tests/packages/test_directory_dependency.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import cast
@@ -94,7 +96,8 @@ def test_directory_dependency_pep_508_local_absolute() -> None:
     )
     expected = f"demo @ {path.as_uri()}"
 
-    requirement = f"demo @ file://{path.as_posix()}"
+    prefix = "/" if sys.platform == "win32" else ""
+    requirement = f"demo @ file://{prefix}{path.as_posix()}"
     _test_directory_dependency_pep_508("demo", path, requirement, expected)
 
     requirement = f"demo @ {path}"
@@ -107,7 +110,8 @@ def test_directory_dependency_pep_508_localhost() -> None:
         / "fixtures"
         / "project_with_multi_constraints_dependency"
     )
-    requirement = f"demo @ file://localhost{path.as_posix()}"
+    prefix = "/" if sys.platform == "win32" else ""
+    requirement = f"demo @ file://localhost{prefix}{path.as_posix()}"
     expected = f"demo @ {path.as_uri()}"
     _test_directory_dependency_pep_508("demo", path, requirement, expected)
 
@@ -115,8 +119,8 @@ def test_directory_dependency_pep_508_localhost() -> None:
 def test_directory_dependency_pep_508_local_relative() -> None:
     path = Path("..") / "fixtures" / "project_with_multi_constraints_dependency"
 
+    requirement = f"demo @ file://{path.as_posix()}"
     with pytest.raises(ValueError):
-        requirement = f"demo @ file://{path.as_posix()}"
         _test_directory_dependency_pep_508("demo", path, requirement)
 
     requirement = f"demo @ {path}"
@@ -133,7 +137,10 @@ def test_directory_dependency_pep_508_with_subdirectory() -> None:
     )
     expected = f"demo @ {path.as_uri()}"
 
-    requirement = f"demo @ file://{path.parent.as_posix()}#subdirectory={path.name}"
+    prefix = "/" if sys.platform == "win32" else ""
+    requirement = (
+        f"demo @ file://{prefix}{path.parent.as_posix()}#subdirectory={path.name}"
+    )
     _test_directory_dependency_pep_508("demo", path, requirement, expected)
 
 
@@ -143,7 +150,8 @@ def test_directory_dependency_pep_508_extras() -> None:
         / "fixtures"
         / "project_with_multi_constraints_dependency"
     )
-    requirement = f"demo[foo,bar] @ file://{path.as_posix()}"
+    prefix = "/" if sys.platform == "win32" else ""
+    requirement = f"demo[foo,bar] @ file://{prefix}{path.as_posix()}"
     expected = f"demo[bar,foo] @ {path.as_uri()}"
     _test_directory_dependency_pep_508("demo", path, requirement, expected)
 
@@ -154,7 +162,8 @@ def test_directory_dependency_pep_508_with_marker() -> None:
         / "fixtures"
         / "project_with_multi_constraints_dependency"
     )
-    requirement = f'demo @ file://{path.as_posix()} ; sys_platform == "linux"'
+    prefix = "/" if sys.platform == "win32" else ""
+    requirement = f'demo @ file://{prefix}{path.as_posix()} ; sys_platform == "linux"'
     expected = f'demo @ {path.as_uri()} ; sys_platform == "linux"'
     _test_directory_dependency_pep_508("demo", path, requirement, expected)
 

--- a/tests/packages/test_file_dependency.py
+++ b/tests/packages/test_file_dependency.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import cast
@@ -83,7 +85,8 @@ def test_file_dependency_pep_508_local_file_absolute(mocker: MockerFixture) -> N
     path = DIST_PATH / "demo-0.2.0.tar.gz"
     expected = f"demo @ {path.as_uri()}"
 
-    requirement = f"demo @ file://{path.as_posix()}"
+    prefix = "/" if sys.platform == "win32" else ""
+    requirement = f"demo @ file://{prefix}{path.as_posix()}"
     _test_file_dependency_pep_508(mocker, "demo", path, requirement, expected)
 
     requirement = f"demo @ {path}"
@@ -92,7 +95,8 @@ def test_file_dependency_pep_508_local_file_absolute(mocker: MockerFixture) -> N
 
 def test_file_dependency_pep_508_local_file_localhost(mocker: MockerFixture) -> None:
     path = DIST_PATH / "demo-0.2.0.tar.gz"
-    requirement = f"demo @ file://localhost{path.as_posix()}"
+    prefix = "/" if sys.platform == "win32" else ""
+    requirement = f"demo @ file://localhost{prefix}{path.as_posix()}"
     expected = f"demo @ {path.as_uri()}"
     _test_file_dependency_pep_508(mocker, "demo", path, requirement, expected)
 
@@ -116,7 +120,8 @@ def test_file_dependency_pep_508_with_subdirectory(mocker: MockerFixture) -> Non
     path = DIST_PATH / "demo.zip"
     expected = f"demo @ {path.as_uri()}#subdirectory=sub"
 
-    requirement = f"demo @ file://{path.as_posix()}#subdirectory=sub"
+    prefix = "/" if sys.platform == "win32" else ""
+    requirement = f"demo @ file://{prefix}{path.as_posix()}#subdirectory=sub"
     _test_file_dependency_pep_508(mocker, "demo", path, requirement, expected)
 
 

--- a/tests/packages/utils/test_utils_urls.py
+++ b/tests/packages/utils/test_utils_urls.py
@@ -56,6 +56,28 @@ def test_url_to_path(url: str, win_expected: str, non_win_expected: str | None) 
 
 
 @pytest.mark.skipif("sys.platform != 'win32'")
+def test_url_to_path_deprecated() -> None:
+    # This is actually not valid, but we keep it for backwards-compatibility.
+    with pytest.warns(UserWarning) as e:
+        assert url_to_path("file://c:/tmp/file") == Path(r"C:\tmp\file")
+    assert str(e[0].message) == (
+        "The file URL file://c:/tmp/file uses a drive letter without a leading slash."
+        " Did you mean file:///c:/tmp/file?"
+    )
+
+
+@pytest.mark.skipif("sys.platform != 'win32'")
+def test_url_to_path_deprecated_localhost() -> None:
+    # This is actually not valid, but we keep it for backwards-compatibility.
+    with pytest.warns(UserWarning) as e:
+        assert url_to_path("file://localhostc:/tmp/file") == Path(r"C:\tmp\file")
+    assert str(e[0].message) == (
+        "The file URL file://localhostc:/tmp/file is missing a slash between localhost"
+        " and the drive letter. Did you mean file://localhost/c:/tmp/file?"
+    )
+
+
+@pytest.mark.skipif("sys.platform != 'win32'")
 def test_url_to_path_path_to_url_symmetry_win() -> None:
     path = r"C:\tmp\file"
     assert url_to_path(path_to_url(path)) == Path(path)


### PR DESCRIPTION
<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

CI:
- Include Python 3.14 in the CI workflow for testing

## Summary by Sourcery

Ensure Python 3.14 compatibility by updating the CI workflow, refining Windows file URI handling with deprecation warnings, adjusting imports for Python version differences, and updating tests and integration scripts accordingly

Bug Fixes:
- Correct parsing of drive-letter file URLs on Windows by prepending a leading slash and issuing deprecation warnings

Enhancements:
- Import Traversable from importlib.resources.abc on Python 3.11+ for compatibility
- Refactor PEP 517 backend test to reference the build-system requirement via URI instead of file path

CI:
- Add Python 3.14 to the CI test matrix

Tests:
- Add tests for deprecated Windows file URL patterns
- Update directory and file dependency tests to include platform-specific leading slashes in file URIs