### PR TITLE
fix schema to define optional PEP 735 dependency groups

### DIFF
--- a/src/poetry/core/json/schemas/poetry-schema.json
+++ b/src/poetry/core/json/schemas/poetry-schema.json
@@ -181,6 +181,11 @@
               "required": [
                 "include-groups"
               ]
+            },
+            {
+              "required": [
+                "optional"
+              ]
             }
           ],
           "properties": {

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -2006,3 +2006,29 @@ foo = "*"
         ("foo", "parent"),
         ("foo", "child"),
     ]
+
+
+@pytest.mark.parametrize("optional", [False, True])
+def test_create_poetry_with_optional_dependency_group(
+    temporary_directory: Path, optional: bool
+) -> None:
+    pyproject_toml = temporary_directory / "pyproject.toml"
+    content = f"""\
+[project]
+name = "my-package"
+version = "1.2.3"
+
+[dependency-groups]
+dev = [ "foo" ]
+
+# only "optional" in poetry section, no dependencies or include-groups
+[tool.poetry.group.dev]
+optional = {str(optional).lower()}
+"""
+
+    pyproject_toml.write_text(content, encoding="utf-8")
+
+    poetry = Factory().create_poetry(temporary_directory)
+    assert len(poetry.package.all_requires) == 1
+    assert poetry.package.has_dependency_group("dev")
+    assert poetry.package.dependency_group("dev").is_optional() is optional


### PR DESCRIPTION
Resolves: python-poetry/poetry#10558

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

Enable optional dependency groups in the Poetry schema per PEP 735 and verify behavior via new tests

Bug Fixes:
- Include 'optional' attribute in PEP 735 dependency group schema to allow defining optional groups without dependencies or include-groups

Tests:
- Add parametrized tests for create_poetry to verify optional dependency groups are recognized correctly