### PR TITLE
Fix `Version.difference` with a local variant of the same version

### DIFF
--- a/src/poetry/core/constraints/version/version.py
+++ b/src/poetry/core/constraints/version/version.py
@@ -126,17 +126,18 @@ class Version(PEP440Version, VersionRangeConstraint):
             return EmptyConstraint()
 
         if isinstance(other, Version) and self.allows(other):
-            # `self` is a non-local version and `other` a local variant of it,
-            # e.g. `2.12.1`.difference(`2.12.1+cpu`). The result must not
-            # allow `other`, which a plain `Version` cannot express, so
-            # delegate to the equivalent single-point range whose difference
-            # arithmetic can represent the split.
-            # See https://github.com/python-poetry/poetry/issues/10965.
+            # A public version constraint also allows all of its local
+            # variants. Represent that set as a half-open range before
+            # removing the one local variant. Using ``self`` as both bounds
+            # would discard local variants ordered after ``other``.
             from poetry.core.constraints.version.version_range import VersionRange
 
-            return VersionRange(
-                self, self, include_min=True, include_max=True
-            ).difference(other)
+            upper = (
+                self.next_devrelease()
+                if self.is_devrelease()
+                else self.next_postrelease()
+            )
+            return VersionRange(self, upper, include_min=True).difference(other)
 
         return self
 

--- a/src/poetry/core/constraints/version/version.py
+++ b/src/poetry/core/constraints/version/version.py
@@ -121,9 +121,22 @@ class Version(PEP440Version, VersionRangeConstraint):
 
         return VersionUnion.of(self, other)
 
-    def difference(self, other: VersionConstraint) -> Version | EmptyConstraint:
+    def difference(self, other: VersionConstraint) -> VersionConstraint:
         if other.allows(self):
             return EmptyConstraint()
+
+        if isinstance(other, Version) and self.allows(other):
+            # `self` is a non-local version and `other` a local variant of it,
+            # e.g. `2.12.1`.difference(`2.12.1+cpu`). The result must not
+            # allow `other`, which a plain `Version` cannot express, so
+            # delegate to the equivalent single-point range whose difference
+            # arithmetic can represent the split.
+            # See https://github.com/python-poetry/poetry/issues/10965.
+            from poetry.core.constraints.version.version_range import VersionRange
+
+            return VersionRange(
+                self, self, include_min=True, include_max=True
+            ).difference(other)
 
         return self
 

--- a/tests/constraints/version/test_version.py
+++ b/tests/constraints/version/test_version.py
@@ -518,6 +518,25 @@ def test_difference() -> None:
     )
 
 
+def test_difference_local_version() -> None:
+    """The difference of a non-local version and one of its local variants
+    must not allow the subtracted local variant.
+
+    Regression test for https://github.com/python-poetry/poetry/issues/10965
+    (the solver looped forever because the difference made no progress).
+    """
+    public = Version.parse("2.12.1")
+    local = Version.parse("2.12.1+cpu")
+
+    difference = public.difference(local)
+
+    assert not difference.allows(local)
+    assert difference.allows(public)
+    # The reverse direction is unchanged: a non-local version constraint
+    # subsumes its local variants entirely.
+    assert local.difference(public).is_empty()
+
+
 @pytest.mark.parametrize(
     "version,normalized_version",
     [

--- a/tests/constraints/version/test_version.py
+++ b/tests/constraints/version/test_version.py
@@ -532,9 +532,24 @@ def test_difference_local_version() -> None:
 
     assert not difference.allows(local)
     assert difference.allows(public)
+    assert difference.allows(Version.parse("2.12.1+aaa"))
+    assert difference.allows(Version.parse("2.12.1+zzz"))
+    assert not difference.allows(Version.parse("2.12.1.post0"))
     # The reverse direction is unchanged: a non-local version constraint
     # subsumes its local variants entirely.
     assert local.difference(public).is_empty()
+
+
+def test_difference_local_dev_version() -> None:
+    public = Version.parse("2.12.1.dev1")
+    local = Version.parse("2.12.1.dev1+cpu")
+
+    difference = public.difference(local)
+
+    assert not difference.allows(local)
+    assert difference.allows(public)
+    assert difference.allows(Version.parse("2.12.1.dev1+zzz"))
+    assert not difference.allows(Version.parse("2.12.1.dev2"))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Related: python-poetry/poetry#10965

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code. *(internal constraint-arithmetic fix, no user-facing docs)*

## Problem

A public `Version` uses PEP 440 weak equality and therefore allows all local variants of the same public version:

```python
public = Version.parse("2.12.1")
local = Version.parse("2.12.1+cpu")
difference = public.difference(local)
```

Previously `difference` returned `public` unchanged, so it still allowed the version that had just been subtracted. Constraint solving could therefore make no progress.

## Fix

Represent the public version and all its local variants as a half-open range ending at the next post release (or next development release for dev versions), then subtract the requested local version. This preserves local variants on both sides of the removed value while excluding post/dev successors.

## Verification

- `tests/constraints/version/test_version.py`: 206 passed.
- `tests/constraints/`: 1001 passed.
- Regression coverage verifies that the removed local variant is rejected, lower and higher local variants remain allowed, and the upper public successor remains rejected.

## Scope

This corrects the non-progressing `Version.difference()` operation identified while investigating python-poetry/poetry#10965. Re-running that issue's full Poetry reproduction now proceeds past the infinite loop but exposes a separate `KeyError: Package('triton', '3.7.1')` in Poetry's compatibility-result aggregation. This PR no longer claims to fully resolve that Poetry-side failure.

## Disclosure

This fix was developed with the assistance of AI tooling; I manually reviewed the constraint semantics, reproduced the original Poetry scenario, and ran the tests above.
