### PR TITLE
fix: correct allows_all containment check for "!=" vs "not in"

### DIFF
--- a/src/poetry/core/constraints/generic/constraint.py
+++ b/src/poetry/core/constraints/generic/constraint.py
@@ -88,9 +88,8 @@ class Constraint(BaseConstraint):
             if other.operator == "in" and self._operator == "in":
                 return self.value in other.value
 
-            if other.operator == "not in":
-                if self._operator in ("not in", "!="):
-                    return other.value in self.value
+            if other.operator == "not in" and self._operator in ("not in", "!="):
+                return other.value in self.value
 
             return self == other
 

--- a/src/poetry/core/constraints/generic/constraint.py
+++ b/src/poetry/core/constraints/generic/constraint.py
@@ -89,10 +89,8 @@ class Constraint(BaseConstraint):
                 return self.value in other.value
 
             if other.operator == "not in":
-                if self._operator == "not in":
+                if self._operator in ("not in", "!="):
                     return other.value in self.value
-                if self._operator == "!=":
-                    return self.value not in other.value
 
             return self == other
 

--- a/tests/constraints/generic/test_constraint.py
+++ b/tests/constraints/generic/test_constraint.py
@@ -253,6 +253,21 @@ def test_allows(
             True,
             False,
         ),
+        # "!=" combined with "not in" where the excluded value is not a
+        # substring of the excluded-substring's value: allows_all must be
+        # False, since e.g. "a" itself satisfies "'b' not in x" but not "!= a"
+        (
+            Constraint("a", "!="),
+            Constraint("b", "not in"),
+            True,
+            False,
+        ),
+        (
+            Constraint("ab", "!="),
+            Constraint("a", "not in"),
+            True,
+            True,
+        ),
         (
             Constraint("1.2.3-tegra", "=="),
             Constraint("tegra", "in"),

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -1466,6 +1466,10 @@ def test_multi_marker_removes_duplicates() -> None:
             {"platform_release": "4.9.253"},
             True,
         ),
+        # both terms must be kept, not just the "not in" one
+        ("os_name != 'a' and 'b' not in os_name", {"os_name": "a"}, False),
+        ("os_name != 'a' and 'b' not in os_name", {"os_name": "ab"}, False),
+        ("os_name != 'a' and 'b' not in os_name", {"os_name": "c"}, True),
         (
             "platform_release >= '6.6.0+rpt-rpi-v8'",
             {"platform_release": "6.6.20+rpt-rpi-v8"},


### PR DESCRIPTION
Fixes python-poetry/poetry#10977

`Constraint.allows_all()` had a containment check backwards for the case where `self` is a `!=` constraint and `other` is a `not in` constraint. It tested `self.value not in other.value`, but the correct check has the same shape as the existing `not in` / `not in` branch just above it: `other.value in self.value`.

Concretely:

```python
>>> from poetry.core.version.markers import parse_marker
>>> m = parse_marker('os_name != "a" and "b" not in os_name')
>>> str(m)  # before: the `!=` clause silently disappears
'"b" not in os_name'
>>> m.validate({"os_name": "a"})  # before: True (wrong)
>>> m.validate({"os_name": "a"})  # after: False (correct)
```

This happened because `MultiMarker`/constraint intersection logic uses `allows_all` to drop a clause it believes is redundant. The old formula wrongly considered `os_name != "a"` redundant given `"b" not in os_name`, even though `os_name == "a"` satisfies the latter but not the former.

I merged the two branches for `self._operator == "not in"` and `self._operator == "!="` under `other.operator == "not in"` since they resolve to the identical correct formula.

Added regression tests in `tests/constraints/generic/test_constraint.py` (direct `allows_all` cases) and `tests/version/test_markers.py` (the exact marker/validate scenario from the issue, plus two adjacent cases).
