### PR TITLE
fix wording

### DIFF
--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -740,7 +740,7 @@ class Factory:
                     canonicalize_license_expression(project_license)
                 except InvalidLicenseExpression:
                     result["warnings"].append(
-                        "[project.license] is not a valid SPDX identifier."
+                        "[project.license] is not a valid SPDX expression."
                         " This is deprecated and will raise an error in the future."
                     )
             else:

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -947,7 +947,7 @@ def test_validate_with_license_type(
         )
     elif project in {"str_empty", "str_no_spdx"}:
         expected_warnings.append(
-            "[project.license] is not a valid SPDX identifier."
+            "[project.license] is not a valid SPDX expression."
             " This is deprecated and will raise an error in the future."
         )
 


### PR DESCRIPTION
The license field allows SPDX expressions - not just identifiers.

## Summary by Sourcery

Update license validation warning to reference SPDX expressions.

Enhancements:
- Change warning message to mention SPDX expressions instead of identifiers in core factory code.

Tests:
- Update test expectations to match the revised warning message referencing SPDX expressions.