### PR TITLE
perf: trivial changes

### DIFF
--- a/src/poetry/core/constraints/version/parser.py
+++ b/src/poetry/core/constraints/version/parser.py
@@ -39,6 +39,7 @@ def parse_constraint(constraints: str) -> VersionConstraint:
     return _parse_constraint(constraints=constraints)
 
 
+@functools.cache
 def parse_marker_version_constraint(
     constraints: str, *, pep440: bool = True
 ) -> VersionConstraint:

--- a/src/poetry/core/packages/specification.py
+++ b/src/poetry/core/packages/specification.py
@@ -40,10 +40,11 @@ class PackageSpecification:
         self._source_resolved_reference = source_resolved_reference
         self._source_subdirectory = source_subdirectory
 
-        if not features:
-            features = []
-
-        self._features = frozenset(canonicalize_name(feature) for feature in features)
+        self._features = (
+            frozenset(canonicalize_name(feature) for feature in features)
+            if features
+            else frozenset()
+        )
 
     @staticmethod
     def _normalize_source_url(


### PR DESCRIPTION
Not much gain, but trivial changes that do not affect maintainability.

1. We already cache `parse_constraint` (some lines above) so that it just makes sense to also cache `parse_marker_version_constraint`.
2. We can avoid the creation of a throwaway empty list.