### PR TITLE
fix creation of `python_version` markers from constraints with one digit (e.g. ">3,<4", "3.*")

### DIFF
--- a/src/poetry/core/packages/utils/utils.py
+++ b/src/poetry/core/packages/utils/utils.py
@@ -368,10 +368,14 @@ def normalize_python_version_markers(  # NOSONAR
         for op, version in or_:
             # Expand python version
             if op == "==" and "*" not in version and version.count(".") < 2:
+                if version.count(".") == 0:
+                    version += ".0"
                 version = "~" + version
                 op = ""
 
             elif op == "!=" and "*" not in version and version.count(".") < 2:
+                if version.count(".") == 0:
+                    version += ".0"
                 version += ".*"
 
             elif op in ("<=", ">"):
@@ -402,7 +406,6 @@ def normalize_python_version_markers(  # NOSONAR
                     elif op == ">":
                         op = ">="
 
-                if parsed_version.precision == 2:
                     version = parsed_version.next_minor().text
 
             elif op in ("in", "not in"):

--- a/tests/packages/test_dependency.py
+++ b/tests/packages/test_dependency.py
@@ -49,16 +49,6 @@ def test_to_pep_508() -> None:
     result = dependency.to_pep_508()
     assert result == "Django (>=1.23,<2.0)"
 
-    dependency = Dependency("Django", "^1.23")
-    dependency.python_versions = "~2.7 || ^3.6"
-
-    result = dependency.to_pep_508()
-    assert (
-        result == "Django (>=1.23,<2.0) ; "
-        'python_version == "2.7" '
-        'or python_version >= "3.6" and python_version < "4.0"'
-    )
-
 
 def test_to_pep_508_wilcard() -> None:
     dependency = Dependency("Django", "*")
@@ -136,11 +126,15 @@ def test_to_pep_508_with_excluded_versions(exclusion: str, expected: str) -> Non
         ("<3.5.4", 'python_full_version < "3.5.4"'),
         (">=3.5.4", 'python_full_version >= "3.5.4"'),
         ("== 3.5.4", 'python_full_version == "3.5.4"'),
+        (">=3,<4", 'python_version >= "3" and python_version < "4"'),
+        ("==3.*", 'python_version >= "3" and python_version < "4"'),
+        (
+            "~2.7 || ^3.6",
+            'python_version == "2.7" or python_version >= "3.6" and python_version < "4.0"',
+        ),
     ],
 )
-def test_to_pep_508_with_patch_python_version(
-    python_versions: str, marker: str
-) -> None:
+def test_to_pep_508_with_python_versions(python_versions: str, marker: str) -> None:
     dependency = Dependency("Django", "^1.23")
     dependency.python_versions = python_versions
 

--- a/tests/packages/test_main.py
+++ b/tests/packages/test_main.py
@@ -325,7 +325,7 @@ def test_dependency_from_pep_508_should_not_produce_empty_constraints_for_correc
 ):
     name = (
         'pytest-mypy; python_implementation != "PyPy" and python_version <= "3.10" and'
-        ' python_version > "3"'
+        ' python_version >= "3"'
     )
     dep = Dependency.create_from_pep_508(name)
 
@@ -339,5 +339,5 @@ def test_dependency_from_pep_508_should_not_produce_empty_constraints_for_correc
     assert (
         str(dep.marker)
         == 'platform_python_implementation != "PyPy" and python_version <= "3.10" and'
-        ' python_version > "3"'
+        ' python_version >= "3"'
     )

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -177,14 +177,16 @@ def test_create_nested_marker_version_constraint(
         ('python_version == "3.6"', "~3.6"),
         ('python_version == "3.6.*"', "==3.6.*"),
         ('python_version == "3.6.* "', "==3.6.*"),
+        ('python_version == "3"', ">=3.0,<3.1"),
+        ('python_version == "3.*"', ">=3,<4"),
         # !=
         ('python_version != "3.6"', "!=3.6.*"),
         ('python_version != "3.6.*"', "!=3.6.*"),
         ('python_version != "3.6.* "', "!=3.6.*"),
         # <, <=, >, >= precision 1
         ('python_version < "3"', "<3"),
-        ('python_version <= "3"', "<3"),
-        ('python_version > "3"', ">=3"),
+        ('python_version <= "3"', "<3.1"),
+        ('python_version > "3"', ">=3.1"),
         ('python_version >= "3"', ">=3"),
         # <, <=, >, >= precision 2
         ('python_version < "3.6"', "<3.6"),

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -32,6 +32,9 @@ EMPTY = "<empty>"
 @pytest.mark.parametrize(
     "marker",
     [
+        'python_version >= "3.6" and python_version < "3.9"',
+        'python_version >= "3.0" and python_version < "4.0"',
+        'python_version >= "3" and python_version < "4"',
         'sys_platform == "linux" or sys_platform == "win32"',
         'sys_platform == "win32" or sys_platform == "linux"',
         (
@@ -271,6 +274,13 @@ def test_single_marker_not_in_python_intersection() -> None:
         parse_marker('python_version not in "2.7, 3.0, 3.1, 3.2"')
     )
     assert str(intersection) == 'python_version not in "2.7, 3.0, 3.1, 3.2"'
+
+
+def test_single_marker_intersect_python_version_only_major() -> None:
+    m = parse_marker('python_version >= "3"')
+    m2 = parse_marker('python_version < "4"')
+    intersection = m.intersect(m2)
+    assert str(intersection) == 'python_version >= "3" and python_version < "4"'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Resolves: https://github.com/python-poetry/poetry-plugin-export/issues/354

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

Fix normalization of python_version markers for single-component and wildcard version constraints and update related marker intersection behavior.

Bug Fixes:
- Correct handling of python_version equality and inequality markers with one-digit versions (e.g. "3", "3.*") when normalizing to constraint ranges.
- Adjust normalization of python_version range markers using <= and > so that generated upper and lower bounds correctly reflect the intended version intervals and do not produce empty constraints.

Tests:
- Expand unit tests for dependency PEP 508 generation to cover additional python_version patterns including major-only and wildcard versions and combined constraints.
- Add marker parsing and intersection tests for python_version ranges involving major-only bounds to verify correct normalization and combination behavior.
- Update existing tests for constraint creation from python_version markers to reflect the corrected normalization logic for comparisons against major-only versions.