### PR TITLE
release: bump version to 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 
 
+## [2.4.1] - 2026-05-23
+
+### Fixed
+
+- Fix an issue where certain marker operations (mostly used with extra markers) resulted in wrong markers ([#943](https://github.com/python-poetry/poetry-core/pull/943)).
+
+
 ## [2.4.0] - 2026-05-03
 
 ### Changed
@@ -886,7 +893,8 @@ No changes.
 - Fixed support for stub-only packages ([#28](https://github.com/python-poetry/core/pull/28)).
 
 
-[Unreleased]: https://github.com/python-poetry/poetry-core/compare/2.4.0...main
+[Unreleased]: https://github.com/python-poetry/poetry-core/compare/2.4.1...main
+[2.4.1]: https://github.com/python-poetry/poetry-core/releases/tag/2.4.1
 [2.4.0]: https://github.com/python-poetry/poetry-core/releases/tag/2.4.0
 [2.3.2]: https://github.com/python-poetry/poetry-core/releases/tag/2.3.2
 [2.3.1]: https://github.com/python-poetry/poetry-core/releases/tag/2.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "poetry-core"
-version = "2.4.0"
+version = "2.4.1"
 description = "Poetry PEP 517 Build Backend"
 authors = [
   { name = "Sébastien Eustace", email =  "sebastien@eustace.io" }

--- a/src/poetry/core/__init__.py
+++ b/src/poetry/core/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 # this cannot presently be replaced with importlib.metadata.version as when building
 # itself, poetry-core is not available as an installed distribution.
-__version__ = "2.4.0"
+__version__ = "2.4.1"
 
 __vendor_site__ = (Path(__file__).parent / "_vendor").as_posix()
 


### PR DESCRIPTION
### Fixed

- Fix an issue where certain marker operations (mostly used with extra markers) resulted in wrong markers ([#943](https://github.com/python-poetry/poetry-core/pull/943)).
