### PR TITLE
fix parsing Windows server `platform_release`

### DIFF
--- a/src/poetry/core/constraints/version/patterns.py
+++ b/src/poetry/core/constraints/version/patterns.py
@@ -29,7 +29,7 @@ BASIC_CONSTRAINT = re.compile(
 
 RELEASE_PATTERN = r"""
 (?P<release>[0-9]+(?:\.[0-9]+)*)
-(?:(\+|-)(?P<build>
+(?:(\+|-)?(?P<build>
     [0-9a-zA-Z-]+
     (?:\.[0-9a-zA-Z-]+)*
 ))?

--- a/tests/constraints/version/test_parse_constraint.py
+++ b/tests/constraints/version/test_parse_constraint.py
@@ -584,12 +584,22 @@ def test_parse_constraint_with_white_space_padding(
     assert parse_constraint(constraint) == expected
 
 
-def test_parse_marker_constraint_does_not_allow_invalid_version() -> None:
+@pytest.mark.parametrize("constraint", ["4.9.253-tegra", "2022Server"])
+def test_parse_marker_constraint_does_not_allow_invalid_version(
+    constraint: str,
+) -> None:
     with pytest.raises(ParseConstraintError):
-        parse_marker_version_constraint("4.9.253-tegra")
+        parse_marker_version_constraint(constraint)
 
 
-def test_parse_marker_constraint_does_allow_invalid_version_if_requested() -> None:
-    assert parse_marker_version_constraint(
-        "4.9.253-tegra", pep440=False
-    ) == Version.from_parts(4, 9, 253, local="tegra")
+@pytest.mark.parametrize(
+    ("constraint", "expected"),
+    [
+        ("4.9.253-tegra", Version.from_parts(4, 9, 253, local="tegra")),
+        ("2022Server", Version.from_parts(2022, local="Server")),
+    ],
+)
+def test_parse_marker_constraint_does_allow_invalid_version_if_requested(
+    constraint: str, expected: VersionConstraint
+) -> None:
+    assert parse_marker_version_constraint(constraint, pep440=False) == expected


### PR DESCRIPTION
Resolves: python-poetry/poetry#10710

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

Relax version parsing to support additional non-PEP 440 platform release formats while preserving strict validation by default.

Bug Fixes:
- Fix parsing of Windows Server-style platform_release values when non-PEP 440 versions are explicitly allowed.

Tests:
- Extend marker version constraint tests to cover additional invalid and non-PEP 440 platform release patterns, including Windows Server-style versions.