### PR TITLE
perf: make splitext ten times faster

### DIFF
--- a/src/poetry/core/packages/utils/link.py
+++ b/src/poetry/core/packages/utils/link.py
@@ -142,7 +142,7 @@ class Link:
         return urlparse.unquote(urlparse.urlsplit(self.url)[2])
 
     def splitext(self) -> tuple[str, str]:
-        return splitext(posixpath.basename(self.path.rstrip("/")))
+        return splitext(posixpath.basename(self.path.rstrip("/")), is_filename=True)
 
     @cached_property
     def ext(self) -> str:

--- a/src/poetry/core/packages/utils/utils.py
+++ b/src/poetry/core/packages/utils/utils.py
@@ -177,13 +177,13 @@ def splitext(path: str | Path, *, is_filename: bool = False) -> tuple[str, str]:
         # - is twice as fast as os.path.splitext()
         # - is by factor 10 faster than path.stem and path.suffix
         base, sep, ext = str(path).rpartition(".")
-        ext = f"{sep}{ext}"
+        ext = sep + ext
         if not base:
             return ext, ""
     else:
         base, ext = os.path.splitext(path)  # noqa: PTH122
     if base.lower().endswith(".tar"):
-        ext = f"{base[-4:]}{ext}"
+        ext = base[-4:] + ext
         base = base[:-4]
     return base, ext
 

--- a/src/poetry/core/packages/utils/utils.py
+++ b/src/poetry/core/packages/utils/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import functools
+import os
 import re
 import sys
 import warnings
@@ -159,19 +160,28 @@ def is_archive_file(name: str | Path) -> bool:
     return ext in ARCHIVE_EXTENSIONS
 
 
-def splitext(path: str | Path) -> tuple[str, str]:
-    """Like os.path.splitext, but take off .tar too"""
+def splitext(path: str | Path, *, is_filename: bool = False) -> tuple[str, str]:
+    """Like os.path.splitext, but take off .tar too
+
+    path:
+        The path or filename.
+    is_filename:
+        Whether the path is just a filename (i.e., contains no path separators).
+        In this case, we can use a performance shortcut
+        that only takes half of the time.
+    """
     # Do not use pathlib because this method is a performance hotspot!
-    if isinstance(path, Path):
-        path = str(path)
-    # Using rpartition()
-    # - seems to be slightly faster than rsplit()
-    # - is much faster than os.path.splitext()
-    # - is by factor 10 faster than path.stem and path.suffix
-    base, sep, ext = path.rpartition(".")
-    ext = f"{sep}{ext}"
-    if not base:
-        return ext, ""
+    if is_filename:
+        # Using rpartition()
+        # - seems to be slightly faster than rsplit()
+        # - is twice as fast as os.path.splitext()
+        # - is by factor 10 faster than path.stem and path.suffix
+        base, sep, ext = str(path).rpartition(".")
+        ext = f"{sep}{ext}"
+        if not base:
+            return ext, ""
+    else:
+        base, ext = os.path.splitext(path)  # noqa: PTH122
     if base.lower().endswith(".tar"):
         ext = f"{base[-4:]}{ext}"
         base = base[:-4]

--- a/src/poetry/core/packages/utils/utils.py
+++ b/src/poetry/core/packages/utils/utils.py
@@ -160,10 +160,18 @@ def is_archive_file(name: str | Path) -> bool:
 
 
 def splitext(path: str | Path) -> tuple[str, str]:
-    """Like pathlib.Path.stem and suffix, but take off .tar too"""
-    if isinstance(path, str):
-        path = Path(path)
-    base, ext = path.stem, path.suffix
+    """Like os.path.splitext, but take off .tar too"""
+    # Do not use pathlib because this method is a performance hotspot!
+    if isinstance(path, Path):
+        path = str(path)
+    # Using rpartition()
+    # - seems to be slightly faster than rsplit()
+    # - is much faster than os.path.splitext()
+    # - is by factor 10 faster than path.stem and path.suffix
+    base, sep, ext = path.rpartition(".")
+    ext = f"{sep}{ext}"
+    if not base:
+        return ext, ""
     if base.lower().endswith(".tar"):
         ext = f"{base[-4:]}{ext}"
         base = base[:-4]

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -11,6 +11,7 @@ from poetry.core.packages.utils.utils import convert_markers
 from poetry.core.packages.utils.utils import create_nested_marker
 from poetry.core.packages.utils.utils import get_python_constraint_from_marker
 from poetry.core.packages.utils.utils import is_python_project
+from poetry.core.packages.utils.utils import splitext
 from poetry.core.version.markers import parse_marker
 
 
@@ -245,6 +246,24 @@ def test_get_python_constraint_from_marker(marker: str, constraint: str) -> None
     marker_parsed = parse_marker(marker)
     constraint_parsed = parse_marker_version_constraint(constraint)
     assert get_python_constraint_from_marker(marker_parsed) == constraint_parsed
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("demo", ("demo", "")),
+        ("demo.whl", ("demo", ".whl")),
+        (".env", (".env", "")),
+        ("demo-1.0.0.tar", ("demo-1.0.0", ".tar")),
+        ("demo-1.0.0.tar.gz", ("demo-1.0.0", ".tar.gz")),
+        ("demo-1.0.0.tar.bz2", ("demo-1.0.0", ".tar.bz2")),
+        ("demo-1.0.0.TAR.GZ", ("demo-1.0.0", ".TAR.GZ")),
+        ("dist/demo-1.0.0.tar.gz", ("dist/demo-1.0.0", ".tar.gz")),
+        (Path("demo-1.0.0.tar.gz"), ("demo-1.0.0", ".tar.gz")),
+    ],
+)
+def test_splitext(path: str | Path, expected: tuple[str, str]) -> None:
+    assert splitext(path) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -263,7 +263,12 @@ def test_get_python_constraint_from_marker(marker: str, constraint: str) -> None
         (Path("dist/demo-1.0.0.tar.gz"), (str(Path("dist/demo-1.0.0")), ".tar.gz")),
     ],
 )
-def test_splitext(path: str | Path, expected: tuple[str, str]) -> None:
+@pytest.mark.parametrize("is_filename", [False, True])
+def test_splitext(
+    path: str | Path, expected: tuple[str, str], is_filename: bool
+) -> None:
+    if is_filename is True and "/" in Path(path).as_posix():
+        pytest.skip(reason="Not a filename")
     assert splitext(path) == expected
 
 

--- a/tests/packages/utils/test_utils.py
+++ b/tests/packages/utils/test_utils.py
@@ -260,6 +260,7 @@ def test_get_python_constraint_from_marker(marker: str, constraint: str) -> None
         ("demo-1.0.0.TAR.GZ", ("demo-1.0.0", ".TAR.GZ")),
         ("dist/demo-1.0.0.tar.gz", ("dist/demo-1.0.0", ".tar.gz")),
         (Path("demo-1.0.0.tar.gz"), ("demo-1.0.0", ".tar.gz")),
+        (Path("dist/demo-1.0.0.tar.gz"), (str(Path("dist/demo-1.0.0")), ".tar.gz")),
     ],
 )
 def test_splitext(path: str | Path, expected: tuple[str, str]) -> None:


### PR DESCRIPTION
Since this is a hotspot during dependency resolution, this even makes "poetry lock" 10 % faster in some cases.

Incidentally, this also reverts the irrelevant change we ignored in https://github.com/python-poetry/poetry-core/pull/641/changes#r1460856881.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
