### PR TITLE
fix: str() of a range whose upper bound is all zeros raised IndexError

### DIFF
--- a/src/poetry/core/constraints/version/version_constraint.py
+++ b/src/poetry/core/constraints/version/version_constraint.py
@@ -93,6 +93,12 @@ def _is_wildcard_candidate(
     while parts_second and parts_second[-1] == 0:
         del parts_second[-1]
 
+    # second is zero in every part (e.g. the upper bound of ">=0.dev0,<0",
+    # which is "==0.*" minus "==0"): no release is one step below it,
+    # so this cannot be a wildcard range
+    if not parts_second:
+        return False
+
     # fill up first with zeros
     parts_first += [0] * (len(parts_second) - len(parts_first))
 

--- a/tests/constraints/version/test_version_range.py
+++ b/tests/constraints/version/test_version_range.py
@@ -696,6 +696,10 @@ def test_is_single_wildcard_range_include_min_include_max(
         ("2.0.post1.dev0", "2.0.post2.dev1", False),
         ("2.0.post1.dev0", "2.0.post3", False),
         ("2.0.post1.dev0", "2.0.post1", False),
+        # upper bound that is zero in every part
+        ("0.dev0", "0", False),
+        ("0.dev0", "0.0", False),
+        ("0.0.dev0", "0", False),
     ],
 )
 def test_is_single_wildcard_range(
@@ -772,6 +776,17 @@ def test_intersect_returns_empty_constraint_not_empty_range() -> None:
     half_open = VersionRange(v, v, include_min=True, include_max=False)
     result = point.intersect(half_open)
     assert isinstance(result, EmptyConstraint)
+
+
+def test_str_of_range_whose_upper_bound_is_zero() -> None:
+    # ">=0.dev0,<0" arises as "==0.*" minus "==0"; str() used to raise
+    # IndexError because the upper bound has no non-zero part
+    version_range = VersionRange(
+        Version.parse("0.dev0"), Version.parse("0"), include_min=True
+    )
+    assert str(version_range) == ">=0.dev0,<0"
+    constraint = parse_constraint("==0.*").difference(parse_constraint("==0"))
+    assert str(constraint) == ">=0.dev0,!=0,<1"
 
 
 def test_difference_returns_empty_constraint_not_empty_range() -> None:


### PR DESCRIPTION
`_is_wildcard_candidate` strips trailing zeros from the upper bound and then indexes the last remaining part. When the upper bound is zero in every part (e.g. `>=0.dev0,<0`, which is what `==0.*` minus `==0` produces), nothing remains and the index fails.

This surfaces as `IndexError: list index out of range` from the resolver when a package has a release `0` and something depends on it with `==0.*`: recording the incompatibility formats the constraint.

An upper bound with no non-zero part has no release one step below it, so the range cannot be a wildcard range; return False.

```python
from poetry.core.constraints.version import parse_constraint
str(parse_constraint("==0.*").difference(parse_constraint("==0")))
# IndexError: list index out of range
```

Resolves: python-poetry# ‐ Could not find.

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code. - n/a, internal helper; no documented behaviour changes
