### PR TITLE
ci: do not use same cache for CPython and PyPy

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -67,7 +67,7 @@ jobs:
         id: cache
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ runner.os }}-${{ startsWith(matrix.python-version, 'pypy') && 'pypy-' || '' }}${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Ensure cache is healthy
         if: steps.cache.outputs.cache-hit == 'true'


### PR DESCRIPTION
Every first PyPy test run fails with

 ```
 SystemError

  invalid sysconfig.get_config_var('EXT_SUFFIX')

  at ~/.local/share/pypoetry/venv/lib/pypy3.11/site-packages/packaging/tags.py:496 in _generic_abi
       492│     #                                               => graalpy_38_native
       493│ 
       494│     ext_suffix = _get_config_var("EXT_SUFFIX", warn=True)
       495│     if not isinstance(ext_suffix, str) or not ext_suffix.startswith("."):
    →  496│         raise SystemError("invalid sysconfig.get_config_var('EXT_SUFFIX')")
       497│     parts = ext_suffix.split(".")
       498│     if len(parts) < 3:
       499│         # CPython3.7 and earlier uses ".pyd" on Windows.
       500│         return _cpython_abis(sys.version_info[:2])
```

A subsequent run of the failed job succeeds.