### PR TITLE
perf: allow to create Link with given filename

### DIFF
--- a/src/poetry/core/packages/utils/link.py
+++ b/src/poetry/core/packages/utils/link.py
@@ -22,6 +22,7 @@ class Link:
         self,
         url: str,
         *,
+        filename: str | None = None,
         requires_python: str | None = None,
         hashes: Mapping[str, str] | None = None,
         metadata: str | bool | dict[str, str] | None = None,
@@ -34,6 +35,12 @@ class Link:
 
         url:
             url of the resource pointed to (href of the link)
+        filename:
+            The filename of the resource.
+            If not provided, it will be derived from the URL.
+            PEP 691 mandates a `filename` field,
+            which does not even have to be part of the URL.
+            Further, using it lets us skip expensive work.
         requires_python:
             String containing the `Requires-Python` metadata field, specified
             in PEP 345. This may be specified by a data-requires-python
@@ -64,6 +71,9 @@ class Link:
             url = path_to_url(url)
 
         self.url = url
+        if filename:
+            # override cached_property
+            self.filename = filename
         self.requires_python = requires_python if requires_python else None
         self._hashes = hashes
 
@@ -142,7 +152,7 @@ class Link:
         return urlparse.unquote(urlparse.urlsplit(self.url)[2])
 
     def splitext(self) -> tuple[str, str]:
-        return splitext(posixpath.basename(self.path.rstrip("/")), is_filename=True)
+        return splitext(self.filename, is_filename=True)
 
     @cached_property
     def ext(self) -> str:

--- a/tests/packages/utils/test_utils_link.py
+++ b/tests/packages/utils/test_utils_link.py
@@ -28,6 +28,7 @@ def metadata_checksum() -> str:
 def make_url(
     ext: str,
     *,
+    filename: str | None = None,
     file_checksum: str | None = None,
     metadata_checksum: str | None = None,
     hashes: dict[str, str] | None = None,
@@ -39,7 +40,31 @@ def make_url(
         url += f"#sha256={file_checksum}"
     if not metadata:
         metadata = f"sha256={metadata_checksum}" if metadata_checksum else None
-    return Link(url, hashes=hashes, metadata=metadata)
+    return Link(url, filename=filename, hashes=hashes, metadata=metadata)
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected"),
+    [
+        (None, "demo-1.0.0.whl"),
+        ("other.whl", "other.whl"),
+    ],
+)
+def test_package_link_filename(filename: str | None, expected: str) -> None:
+    link = make_url(ext="whl", filename=filename)
+    assert link.filename == expected
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected"),
+    [
+        (None, ".whl"),
+        ("other.tar.gz", ".tar.gz"),
+    ],
+)
+def test_package_link_ext(filename: str | None, expected: str) -> None:
+    link = make_url(ext="whl", filename=filename)
+    assert link.ext == expected
 
 
 def test_package_link_hash(file_checksum: str) -> None:


### PR DESCRIPTION
Extracting the filename from the URL is quite expensive and PEP 691 mandates a `filename` field anyway.

This can be used downstream to speed up locking by about 15 % in some cases.

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
