### PR TITLE
Fix uppercase localhost file URLs

### DIFF
--- a/src/poetry/core/packages/utils/utils.py
+++ b/src/poetry/core/packages/utils/utils.py
@@ -71,7 +71,7 @@ def url_to_path(url: str) -> Path:
 
     _, netloc, path, _, _ = urlsplit(url)
 
-    if not netloc or netloc == "localhost":
+    if not netloc or netloc.lower() == "localhost":
         # According to RFC 8089, same as empty authority.
         netloc = ""
     elif netloc not in {".", ".."} and sys.platform == "win32":

--- a/tests/packages/utils/test_utils_urls.py
+++ b/tests/packages/utils/test_utils_urls.py
@@ -36,6 +36,7 @@ def test_path_to_url_win() -> None:
         ("file:c:/path/to/file", r"C:\path\to\file", "c:/path/to/file"),
         ("file:/path/to/file", r"\path\to\file", "/path/to/file"),
         ("file://localhost/tmp/file", r"\tmp\file", "/tmp/file"),
+        ("file://LOCALHOST/tmp/file", r"\tmp\file", "/tmp/file"),
         ("file://localhost/c:/tmp/file", r"C:\tmp\file", "/c:/tmp/file"),
         ("file://somehost/tmp/file", r"\\somehost\tmp\file", None),
         ("file:///tmp/file", r"\tmp\file", "/tmp/file"),


### PR DESCRIPTION
Resolves: N/A — independently reproduced in `poetry-core`

## Summary

`url_to_path()` rejects `file://LOCALHOST/...` as a remote file URI even though URI host names are case-insensitive and lowercase `localhost` is already treated as an empty local authority.

Compare the parsed authority case-insensitively and cover the uppercase form in the existing cross-platform table test. Other remote authorities remain rejected on non-Windows platforms.

## Tests

- [x] Added tests for changed code.
- [ ] Updated documentation for changed code — not needed; this corrects accepted URI spelling without changing the documented API.
- URL utility suite: 10 passed, 4 skipped.
- Full unit suite: 2,932 passed, 7 skipped, 9 deselected.
- Mypy: no issues in 151 source files.
- Pre-commit: all 14 hooks passed.
