### PR TITLE
Fix union of public and local versions

### DIFF
--- a/src/poetry/core/constraints/version/version.py
+++ b/src/poetry/core/constraints/version/version.py
@@ -119,6 +119,9 @@ class Version(PEP440Version, VersionRangeConstraint):
         if other.allows(self):
             return other
 
+        if self.allows(other):
+            return self
+
         return VersionUnion.of(self, other)
 
     def difference(self, other: VersionConstraint) -> VersionConstraint:

--- a/tests/constraints/version/test_version.py
+++ b/tests/constraints/version/test_version.py
@@ -505,6 +505,14 @@ def test_union() -> None:
     assert result.allows(Version.parse("0.1.0"))
 
 
+def test_union_public_version_with_local_version() -> None:
+    public = Version.parse("1.2.3")
+    local = Version.parse("1.2.3+local")
+
+    assert public.union(local) == public
+    assert local.union(public) == public
+
+
 def test_difference() -> None:
     v = Version.parse("1.2.3")
 


### PR DESCRIPTION
Resolves: N/A — independently reproduced on poetry-core `main`

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code. (Not applicable; this restores existing version-constraint union behavior.)

## Summary

Unioning an exact public version with one of its local variants raised `RecursionError`. The public constraint already allows that local variant, but `Version.union()` only checked containment in the opposite direction before `VersionUnion.of()` tried to merge the same pair again.

Check the existing containment direction first, then return `self` when it contains `other`. Keeping the new check after the existing one preserves prior operand selection for mutually equivalent versions such as `1` and `1.0`.

## Tests

- `python -m pytest -p no:sugar -q tests/constraints/version/test_version.py::test_union_public_version_with_local_version` — 1 passed
- `python -m pytest -p no:sugar -q tests/constraints/version` — 708 passed
- `python -m pytest -p no:sugar -q tests/` — 2927 passed, 7 skipped, 9 deselected
- `python -m pytest -p no:sugar --integration -q tests/integration` — 9 passed
- `mypy` — no issues in 151 source files
- `pre-commit run --all-files --show-diff-on-failure` — all hooks passed
