### PR TITLE
release: bump version to 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 
 
+## [2.2.1] - 2025-09-21
+
+### Fixed
+
+- Fix an issue where it was not possible to declare a PEP 735 dependency group as optional ([#888](https://github.com/python-poetry/poetry-core/pull/888)).
+
+
 ## [2.2.0] - 2025-09-14
 
 ### Added
@@ -803,7 +810,8 @@ No changes.
 - Fixed support for stub-only packages ([#28](https://github.com/python-poetry/core/pull/28)).
 
 
-[Unreleased]: https://github.com/python-poetry/poetry-core/compare/2.2.0...main
+[Unreleased]: https://github.com/python-poetry/poetry-core/compare/2.2.1...main
+[2.2.1]: https://github.com/python-poetry/poetry-core/releases/tag/2.2.1
 [2.2.0]: https://github.com/python-poetry/poetry-core/releases/tag/2.2.0
 [2.1.3]: https://github.com/python-poetry/poetry-core/releases/tag/2.1.3
 [2.1.2]: https://github.com/python-poetry/poetry-core/releases/tag/2.1.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "poetry-core"
-version = "2.2.0"
+version = "2.2.1"
 description = "Poetry PEP 517 Build Backend"
 authors = [
   { name = "Sébastien Eustace", email =  "sebastien@eustace.io" }

--- a/src/poetry/core/__init__.py
+++ b/src/poetry/core/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 # this cannot presently be replaced with importlib.metadata.version as when building
 # itself, poetry-core is not available as an installed distribution.
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 
 __vendor_site__ = (Path(__file__).parent / "_vendor").as_posix()
 


### PR DESCRIPTION
### Fixed

- Fix an issue where it was not possible to declare a PEP 735 dependency group as optional ([#888](https://github.com/python-poetry/poetry-core/pull/888)).
