### PR TITLE
Fix VersionRange.intersect broadening for local-version other

### DIFF
--- a/src/poetry/core/constraints/version/version_range.py
+++ b/src/poetry/core/constraints/version/version_range.py
@@ -205,7 +205,16 @@ class VersionRange(VersionRangeConstraint):
                 return other
 
             # `>=1.2.3+local` intersects `1.2.3` to return `>=1.2.3+local,<1.2.4`.
-            if self.min is not None and self.min.is_local() and other.allows(self.min):
+            # Skip when ``other`` is itself a local version: for an exclusive
+            # lower bound like ``>1.2.3+local`` intersected with the excluded
+            # point ``1.2.3+local``, broadening would wrongly return a
+            # non-empty range instead of the correct empty constraint.
+            if (
+                self.min is not None
+                and self.min.is_local()
+                and not other.is_local()
+                and other.allows(self.min)
+            ):
                 upper = other.stable.next_patch()
                 return _range_or_empty(
                     min=self.min,

--- a/tests/constraints/version/test_version_range.py
+++ b/tests/constraints/version/test_version_range.py
@@ -780,7 +780,10 @@ def test_intersect_with_local_version_other_does_not_broaden_exclusive_min() -> 
         ("cpu", "cpu"),
     ],
 )
-def test_intersect_with_two_local_versions(min_local: str, other_local: str) -> None:
+@pytest.mark.parametrize("include_min", [True, False])
+def test_intersect_with_two_local_versions(
+    min_local: str, other_local: str, include_min: bool
+) -> None:
     """Cross-local intersection: ``self.min`` and ``other`` both carry
     local segments. ``==X+other`` matches only the literal point
     ``X+other``, so the result is just the point if it falls in the
@@ -789,12 +792,11 @@ def test_intersect_with_two_local_versions(min_local: str, other_local: str) -> 
     other = Version.parse(f"1.2.3+{other_local}")
     upper = Version.parse("2.0")
 
-    for include_min in (True, False):
-        rng = VersionRange(self_min, upper, include_min=include_min)
-        expected = other if rng.allows(other) else EmptyConstraint()
-        assert rng.intersect(other) == expected, (
-            f"include_min={include_min}: {rng} ∩ =={other} should be {expected}"
-        )
+    rng = VersionRange(self_min, upper, include_min=include_min)
+    expected = other if rng.allows(other) else EmptyConstraint()
+    assert rng.intersect(other) == expected, (
+        f"include_min={include_min}: {rng} ∩ =={other} should be {expected}"
+    )
 
 
 def test_intersect_punctured_range_with_excluded_point_is_empty() -> None:

--- a/tests/constraints/version/test_version_range.py
+++ b/tests/constraints/version/test_version_range.py
@@ -735,6 +735,82 @@ def test_difference_returns_empty_constraint_not_empty_range() -> None:
     assert isinstance(result, EmptyConstraint)
 
 
+def test_intersect_with_local_version_other_does_not_broaden_exclusive_min() -> None:
+    """Regression test: ``>0.21.0+cpu,<0.22.0 ∩ ==0.21.0+cpu`` must be
+    empty. Previously returned ``>0.21.0+cpu,<0.21.1`` because the
+    ``>=X+local ∩ public_X`` broadening fired for local ``other`` too.
+    """
+    excluded_point = Version.parse("0.21.0+cpu")
+    upper = Version.parse("0.22.0")
+
+    exclusive = VersionRange(
+        excluded_point, upper, include_min=False, include_max=False
+    )
+    assert isinstance(exclusive.intersect(excluded_point), EmptyConstraint)
+
+    # Inclusive-lower case still returns the literally-equal point.
+    inclusive = VersionRange(
+        excluded_point, upper, include_min=True, include_max=False
+    )
+    assert inclusive.intersect(excluded_point) == excluded_point
+
+    # Original motivating case (``>=X+local ∩ public X``) still broadens.
+    public = Version.parse("0.21.0")
+    range_ge_local = VersionRange(
+        excluded_point, Version.parse("1.0"), include_min=True, include_max=False
+    )
+    assert range_ge_local.intersect(public) == VersionRange(
+        excluded_point,
+        public.next_patch(),
+        include_min=True,
+        include_max=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("min_local", "other_local"),
+    [
+        # other lex-orders after min: in range → return other.
+        ("a", "b"),
+        ("cpu", "cu124"),
+        ("cpu", "cpu1"),
+        # other lex-orders before min: out of range → empty.
+        ("b", "a"),
+        ("cu124", "cpu"),
+        # literal equal: handled by self.allows(other) on line 204 for
+        # inclusive; falls through to the special case for exclusive.
+        ("cpu", "cpu"),
+    ],
+)
+def test_intersect_with_two_local_versions(
+    min_local: str, other_local: str
+) -> None:
+    """Cross-local intersection: ``self.min`` and ``other`` both carry
+    local segments. ``==X+other`` matches only the literal point
+    ``X+other``, so the result is just the point if it falls in the
+    range and empty otherwise — never a broadened range."""
+    self_min = Version.parse(f"1.2.3+{min_local}")
+    other = Version.parse(f"1.2.3+{other_local}")
+    upper = Version.parse("2.0")
+
+    for include_min in (True, False):
+        rng = VersionRange(self_min, upper, include_min=include_min)
+        expected = other if rng.allows(other) else EmptyConstraint()
+        assert rng.intersect(other) == expected, (
+            f"include_min={include_min}: {rng} ∩ =={other} should be {expected}"
+        )
+
+
+def test_intersect_punctured_range_with_excluded_point_is_empty() -> None:
+    """A punctured ``VersionUnion`` (``>=A,!=V,<B``) intersected with
+    the excluded point ``V`` must be empty.
+    """
+    punctured = parse_constraint(">=0.21.0,!=0.21.0+cpu,<0.22.0")
+    excluded_point = parse_constraint("==0.21.0+cpu")
+    assert punctured.intersect(excluded_point).is_empty()
+    assert excluded_point.intersect(punctured).is_empty()
+
+
 def test_parsed_strict_max_excludes_dev_releases_of_stable() -> None:
     """PEP 440: ``<V`` for stable V MUST NOT allow pre-/dev-releases of V.
     The parser canonicalizes to ``<V.dev0`` so ``allows`` reports correctly."""

--- a/tests/constraints/version/test_version_range.py
+++ b/tests/constraints/version/test_version_range.py
@@ -749,9 +749,7 @@ def test_intersect_with_local_version_other_does_not_broaden_exclusive_min() -> 
     assert isinstance(exclusive.intersect(excluded_point), EmptyConstraint)
 
     # Inclusive-lower case still returns the literally-equal point.
-    inclusive = VersionRange(
-        excluded_point, upper, include_min=True, include_max=False
-    )
+    inclusive = VersionRange(excluded_point, upper, include_min=True, include_max=False)
     assert inclusive.intersect(excluded_point) == excluded_point
 
     # Original motivating case (``>=X+local ∩ public X``) still broadens.
@@ -782,9 +780,7 @@ def test_intersect_with_local_version_other_does_not_broaden_exclusive_min() -> 
         ("cpu", "cpu"),
     ],
 )
-def test_intersect_with_two_local_versions(
-    min_local: str, other_local: str
-) -> None:
+def test_intersect_with_two_local_versions(min_local: str, other_local: str) -> None:
     """Cross-local intersection: ``self.min`` and ``other`` both carry
     local segments. ``==X+other`` matches only the literal point
     ``X+other``, so the result is just the point if it falls in the

