### PR TITLE
add (optional) size and upload_time to link and Package.files

### DIFF
--- a/src/poetry/core/packages/package.py
+++ b/src/poetry/core/packages/package.py
@@ -37,9 +37,19 @@ if TYPE_CHECKING:
     T = TypeVar("T", bound="Package")
 
 
-class PackageFile(TypedDict):
+# TODO: Make use of https://peps.python.org/pep-0655/ when we drop support for Python < 3.11.
+# TODO: Make use of https://peps.python.org/pep-0705/ when we drop support for Python < 3.10.
+# We could also use the backport in typing-extensions, but it is not worth to vendor
+# another dependency just for this.
+class _PackageFile(TypedDict):
     file: str
     hash: str
+
+
+class PackageFile(_PackageFile, total=False):
+    url: str  # not required for file dependencies
+    size: int
+    upload_time: str
 
 
 class Package(PackageSpecification):

--- a/tests/packages/utils/test_utils_link.py
+++ b/tests/packages/utils/test_utils_link.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import uuid
 
+from datetime import datetime
+from datetime import timezone
 from hashlib import sha256
 
 import pytest
@@ -157,3 +159,46 @@ def test_package_link_pep592_yanked(
 
     assert link.yanked == expected_yanked
     assert link.yanked_reason == expected_yanked_reason
+
+
+def test_package_link_size_default_is_none() -> None:
+    link = Link("https://example.org")
+
+    assert link.size is None
+
+
+def test_package_link_size() -> None:
+    link = Link("https://example.org", size=1234)
+
+    assert link.size == 1234
+
+
+def test_package_link_upload_time_default_is_none() -> None:
+    link = Link("https://example.org")
+
+    assert link.upload_time is None
+
+
+@pytest.mark.parametrize(
+    ("upload_time", "expected"),
+    [
+        ("2023-06-15T08:30:45Z", datetime(2023, 6, 15, 8, 30, 45, tzinfo=timezone.utc)),
+        (
+            "2022-12-31T23:59:59+00:00",
+            datetime(2022, 12, 31, 23, 59, 59, tzinfo=timezone.utc),
+        ),
+        (
+            "2023-06-15T08:30:45.123456Z",
+            datetime(2023, 6, 15, 8, 30, 45, 123456, tzinfo=timezone.utc),
+        ),
+        (
+            "2023-06-15T10:30:45+02:00",
+            datetime(2023, 6, 15, 8, 30, 45, tzinfo=timezone.utc),
+        ),
+        ("not-a-timestamp", None),
+    ],
+)
+def test_package_link_upload_time(upload_time: str, expected: datetime) -> None:
+    link = Link("https://example.org", upload_time=upload_time)
+
+    assert link.upload_time == expected


### PR DESCRIPTION
Related-to: https://github.com/python-poetry/poetry-plugin-export/issues/336
Related-to: https://github.com/python-poetry/poetry/issues/10356
Related-to: https://github.com/python-poetry/poetry/issues/10646

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

Add optional distribution file size and upload timestamp metadata to links and package files.

New Features:
- Expose optional size and upload_time fields on package link objects, including parsed datetime access for upload_time.
- Allow Package.files entries to carry optional url, size, and upload_time metadata.

Tests:
- Add unit tests covering default and explicit size and upload_time handling on Link, including ISO 8601 timestamp parsing.