### PR TITLE
fix python constraint derived from markers to better support pre-release versions of Python

### DIFF
--- a/src/poetry/core/constraints/version/parser.py
+++ b/src/poetry/core/constraints/version/parser.py
@@ -180,6 +180,8 @@ def parse_single_constraint(
         if op == ">":
             return VersionRange(min=version)
         if op == ">=":
+            if is_marker_constraint:
+                version = version.stable
             return VersionRange(min=version, include_min=True)
 
         if m.group("wildcard") is not None:

--- a/src/poetry/core/packages/utils/utils.py
+++ b/src/poetry/core/packages/utils/utils.py
@@ -336,11 +336,14 @@ def normalize_python_version_markers(  # NOSONAR
         for op, version in or_:
             # Expand python version
             if op == "==" and "*" not in version and version.count(".") < 2:
-                version = "~" + version
+                version += ".*"
                 op = ""
 
             elif op == "!=" and "*" not in version and version.count(".") < 2:
                 version += ".*"
+
+            elif op == ">=" and version.count(".") < 2:
+                version += ".dev0"
 
             elif op in ("<=", ">"):
                 # Make adjustments on encountering versions with less than full

--- a/tests/constraints/version/test_parse_constraint.py
+++ b/tests/constraints/version/test_parse_constraint.py
@@ -22,6 +22,26 @@ from poetry.core.version.pep440 import ReleaseTag
         ("<1.2.3", VersionRange(max=Version.from_parts(1, 2, 3))),
         ("<=1.2.3", VersionRange(max=Version.from_parts(1, 2, 3), include_max=True)),
         (">=1.2.3", VersionRange(min=Version.from_parts(1, 2, 3), include_min=True)),
+        (
+            ">1.2.dev0",
+            VersionRange(min=Version.from_parts(1, 2, dev=ReleaseTag("dev", 0))),
+        ),
+        (
+            "<1.2.dev0",
+            VersionRange(max=Version.from_parts(1, 2, dev=ReleaseTag("dev", 0))),
+        ),
+        (
+            ">=1.2.dev0",
+            VersionRange(
+                min=Version.from_parts(1, 2, dev=ReleaseTag("dev", 0)), include_min=True
+            ),
+        ),
+        (
+            "<=1.2.dev0",
+            VersionRange(
+                max=Version.from_parts(1, 2, dev=ReleaseTag("dev", 0)), include_max=True
+            ),
+        ),
         ("=1.2.3", Version.from_parts(1, 2, 3)),
         ("1.2.3", Version.from_parts(1, 2, 3)),
         ("1!2.3.4", Version.from_parts(2, 3, 4, epoch=1)),
@@ -582,6 +602,25 @@ def test_parse_constraint_with_white_space_padding(
     padding = " " * (4 if with_whitespace_padding else 0)
     constraint = padding.join(["", *constraint_parts, ""])
     assert parse_constraint(constraint) == expected
+
+
+@pytest.mark.parametrize(
+    ("constraint", "expected"),
+    [
+        (">=3.14.dev0", VersionRange(min=Version.from_parts(3, 14), include_min=True)),
+        (
+            "3.14.*",
+            VersionRange(
+                Version.from_parts(3, 14), Version.from_parts(3, 15), include_min=True
+            ),
+        ),
+    ],
+)
+def test_parse_marker_constraint_special_cases(
+    constraint: str, expected: Version | VersionRange
+) -> None:
+    assert parse_marker_version_constraint(constraint) == expected
+    assert parse_constraint(constraint) != expected
 
 
 def test_parse_marker_constraint_does_not_allow_invalid_version() -> None:

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -363,10 +363,10 @@ def test_with_groups() -> None:
 @pytest.mark.parametrize(
     "marker, expected",
     [
-        ('python_version >= "3.6" and python_version < "4.0"', ">=3.6,<4.0"),
+        ('python_version >= "3.6" and python_version < "4.0"', ">=3.6.dev0,<4.0"),
         ('sys_platform == "linux"', "*"),
         ('python_version >= "3.9" or sys_platform == "linux"', "*"),
-        ('python_version >= "3.9" and sys_platform == "linux"', ">=3.9"),
+        ('python_version >= "3.9" and sys_platform == "linux"', ">=3.9.dev0"),
     ],
 )
 def test_marker_properly_sets_python_constraint(marker: str, expected: str) -> None:
@@ -386,7 +386,7 @@ def test_marker_properly_unsets_python_constraint() -> None:
     dependency = Dependency("foo", "^1.2.3")
 
     dependency.marker = 'python_version >= "3.6"'
-    assert str(dependency.python_constraint) == ">=3.6"
+    assert str(dependency.python_constraint) == ">=3.6.dev0"
 
     dependency.marker = "*"
     assert str(dependency.python_constraint) == "*"

--- a/tests/packages/test_main.py
+++ b/tests/packages/test_main.py
@@ -73,7 +73,7 @@ def test_dependency_from_pep_508_with_python_version() -> None:
     assert dep.name == "requests"
     assert str(dep.constraint) == "2.18.0"
     assert dep.extras == frozenset()
-    assert dep.python_versions == ">=2.6 <2.8"
+    assert dep.python_versions == ">=2.6.dev0 <2.8"
     assert str(dep.marker) == 'python_version >= "2.6" and python_version < "2.8"'
 
 
@@ -84,7 +84,7 @@ def test_dependency_from_pep_508_with_single_python_version() -> None:
     assert dep.name == "requests"
     assert str(dep.constraint) == "2.18.0"
     assert dep.extras == frozenset()
-    assert dep.python_versions == "~2.7"
+    assert dep.python_versions == "2.7.*"
     assert str(dep.marker) == 'python_version == "2.7"'
 
 
@@ -111,7 +111,7 @@ def test_dependency_from_pep_508_complex() -> None:
     assert dep.name == "requests"
     assert str(dep.constraint) == "2.18.0"
     assert dep.in_extras == ["foo"]
-    assert dep.python_versions == ">=2.7 !=3.2.*"
+    assert dep.python_versions == ">=2.7.dev0 !=3.2.*"
     assert (
         str(dep.marker) == 'python_version >= "2.7" and python_version != "3.2" '
         'and (sys_platform == "win32" or sys_platform == "darwin") '
@@ -176,7 +176,7 @@ def test_dependency_from_pep_508_with_python_version_union_of_multi() -> None:
     assert dep.name == "requests"
     assert str(dep.constraint) == "2.18.0"
     assert dep.extras == frozenset()
-    assert dep.python_versions == "~2.7 || ~3.4"
+    assert dep.python_versions == "2.7.* || 3.4.*"
     assert str(dep.marker) == 'python_version == "2.7" or python_version == "3.4"'
 
 
@@ -291,7 +291,7 @@ def test_dependency_from_pep_508_with_python_full_version() -> None:
     assert dep.name == "requests"
     assert str(dep.constraint) == "2.18.0"
     assert dep.extras == frozenset()
-    assert dep.python_versions == "~2.7 || >=3.4.0 <3.5.4"
+    assert dep.python_versions == "2.7.* || >=3.4.0 <3.5.4"
     assert (
         str(dep.marker) == 'python_version == "2.7" '
         'or python_full_version >= "3.4.0" and python_full_version < "3.5.4"'

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -172,7 +172,7 @@ def test_create_nested_marker_version_constraint(
     ["marker", "constraint"],
     [
         # ==
-        ('python_version == "3.6"', "~3.6"),
+        ('python_version == "3.6"', "3.6.*"),
         ('python_version == "3.6.*"', "==3.6.*"),
         ('python_version == "3.6.* "', "==3.6.*"),
         # !=
@@ -183,32 +183,32 @@ def test_create_nested_marker_version_constraint(
         ('python_version < "3"', "<3"),
         ('python_version <= "3"', "<3"),
         ('python_version > "3"', ">=3"),
-        ('python_version >= "3"', ">=3"),
+        ('python_version >= "3"', ">=3.dev0"),
         # <, <=, >, >= precision 2
         ('python_version < "3.6"', "<3.6"),
         ('python_version <= "3.6"', "<3.7"),
         ('python_version > "3.6"', ">=3.7"),
-        ('python_version >= "3.6"', ">=3.6"),
+        ('python_version >= "3.6"', ">=3.6.dev0"),
         # in, not in
         ('python_version in "2.7, 3.6"', ">=2.7.0,<2.8.0 || >=3.6.0,<3.7.0"),
         ('python_version in "2.7, 3.6.2"', ">=2.7.0,<2.8.0 || 3.6.2"),
         ('python_version not in "2.7, 3.6"', "<2.7.0 || >=2.8.0,<3.6.0 || >=3.7.0"),
         ('python_version not in "2.7, 3.6.2"', "<2.7.0 || >=2.8.0,<3.6.2 || >3.6.2"),
         # and
-        ('python_version >= "3.6" and python_full_version < "4.0"', ">=3.6, <4.0"),
+        ('python_version >= "3.6" and python_full_version < "4.0"', ">=3.6.dev0, <4.0"),
         (
             'python_full_version >= "3.6.1" and python_full_version < "4.0.0"',
             ">=3.6.1, <4.0.0",
         ),
         # or
-        ('python_version < "3.6" or python_version >= "3.9"', "<3.6 || >=3.9"),
+        ('python_version < "3.6" or python_version >= "3.9"', "<3.6 || >=3.9.dev0"),
         # and or
         (
             (
                 'python_version >= "3.7" and python_version < "3.8" or python_version'
                 ' >= "3.9" and python_version < "3.10"'
             ),
-            ">=3.7,<3.8 || >=3.9,<3.10",
+            "==3.7.* || ==3.9.*",
         ),
         (
             (
@@ -224,17 +224,17 @@ def test_create_nested_marker_version_constraint(
         # no relevant python_version
         ('python_version >= "3.9" or sys_platform == "linux"', "*"),
         # relevant python_version
-        ('python_version >= "3.9" and sys_platform == "linux"', ">=3.9"),
+        ('python_version >= "3.9" and sys_platform == "linux"', ">=3.9.dev0"),
         # exclude specific version
         (
             'python_version >= "3.5" and python_full_version != "3.7.6"',
-            ">=3.5,<3.7.6 || >3.7.6",
+            ">=3.5.dev0,<3.7.6 || >3.7.6",
         ),
         # Full exact version
-        (
-            'python_full_version == "3.6.1"',
-            "3.6.1",
-        ),
+        ('python_full_version == "3.6.0"', "3.6.0"),
+        ('python_full_version == "3.6.1"', "3.6.1"),
+        ('python_full_version >= "3.6.0"', ">=3.6.0"),
+        ('python_full_version >= "3.6.1"', ">=3.6.1"),
     ],
 )
 def test_get_python_constraint_from_marker(marker: str, constraint: str) -> None:

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -239,7 +239,7 @@ def test_create_poetry(project: str) -> None:
 
     pathlib2 = dependencies["pathlib2"]
     assert pathlib2.pretty_constraint == (">=2.2,<3.0" if new_format else "^2.2")
-    assert pathlib2.python_versions in {"~2.7", ">=2.7 <2.8"}
+    assert pathlib2.python_versions == "2.7.*"
     assert not pathlib2.is_optional()
 
     demo = dependencies["demo"]
@@ -1091,9 +1091,9 @@ def test_create_poetry_with_markers_and_extras() -> None:
 @pytest.mark.parametrize(
     "constraint, exp_python, exp_marker",
     [
-        ({"python": "3.7"}, "~3.7", 'python_version == "3.7"'),
+        ({"python": "3.7"}, "3.7.*", 'python_version == "3.7"'),
         ({"platform": "linux"}, "*", 'sys_platform == "linux"'),
-        ({"markers": 'python_version == "3.7"'}, "~3.7", 'python_version == "3.7"'),
+        ({"markers": 'python_version == "3.7"'}, "3.7.*", 'python_version == "3.7"'),
         (
             {"markers": 'platform_machine == "x86_64"'},
             "*",
@@ -1101,7 +1101,7 @@ def test_create_poetry_with_markers_and_extras() -> None:
         ),
         (
             {"python": "3.7", "markers": 'platform_machine == "x86_64"'},
-            "~3.7",
+            "3.7.*",
             'platform_machine == "x86_64" and python_version == "3.7"',
         ),
         (
@@ -1115,7 +1115,7 @@ def test_create_poetry_with_markers_and_extras() -> None:
                 "platform": "linux",
                 "markers": 'platform_machine == "x86_64"',
             },
-            "~3.7",
+            "3.7.*",
             (
                 'platform_machine == "x86_64" and python_version == "3.7" and'
                 ' sys_platform == "linux"'
@@ -1123,7 +1123,7 @@ def test_create_poetry_with_markers_and_extras() -> None:
         ),
         (
             {"python": ">=3.7", "markers": 'python_version < "4.0"'},
-            "<4.0 >=3.7",
+            "<4.0 >=3.7.dev0",
             'python_version < "4.0" and python_version >= "3.7"',
         ),
         (


### PR DESCRIPTION
https://github.com/python-poetry/poetry/actions/runs/17171517004/job/48721759731?pr=10514 (failure in `tests/utils/test_isolated_build.py::test_isolated_env_install_discards_requirements_not_needed_by_env` with Python 3.14rc2) shows that our installer does not handle environments of Python pre-release versions well. A dependency with the marker `python_version == "3.14"` is not installed because it is translated into a Python constraint `>=3.14,<3.15`, which does not allow Python 3.14rc2. With this PR the Python constraint is `>=3.14.dev0,<3.15`.

Downstream tests are fixed in python-poetry/poetry#10515

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

Improve marker-to-constraint translation to properly support Python pre-release versions by introducing `.dev0` bounds and wildcard expansions for partial-precision markers

New Features:
- Support pre-release Python versions in marker-derived constraints by using `.dev0` for lower bounds

Enhancements:
- Normalize Python version markers to expand `==x` and `!=x` to `x.*` and append `.dev0` to `>=x` bounds when precision is less than two segments
- Treat marker-based `>=` constraints as stable versions in the version parser for correct handling of dev releases

Tests:
- Add tests for parsing and formatting of `.dev0`-based version constraints and update existing expectations to match new wildcard and dev0 conventions