### PR TITLE
add `Marker.apply(environment)` to partially evaluate a marker

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -102,6 +102,27 @@ class BaseMarker(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def apply(self, environment: Mapping[str, Any]) -> BaseMarker:
+        """
+        Partially evaluate this marker against the (possibly partial) environment.
+
+        Similar to `validate`, but instead of collapsing the whole marker tree to
+        a single `bool`, this returns a simplified `BaseMarker`:
+
+        - Single markers whose variable name is present in `environment` are
+          validated and replaced with `AnyMarker` (if they hold) or `EmptyMarker`
+          (if they do not).
+        - Single markers whose variable name is not present in `environment` are
+          left untouched, so the result can still depend on those undefined
+          variables.
+        - Composite markers are simplified as usual.
+
+        Whereas `validate` treats missing variables as satisfied (returning
+        `True`), `apply` preserves them so the caller can decide later.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def without_extras(self) -> BaseMarker:
         raise NotImplementedError
 
@@ -148,6 +169,9 @@ class AnyMarker(BaseMarker):
     def validate(self, environment: Mapping[str, Any] | None) -> bool:
         return True
 
+    def apply(self, environment: Mapping[str, Any]) -> BaseMarker:
+        return self
+
     def without_extras(self) -> BaseMarker:
         return self
 
@@ -193,6 +217,9 @@ class EmptyMarker(BaseMarker):
 
     def validate(self, environment: Mapping[str, Any] | None) -> bool:
         return False
+
+    def apply(self, environment: Mapping[str, Any]) -> BaseMarker:
+        return self
 
     def without_extras(self) -> BaseMarker:
         return self
@@ -292,6 +319,11 @@ class SingleMarkerLike(BaseMarker, ABC, Generic[SingleMarkerConstraint]):
         # to know that.
         constraint = self._parser(environment[self._name])
         return self._constraint.allows(constraint)  # type: ignore[arg-type]
+
+    def apply(self, environment: Mapping[str, Any]) -> BaseMarker:
+        if self._name not in environment:
+            return self
+        return AnyMarker() if self.validate(environment) else EmptyMarker()
 
     def without_extras(self) -> BaseMarker:
         return self.exclude("extra")
@@ -770,6 +802,11 @@ class MultiMarker(BaseMarker):
     def validate(self, environment: Mapping[str, Any] | None) -> bool:
         return all(m.validate(environment) for m in self._markers)
 
+    def apply(self, environment: Mapping[str, Any]) -> BaseMarker:
+        if not environment:
+            return self
+        return self.of(*(m.apply(environment) for m in self._markers))
+
     def without_extras(self) -> BaseMarker:
         return self.exclude("extra")
 
@@ -975,6 +1012,11 @@ class MarkerUnion(BaseMarker):
 
     def validate(self, environment: Mapping[str, Any] | None) -> bool:
         return any(m.validate(environment) for m in self._markers)
+
+    def apply(self, environment: Mapping[str, Any]) -> BaseMarker:
+        if not environment:
+            return self
+        return self.of(*(m.apply(environment) for m in self._markers))
 
     def without_extras(self) -> BaseMarker:
         return self.exclude("extra")

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -1541,6 +1541,109 @@ def test_validate(
 
 
 @pytest.mark.parametrize(
+    ("marker_string", "environment", "expected"),
+    [
+        # AnyMarker / EmptyMarker are returned unchanged.
+        ("", {}, ""),
+        ("", {"os_name": "linux"}, ""),
+        (EMPTY, {}, EMPTY),
+        (EMPTY, {"os_name": "linux"}, EMPTY),
+        # Empty environment preserves the marker.
+        ("os_name == 'foo'", {}, "os_name == 'foo'"),
+        (
+            "python_version >= '3.8' and sys_platform == 'linux'",
+            {},
+            "python_version >= '3.8' and sys_platform == 'linux'",
+        ),
+        # SingleMarker with name in env collapses to Any/Empty.
+        ("os_name == 'foo'", {"os_name": "foo"}, ""),
+        ("os_name == 'foo'", {"os_name": "bar"}, EMPTY),
+        ("python_version >= '3.8'", {"python_version": "3.10"}, ""),
+        ("python_version >= '3.8'", {"python_version": "3.7"}, EMPTY),
+        # SingleMarker with name not in env is returned unchanged.
+        ("os_name == 'foo'", {}, "os_name == 'foo'"),
+        ("os_name == 'foo'", {"sys_platform": "linux"}, "os_name == 'foo'"),
+        # MultiMarker: only one name in env -> residual is the other branch.
+        (
+            "python_version >= '3.8' and sys_platform == 'linux'",
+            {"python_version": "3.10"},
+            "sys_platform == 'linux'",
+        ),
+        (
+            "python_version >= '3.8' and sys_platform == 'linux'",
+            {"sys_platform": "linux"},
+            "python_version >= '3.8'",
+        ),
+        # MultiMarker: one branch is False -> whole thing collapses to Empty.
+        (
+            "python_version >= '3.8' and sys_platform == 'linux'",
+            {"python_version": "3.7"},
+            EMPTY,
+        ),
+        # MultiMarker: both names known.
+        (
+            "python_version >= '3.8' and sys_platform == 'linux'",
+            {"python_version": "3.10", "sys_platform": "linux"},
+            "",
+        ),
+        (
+            "python_version >= '3.8' and sys_platform == 'linux'",
+            {"python_version": "3.10", "sys_platform": "win32"},
+            EMPTY,
+        ),
+        # MarkerUnion: one branch True -> collapses to Any.
+        (
+            "python_version >= '3.8' or sys_platform == 'linux'",
+            {"python_version": "3.10"},
+            "",
+        ),
+        # MarkerUnion: one branch False -> residual is the other branch.
+        (
+            "python_version >= '3.8' or sys_platform == 'linux'",
+            {"python_version": "3.7"},
+            "sys_platform == 'linux'",
+        ),
+        # MarkerUnion: both names known.
+        (
+            "python_version >= '3.8' or sys_platform == 'linux'",
+            {"python_version": "3.7", "sys_platform": "win32"},
+            EMPTY,
+        ),
+        # Nested: (A or B) and C, only python_version known.
+        (
+            "(python_version >= '3.8' or sys_platform == 'win32') and extra == 'foo'",
+            {"python_version": "3.10"},
+            "extra == 'foo'",
+        ),
+        (
+            "(python_version >= '3.8' or sys_platform == 'win32') and extra == 'foo'",
+            {"python_version": "3.7"},
+            "sys_platform == 'win32' and extra == 'foo'",
+        ),
+        # extra: name in env is evaluated, including empty-tuple case.
+        ("extra == 'a'", {"extra": "a"}, ""),
+        ("extra == 'a'", {"extra": "b"}, EMPTY),
+        ("extra == 'a'", {"extra": ()}, EMPTY),
+        ("extra != 'a'", {"extra": ()}, ""),
+        # extra: name not in env is preserved.
+        ("extra == 'a'", {}, "extra == 'a'"),
+        ("extra == 'a'", {"python_version": "3.10"}, "extra == 'a'"),
+        # AtomicMultiMarker / AtomicMarkerUnion (compact extra forms).
+        ("extra != 'a' and extra != 'b'", {"extra": ("c",)}, ""),
+        ("extra != 'a' and extra != 'b'", {"extra": ("a",)}, EMPTY),
+        ("extra != 'a' and extra != 'b'", {}, "extra != 'a' and extra != 'b'"),
+        ("extra == 'a' or extra == 'b'", {"extra": ("a",)}, ""),
+        ("extra == 'a' or extra == 'b'", {"extra": ("c",)}, EMPTY),
+        ("extra == 'a' or extra == 'b'", {}, "extra == 'a' or extra == 'b'"),
+    ],
+)
+def test_apply(marker_string: str, environment: dict[str, str], expected: str) -> None:
+    m = parse_marker(marker_string)
+
+    assert m.apply(environment) == parse_marker(expected)
+
+
+@pytest.mark.parametrize(
     "marker, env",
     [
         (


### PR DESCRIPTION
<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

This is required by poetry-plugin-export, which previously used a combination of `validate` and `without_extras`, which only worked in some cases.

Updating poetry-core to 2.4.1 in the poetry repo in python-poetry/poetry#10921 revealed that #943 partially breaks and partially fixes poetry-plugin-export.

It breaks https://github.com/python-poetry/poetry-plugin-export/blob/65172a089497c4dc1e0da020db637b0376ea25c1/tests/test_exporter_pylock_toml.py#L955-L960

It fixes https://github.com/python-poetry/poetry-plugin-export/blob/65172a089497c4dc1e0da020db637b0376ea25c1/tests/test_exporter_pylock_toml.py#L973-L978 and reveals that the expectation is wrong - it should be `"*"`.

I think we do not have a suitable method (or methods to combine) in poetry-core to achieve what is really required in poetry-plugin-export yet.