### PR TITLE
Fix typos in comments

### DIFF
--- a/src/poetry/core/constraints/version/patterns.py
+++ b/src/poetry/core/constraints/version/patterns.py
@@ -20,7 +20,7 @@ X_CONSTRAINT = re.compile(
     r"^(?P<op>!=|==)?\s*v?(?P<version>(\d+)(?:\.(\d+))?(?:\.(\d+))?)(?:\.\*)+$"
 )
 
-# note that we also allow technically incorrect version patterns with astrix (eg: 3.5.*)
+# note that we also allow technically incorrect version patterns with asterisk (eg: 3.5.*)
 # as this is supported by pip and appears in metadata within python packages
 BASIC_CONSTRAINT = re.compile(
     rf"^(?P<op><>|!=|>=?|<=?|==?)?\s*(?P<version>{VERSION_PATTERN}|dev)(?P<wildcard>\.\*)?$",

--- a/tests/constraints/version/test_version_range.py
+++ b/tests/constraints/version/test_version_range.py
@@ -668,7 +668,7 @@ def test_is_single_wildcard_range_include_min_include_max(
         ("1.2.dev0", "1.3.dev0", True),
         ("1.dev0", "2", True),
         ("1.2.3.4.5.dev0", "1.2.3.4.6", True),
-        # simple non wilcard ranges
+        # simple non wildcard ranges
         (None, "1.3", False),
         ("1.2.dev0", None, False),
         (None, None, False),


### PR DESCRIPTION
Fix two typos in comments:

- `astrix` -> `asterisk` in `src/poetry/core/constraints/version/patterns.py`
- `wilcard` -> `wildcard` in `tests/constraints/version/test_version_range.py`

Found via `codespell`.