### PR TITLE
fix `Version.difference` and `VersionRange.allows_all` for ranges exluding local versions

### DIFF
--- a/src/poetry/core/constraints/version/version.py
+++ b/src/poetry/core/constraints/version/version.py
@@ -122,14 +122,19 @@ class Version(PEP440Version, VersionRangeConstraint):
         return VersionUnion.of(self, other)
 
     def difference(self, other: VersionConstraint) -> VersionConstraint:
-        if other.allows(self):
+        # ``allows_all`` rather than ``allows``: a public version constraint is
+        # not a single version, it also allows all of its local variants, and
+        # ``other`` has to cover those as well for the difference to be empty.
+        if other.allows_all(self):
             return EmptyConstraint()
 
-        if isinstance(other, Version) and self.allows(other):
-            # A public version constraint also allows all of its local
-            # variants. Represent that set as a half-open range before
-            # removing the one local variant. Using ``self`` as both bounds
-            # would discard local variants ordered after ``other``.
+        if other.allows_any(self):
+            # ``other`` covers part of what this constraint allows -- the
+            # version itself or some of its local variants -- which a plain
+            # ``Version`` cannot express. Represent the allowed set as a
+            # half-open range before subtracting, so that the remainder can be
+            # spelled out. Using ``self`` as both bounds would discard the
+            # local variants ordered after ``other``.
             from poetry.core.constraints.version.version_range import VersionRange
 
             upper = (

--- a/src/poetry/core/constraints/version/version_range.py
+++ b/src/poetry/core/constraints/version/version_range.py
@@ -156,7 +156,26 @@ class VersionRange(VersionRangeConstraint):
             return True
 
         if isinstance(other, Version):
-            return self.allows(other)
+            if not self.allows(other):
+                return False
+
+            if other.is_local():
+                # `==1.2.3+local` allows nothing but that very version.
+                return True
+
+            # A public version constraint also allows every local variant of
+            # the version, so allowing `1.2.3` is not enough: `1.2.3+local`
+            # has to be allowed, too. A bound that is itself a local variant
+            # of `other` splits that band and leaves some of them out.
+            #
+            # Only the upper bound can be one: a local variant sorts above the
+            # version it belongs to, so a range with such a lower bound does
+            # not allow `other` in the first place and has returned already.
+            return not (
+                self._max is not None
+                and self._max.is_local()
+                and self._max.without_local() == other
+            )
 
         if isinstance(other, VersionUnion):
             return all(self.allows_all(constraint) for constraint in other.ranges)

--- a/tests/constraints/version/test_version.py
+++ b/tests/constraints/version/test_version.py
@@ -552,6 +552,25 @@ def test_difference_local_dev_version() -> None:
     assert not difference.allows(Version.parse("2.12.1.dev2"))
 
 
+def test_difference_constraint_excluding_only_some_local_variants() -> None:
+    """A public version constraint is only fully removed by a constraint that
+    also covers its local variants.
+
+    ``>=2.12.1,!=2.12.1+cpu,<2.12.1.post0`` allows ``2.12.1`` but not
+    ``2.12.1+cpu``, so subtracting it from ``==2.12.1`` has to leave that
+    variant behind rather than yield the empty constraint.
+    """
+    public = Version.parse("2.12.1")
+    local = Version.parse("2.12.1+cpu")
+    without_local = public.difference(local)
+
+    difference = public.difference(without_local)
+
+    assert not difference.is_empty()
+    assert difference.allows(local)
+    assert not difference.allows(public)
+
+
 @pytest.mark.parametrize(
     "version,normalized_version",
     [

--- a/tests/constraints/version/test_version_range.py
+++ b/tests/constraints/version/test_version_range.py
@@ -166,6 +166,54 @@ def test_allows_all(
     assert not range.allows_all(v300)
 
 
+def test_allows_all_public_version_includes_its_local_variants() -> None:
+    """A public version constraint denotes the release *and* all of its local
+    variants, so a range that excludes one of those variants does not allow
+    all of it.
+    """
+    public = Version.parse("2.12.1")
+    local = Version.parse("2.12.1+cpu")
+    local_a = Version.parse("2.12.1+aaa")
+    local_z = Version.parse("2.12.1+zzz")
+
+    # `<2.12.1+cpu` allows 2.12.1 but leaves out the local variants from
+    # +cpu onwards.
+    assert VersionRange(max=local).allows(public)
+    assert not VersionRange(max=local).allows_all(public)
+    assert VersionRange(max=local).allows_all(local_a)
+    assert not VersionRange(max=local).allows_all(local)
+    assert not VersionRange(max=local).allows_all(local_z)
+
+    # similar for `<=2.12.1+cpu`
+    assert VersionRange(max=local, include_max=True).allows(public)
+    assert not VersionRange(max=local, include_max=True).allows_all(public)
+    assert VersionRange(max=local, include_max=True).allows_all(local_a)
+    assert VersionRange(max=local, include_max=True).allows_all(local)
+    assert not VersionRange(max=local, include_max=True).allows_all(local_z)
+
+    # `>2.12.1+cpu` does not allow 2.12.1 but allows the local variants from
+    # +cpu onwards.
+    assert not VersionRange(min=local).allows(public)
+    assert not VersionRange(min=local).allows_all(public)
+    assert not VersionRange(min=local).allows_all(local_a)
+    assert not VersionRange(min=local).allows_all(local)
+    assert VersionRange(min=local).allows_all(local_z)
+
+    # similar for `>=2.12.1+cpu`
+    assert not VersionRange(min=local, include_min=True).allows(public)
+    assert not VersionRange(min=local, include_min=True).allows_all(public)
+    assert not VersionRange(min=local, include_min=True).allows_all(local_a)
+    assert VersionRange(min=local, include_min=True).allows_all(local)
+    assert VersionRange(min=local, include_min=True).allows_all(local_z)
+
+    # Bounds that are not local variants of the version cover the whole band.
+    assert VersionRange(
+        public, Version.parse("2.12.2+cpu"), include_min=True
+    ).allows_all(public)
+    assert VersionRange(min=public, include_min=True).allows_all(public)
+    assert VersionRange(max=public, include_max=True).allows_all(public)
+
+
 def test_allows_all_with_no_min(
     v080: Version, v140: Version, v250: Version, v300: Version
 ) -> None:


### PR DESCRIPTION
Follow-up of #953 fixing some more bugs regarding ranges that exclude local versions

Related: https://github.com/python-poetry/poetry/issues/10965

<!-- This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. But please read our [contribution guide](https://python-poetry.org/docs/contributing/) at least once, it will save you unnecessary review cycles! -->

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!--
**Note**: All Pull Requests must be based on the `main` branch.

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
-->
