### PR TITLE
Reject invalid entry-point group names

### DIFF
--- a/src/poetry/core/factory.py
+++ b/src/poetry/core/factory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 
 from collections import defaultdict
 from collections.abc import Mapping
@@ -32,6 +33,18 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+# https://packaging.python.org/en/latest/specifications/entry-points/#data-model
+_ENTRY_POINT_GROUP_RE = re.compile(r"^\w+(\.\w+)*$")
+
+
+def _entry_point_group_error(group_name: str, source: str | None = None) -> str:
+    where = f" in [{source}]" if source else ""
+    return (
+        f"Invalid entry-point group name {group_name!r}{where}. "
+        "Group names must be valid identifiers with dots as separators "
+        "(https://packaging.python.org/en/latest/specifications/entry-points/#data-model)."
+    )
 
 
 class Factory:
@@ -354,9 +367,13 @@ class Factory:
                         f"Group '{group_name}' is reserved and cannot be used"
                         " as a custom entry-point group."
                     )
+                if not _ENTRY_POINT_GROUP_RE.fullmatch(group_name):
+                    raise ValueError(_entry_point_group_error(group_name))
                 entry_points[group_name] = scripts
         elif other_scripts := tool_poetry.get("plugins"):
             for group_name, scripts in sorted(other_scripts.items()):
+                if not _ENTRY_POINT_GROUP_RE.fullmatch(group_name):
+                    raise ValueError(_entry_point_group_error(group_name))
                 entry_points[group_name] = scripts
 
         package.entry_points = dict(entry_points)
@@ -766,6 +783,18 @@ class Factory:
             )
 
         cls._validate_dependency_groups(toml_data, result)
+
+        for source, groups in (
+            ("project.entry-points", (project or {}).get("entry-points")),
+            ("tool.poetry.plugins", config.get("plugins")),
+        ):
+            if not groups:
+                continue
+            for group_name in groups:
+                if not _ENTRY_POINT_GROUP_RE.fullmatch(group_name):
+                    result["errors"].append(
+                        _entry_point_group_error(group_name, source)
+                    )
 
         if strict:
             # Validate [project] section

--- a/src/poetry/core/json/schemas/poetry-schema.json
+++ b/src/poetry/core/json/schemas/poetry-schema.json
@@ -233,8 +233,9 @@
     "plugins": {
       "type": "object",
       "description": "A hash of hashes representing plugins",
+      "additionalProperties": false,
       "patternProperties": {
-        "^[a-zA-Z-_.0-9]+$": {
+        "^\\w+(\\.\\w+)*$": {
           "type": "object",
           "patternProperties": {
             "^[a-zA-Z-_.0-9]+$": {

--- a/tests/json/test_poetry_schema.py
+++ b/tests/json/test_poetry_schema.py
@@ -100,3 +100,18 @@ def test_bad_extra(base_object: dict[str, Any]) -> None:
     errors = validate_object(base_object, "poetry-schema")
     assert len(errors) == 1
     assert errors[0] == "data.extras.test[0] must match pattern ^[a-zA-Z-_.0-9]+$"
+
+
+def test_plugins_reject_hyphenated_group_name(base_object: dict[str, Any]) -> None:
+    base_object["plugins"] = {"epot-test.test": {"abc": "pkg:Cls"}}
+
+    errors = validate_object(base_object, "poetry-schema")
+
+    assert errors
+    assert any("epot-test.test" in error for error in errors)
+
+
+def test_plugins_accept_dotted_group_name(base_object: dict[str, Any]) -> None:
+    base_object["plugins"] = {"poetry.application.plugin": {"my-command": "pkg:Cls"}}
+
+    assert validate_object(base_object, "poetry-schema") == []

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -2106,3 +2106,47 @@ The Poetry configuration is invalid:
         error_type=RuntimeError,
         temporary_directory=temporary_directory,
     )
+
+
+@pytest.mark.parametrize(
+    "section",
+    [
+        '[tool.poetry.plugins."epot-test.test"]\n"abc" = "pkg:Cls"\n',
+        '[project.entry-points."epot-test.test"]\n"abc" = "pkg:Cls"\n',
+    ],
+)
+def test_create_poetry_rejects_invalid_entry_point_group(
+    section: str, temporary_directory: Path
+) -> None:
+    (temporary_directory / "pyproject.toml").write_text(
+        f"""\
+[project]
+name = "my-package"
+version = "1.2.3"
+
+{section}
+"""
+    )
+
+    with pytest.raises(RuntimeError, match="Invalid entry-point group name") as error:
+        Factory().create_poetry(temporary_directory)
+
+    assert "epot-test.test" in str(error.value)
+
+
+def test_validate_invalid_plugin_group_name() -> None:
+    result = Factory.validate(
+        {
+            "project": {"name": "my-package", "version": "1.2.3"},
+            "tool": {
+                "poetry": {
+                    "plugins": {"epot-test.test": {"abc": "pkg:Cls"}},
+                }
+            },
+        }
+    )
+
+    assert any(
+        "Invalid entry-point group name" in message and "epot-test.test" in message
+        for message in result["errors"]
+    )


### PR DESCRIPTION
Resolves: python-poetry/poetry#2581

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

`[tool.poetry.plugins]` accepted group names with hyphens (for example `epot-test.test`). Those names are written into `entry_points.txt`, then `pip` / `pkg_resources` reject them as invalid group names, so the built package cannot be uninstalled.

`[project.entry-points]` already required identifier-style group names. This change applies the same rule to the legacy plugins table and fails `Factory.validate()` / `create_poetry()` with a clear error pointing at the packaging spec.