### PR TITLE
fix: don't crash when merging incompatible platform_release marker forms

### DIFF
--- a/src/poetry/core/version/markers.py
+++ b/src/poetry/core/version/markers.py
@@ -1286,6 +1286,16 @@ def _merge_single_markers(
     if marker1.name != marker2.name:
         return None
 
+    if isinstance(marker1.constraint, VersionConstraint) != isinstance(
+        marker2.constraint, VersionConstraint
+    ):
+        # Same marker name, but the constraints come from incompatible parses:
+        # e.g. `platform_release != "1"` produces a VersionConstraint, while
+        # the swapped form `"a" not in platform_release` produces a generic
+        # Constraint. They can't be intersected/unioned together, so leave
+        # them as separate ANDed/ORed markers instead of crashing below.
+        return None
+
     if merge_class == MultiMarker:
         merge_method = marker1.constraint.intersect
     else:

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -1476,6 +1476,25 @@ def test_multi_marker_removes_duplicates() -> None:
             {"platform_release": "4.9.254-tegra"},
             True,
         ),
+        # Mixing the plain (`!=`) and swapped (`not in`) forms of a
+        # platform_release marker used to raise AttributeError while merging
+        # markers, because the two forms parse to incompatible constraint
+        # types (VersionConstraint vs. generic Constraint).
+        (
+            'platform_release != "1" and "a" not in platform_release',
+            {"platform_release": "1"},
+            False,
+        ),
+        (
+            'platform_release != "1" and "a" not in platform_release',
+            {"platform_release": "2"},
+            True,
+        ),
+        (
+            'platform_release != "1" and "a" not in platform_release',
+            {"platform_release": "2a"},
+            False,
+        ),
         # extras
         # single extra
         ("extra == 'security'", {"extra": "quux"}, False),

--- a/tests/version/test_markers.py
+++ b/tests/version/test_markers.py
@@ -1495,6 +1495,17 @@ def test_multi_marker_removes_duplicates() -> None:
             {"platform_release": "2a"},
             False,
         ),
+        # Same crash, but through the MarkerUnion (`or`) merge path.
+        (
+            'platform_release != "1" or "1" not in platform_release',
+            {"platform_release": "1"},
+            False,
+        ),
+        (
+            'platform_release != "1" or "1" not in platform_release',
+            {"platform_release": "2"},
+            True,
+        ),
         # extras
         # single extra
         ("extra == 'security'", {"extra": "quux"}, False),


### PR DESCRIPTION
Resolves: python-poetry/poetry-core#10978

`platform_release != "1"` parses to a version-based constraint, but the swapped form `"a" not in platform_release` parses to a generic string `Constraint` (this is intentional — the swapped form is a substring check, not a version comparison). `_merge_single_markers` assumed same-name markers always share a constraint type and crashed with `AttributeError: 'Constraint' object has no attribute 'flatten'` when trying to intersect the two.

Added a type check before merging: if the two constraints aren't both version-like, fall back to keeping them as separate ANDed/ORed markers (the existing fallback path for unmergeable markers), instead of crashing. Added regression tests.

- [x] Added tests for changed code.
- [ ] Updated documentation for changed code.