--- a/tests/constraints/version/test_version_range.py
+++ b/tests/constraints/version/test_version_range.py
@@ -747,22 +747,26 @@ def test_intersect_with_local_version_other_does_not_broaden_exclusive_min() -> 
         excluded_point, upper, include_min=False, include_max=False
     )
     assert isinstance(exclusive.intersect(excluded_point), EmptyConstraint)
+    assert isinstance(excluded_point.intersect(exclusive), EmptyConstraint)
 
     # Inclusive-lower case still returns the literally-equal point.
     inclusive = VersionRange(excluded_point, upper, include_min=True, include_max=False)
     assert inclusive.intersect(excluded_point) == excluded_point
+    assert excluded_point.intersect(inclusive) == excluded_point
 
     # Original motivating case (``>=X+local ∩ public X``) still broadens.
     public = Version.parse("0.21.0")
     range_ge_local = VersionRange(
         excluded_point, Version.parse("1.0"), include_min=True, include_max=False
     )
-    assert range_ge_local.intersect(public) == VersionRange(
+    broadened_range = VersionRange(
         excluded_point,
         public.next_patch(),
         include_min=True,
         include_max=False,
     )
+    assert range_ge_local.intersect(public) == broadened_range
+    assert public.intersect(range_ge_local) == broadened_range
 
 
 @pytest.mark.parametrize(
@@ -794,9 +798,8 @@ def test_intersect_with_two_local_versions(
 
     rng = VersionRange(self_min, upper, include_min=include_min)
     expected = other if rng.allows(other) else EmptyConstraint()
-    assert rng.intersect(other) == expected, (
-        f"include_min={include_min}: {rng} ∩ =={other} should be {expected}"
-    )
+    assert rng.intersect(other) == expected
+    assert other.intersect(rng) == expected
 
 
 def test_intersect_punctured_range_with_excluded_point_is_empty() -> None:


### PR DESCRIPTION
VersionRange.intersect(Version) has a special case introduced in #579 to handle '>=X+local ∩ public_X' by broadening to '[X+local, next_patch(X))', because per PEP 440 a public-version Version constraint '==X' matches all local-tagged variants of X.

The broadening must not fire when 'other' is itself a local-tagged version: '==X+local' matches only the literal point X+local, never a sibling local-tagged variant.  For an exclusive lower bound '>X+local ∩ ==X+local' the broadening wrongly returned the non-empty range '(X+local, next_patch(X))' instead of EmptyConstraint, which downstream caused Poetry's solver to derive contradictory punctured-range terms and crash in partial_solution.satisfier with a '[BUG] ... is not satisfied' RuntimeError.

Skip the broadening when 'other.is_local()'; whether the literal point falls in the range is then decided entirely by the existing 'self.allows(other)' check above.

Resolves: python-poetry#<!-- add issue number/link here -->

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
