### PR TITLE
fix parsing `platform_release` with kernel versions containing multiple `+` characters

### DIFF
--- a/src/poetry/core/constraints/version/patterns.py
+++ b/src/poetry/core/constraints/version/patterns.py
@@ -27,11 +27,12 @@ BASIC_CONSTRAINT = re.compile(
     re.VERBOSE | re.IGNORECASE,
 )
 
+# pattern for non Python versions such as OS versions in `platform_release`
 RELEASE_PATTERN = r"""
 (?P<release>[0-9]+(?:\.[0-9]+)*)
 (?:(\+|-)?(?P<build>
-    [0-9a-zA-Z-]+
-    (?:\.[0-9a-zA-Z-]+)*
+    [0-9a-zA-Z+-]+
+    (?:\.[0-9a-zA-Z+-]+)*
 ))?
 """
 

--- a/tests/constraints/version/test_parse_constraint.py
+++ b/tests/constraints/version/test_parse_constraint.py
@@ -584,7 +584,7 @@ def test_parse_constraint_with_white_space_padding(
     assert parse_constraint(constraint) == expected
 
 
-@pytest.mark.parametrize("constraint", ["4.9.253-tegra", "2022Server"])
+@pytest.mark.parametrize("constraint", ["4.9.253-tegra", "2022Server", "6.12.74+deb13+1-amd64"])
 def test_parse_marker_constraint_does_not_allow_invalid_version(
     constraint: str,
 ) -> None:
@@ -597,6 +597,7 @@ def test_parse_marker_constraint_does_not_allow_invalid_version(
     [
         ("4.9.253-tegra", Version.from_parts(4, 9, 253, local="tegra")),
         ("2022Server", Version.from_parts(2022, local="Server")),
+        ("6.12.74+deb13+1-amd64", Version.from_parts(6, 12, 74, local="deb13+1-amd64")),
     ],
 )
 def test_parse_marker_constraint_does_allow_invalid_version_if_requested(

--- a/tests/constraints/version/test_parse_constraint.py
+++ b/tests/constraints/version/test_parse_constraint.py
@@ -584,7 +584,9 @@ def test_parse_constraint_with_white_space_padding(
     assert parse_constraint(constraint) == expected
 
 
-@pytest.mark.parametrize("constraint", ["4.9.253-tegra", "2022Server", "6.12.74+deb13+1-amd64"])
+@pytest.mark.parametrize(
+    "constraint", ["4.9.253-tegra", "2022Server", "6.12.74+deb13+1-amd64"]
+)
 def test_parse_marker_constraint_does_not_allow_invalid_version(
     constraint: str,
 ) -> None:


### PR DESCRIPTION
Resolves: python-poetry/poetry#10786

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->

## Summary by Sourcery

Adjust version parsing to correctly handle non-Python platform release strings with multiple '+' characters.

Bug Fixes:
- Fix parsing of platform_release values whose build metadata contains multiple '+' characters so they are treated as valid versions.

Tests:
- Extend version parsing tests to cover platform_release strings with multiple '+' characters in the local segment.