### PR TITLE
improve type hint for `Package.files`

### DIFF
--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -4,6 +4,7 @@ import warnings
 
 from typing import TYPE_CHECKING
 from typing import ClassVar
+from typing import TypedDict
 from typing import TypeVar
 
 from packaging.utils import canonicalize_name
@@ -34,6 +35,11 @@ if TYPE_CHECKING:
     from poetry.core.version.markers import BaseMarker
 
     T = TypeVar("T", bound="Package")
+
+
+class PackageFile(TypedDict):
+    file: str
+    hash: str
 
 
 class Package(PackageSpecification):
@@ -112,7 +118,7 @@ class Package(PackageSpecification):
 
         self._dependency_groups: Mapping[NormalizedName, DependencyGroup] = {}
 
-        self.files: Sequence[Mapping[str, str]] = []
+        self.files: Sequence[PackageFile] = []
         self.optional = False
 
         self.classifiers: Sequence[str] = []


### PR DESCRIPTION
It is a matter of weighing things up but I believe checking the keys is worth more than checking immutability.

See python-poetry/poetry#10673 for issues that the improved typing uncovered.

## Summary by Sourcery

Improve typing of package file metadata on packages.

Enhancements:
- Introduce a PackageFile TypedDict to describe package file metadata.
- Tighten the Package.files attribute type to use the new PackageFile TypedDict instead of a generic mapping.