### PR TITLE
Avoid merging incompatible marker constraints

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -1286,6 +1286,11 @@ def _merge_single_markers(
     if marker1.name != marker2.name:
         return None
 
+    if isinstance(marker1.constraint, VersionConstraint) != isinstance(
+        marker2.constraint, VersionConstraint
+    ):
+        return None
+
     if merge_class == MultiMarker:
         merge_method = marker1.constraint.intersect
     else:

--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -1289,6 +1289,9 @@ def _merge_single_markers(
     if isinstance(marker1.constraint, VersionConstraint) != isinstance(
         marker2.constraint, VersionConstraint
     ):
+        # `platform_release` can be a VersionConstraint (e.g. `platform_release != "1"`)
+        # or a (generic) Constraint (e.g. `"a" not in platform_release`),
+        # which cannot be merged.
         return None
 
     if merge_class == MultiMarker:

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -73,7 +73,9 @@ EMPTY = "<empty>"
         '"tegra" not in platform_release',
         '"tegra" in platform_release or "rpi-v8" in platform_release',
         '"tegra" not in platform_release and "rpi-v8" not in platform_release',
+        # Mixed version and string comparison
         'platform_release != "1" and "a" not in platform_release',
+        '"a" not in platform_release or platform_release != "1"',
         # extra starting with "in"
         'extra == "in1" or extra == "in2"',
         'extra == "in1" and extra == "in2"',

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -73,6 +73,7 @@ EMPTY = "<empty>"
         '"tegra" not in platform_release',
         '"tegra" in platform_release or "rpi-v8" in platform_release',
         '"tegra" not in platform_release and "rpi-v8" not in platform_release',
+        'platform_release != "1" and "a" not in platform_release',
         # extra starting with "in"
         'extra == "in1" or extra == "in2"',
         'extra == "in1" and extra == "in2"',


### PR DESCRIPTION
Fixes python-poetry/poetry#10978

## Summary
- Avoid merging same-name markers when their constraints use incompatible types.
- Add a regression case for combining a version comparison with a swapped string comparison for `platform_release`.

## Testing
- `pytest tests/version/test_markers.py`
- `pytest`
- `ruff check src/poetry/core/version/markers.py tests/version/test_markers.py`
- `mypy src/poetry/core/version/markers.py tests/version/test_markers.py`